### PR TITLE
DOC: link to audfactory for authentication

### DIFF
--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -22,7 +22,7 @@ Alternatively, export the credentials as environment variables:
     export ARTIFACTORY_API_KEY="MY_API_KEY"
 
 The environment variables will be applied to all servers.
-You might loose access to artifacts on servers
+You might lose access to artifacts on servers
 that are setup for anonymous access
 as it will always try to authenticate
 with the given username and password.

--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -2,29 +2,8 @@ Authentication
 ==============
 
 To use the :class:`audbackend.Artifactory` backend
-store your credentials in :file:`~/.artifactory_python.cfg`:
+you might need to authenticate
+when communicating with the Artifactory server.
+See the `guide on how to provide your credentials`_.
 
-.. code-block:: cfg
-
-    [artifactory.audeering.com/artifactory]
-    username = MY_USERNAME
-    password = MY_API_KEY
-
-and replace ``artifactory.audeering.com/artifactory``
-with your Artifactory server address.
-You can also add several server entries.
-
-Alternatively, export the credentials as environment variables:
-
-.. code-block:: bash
-
-    export ARTIFACTORY_USERNAME="MY_USERNAME"
-    export ARTIFACTORY_API_KEY="MY_API_KEY"
-
-The environment variables will be applied to all servers.
-You might lose access to artifacts on servers
-that are setup for anonymous access
-as it will always try to authenticate
-with the given username and password.
-In this case
-it is recommended to not use the environment variables.
+.. _guide on how to provide your credentials: https://audeering.github.io/audfactory/usage.html#authentication

--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -1,7 +1,8 @@
 Authentication
 ==============
 
-Users have to store their credentials in :file:`~/.artifactory_python.cfg`:
+To use the :class:`audbackend.Artifactory` backend
+store your credentials in :file:`~/.artifactory_python.cfg`:
 
 .. code-block:: cfg
 
@@ -9,9 +10,21 @@ Users have to store their credentials in :file:`~/.artifactory_python.cfg`:
     username = MY_USERNAME
     password = MY_API_KEY
 
-Alternatively, they can export them as environment variables:
+and replace ``artifactory.audeering.com/artifactory``
+with your Artifactory server address.
+You can also add several server entries.
+
+Alternatively, export the credentials as environment variables:
 
 .. code-block:: bash
 
     export ARTIFACTORY_USERNAME="MY_USERNAME"
     export ARTIFACTORY_API_KEY="MY_API_KEY"
+
+The environment variables will be applied to all servers.
+You might loose access to artifacts on servers
+that are setup for anonymous access
+as it will always try to authenticate
+with the given username and password.
+In this case
+it is recommended to not use the environment variables.


### PR DESCRIPTION
This changes the authentication documentation by providing a link to the `audfactory` documentation as single source of truth.

