### PR TITLE
Fix audbackend.Artifactory.exists()

### DIFF
--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -501,7 +501,11 @@ class Artifactory(Backend):
             path: str,
     ) -> bool:
         r"""Check if file exists on backend."""
-        return audfactory.path(path).exists()
+        try:
+            # Can lead to RuntimeError: 404 page not found
+            return audfactory.path(path).exists()
+        except RuntimeError:
+            return False
 
     def _get_file(
             self,

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -504,7 +504,7 @@ class Artifactory(Backend):
         try:
             # Can lead to RuntimeError: 404 page not found
             return audfactory.path(path).exists()
-        except RuntimeError:
+        except RuntimeError:  # pragma: nocover
             return False
 
     def _get_file(


### PR DESCRIPTION
There are some occasions I haven't completely figured out yet that can lead to:
```
RuntimeError: 404 page not found
```
when calling
```python
audfactory.path(path).exists()
```

So I introduced a `try`-`except` statement that handles this case.