### PR TITLE
Support empty file extension

### DIFF
--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -300,6 +300,8 @@ class Backend:
         folder, file = self.split(path)
         if ext is None:
             name, ext = os.path.splitext(file)
+        elif ext == '':
+            name = file
         else:
             if not ext.startswith('.'):
                 ext = '.' + ext

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -322,6 +322,7 @@ def test_glob(tmpdir, files, backend):
         ('media/test.tar.gz', '1.0.0', 'tar.gz', 'test-1.0.0.tar.gz'),
         ('media/test.tar.gz', '1.0.0', '.tar.gz', 'test-1.0.0.tar.gz'),
         ('media/test.1.2.3', '1.0.0', '1.2.3', 'test-1.0.0.1.2.3'),
+        ('media/test.1.2.3', '1.0.0', '', 'test.1.2.3-1.0.0'),
         pytest.param(  # invalid character
             r'media\test',
             '1.0.0',


### PR DESCRIPTION
I realized we were not supporting the case that the file extension is empty. Now the following works, too:

### Example

```python
backend = audbackend.create('file-system', 'host', '/host')
backend.path('my.file.without.ext', '1.0.0', ext='')
```
```
/host/my.file.without.ext/1.0.0/my.file.without.ext-1.0.0
```