### PR TITLE
Add audbackend.Repository

### DIFF
--- a/audbackend/__init__.py
+++ b/audbackend/__init__.py
@@ -5,6 +5,7 @@ from audbackend.core.api import (
 from audbackend.core.artifactory import Artifactory
 from audbackend.core.backend import Backend
 from audbackend.core.filesystem import FileSystem
+from audbackend.core.repository import Repository
 from audbackend.core.utils import md5
 
 

--- a/audbackend/core/repository.py
+++ b/audbackend/core/repository.py
@@ -1,0 +1,40 @@
+class Repository:
+    r"""Repository object.
+
+    It stores all information
+    needed to address a repository:
+    the repository name,
+    host,
+    and backend.
+
+    Args:
+        name: repository name
+        host: repository host
+        backend: repository backend
+
+    Example:
+        >>> Repository('data-local', '/data', 'file-system')
+        Repository('data-local', '/data', 'file-system')
+
+    """
+    def __init__(
+            self,
+            name: str,
+            host: str,
+            backend: str,
+    ):
+        self.name = name
+        r"""Repository name."""
+        self.host = host
+        r"""Repository host."""
+        self.backend = backend
+        r"""Repository backend."""
+
+    def __repr__(self):
+        return (
+            f"Repository("
+            f"'{self.name}', "
+            f"'{self.host}', "
+            f"'{self.backend}'"
+            f")"
+        )

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -44,3 +44,9 @@ register
 --------
 
 .. autofunction:: register
+
+Repository
+----------
+
+.. autoclass:: Repository
+    :members:


### PR DESCRIPTION
This adds the `audbackend.Repository` class, which we can then easily reuse in every project that needs to address repositories.
The users there don't have to call the actual `audbackend` package, but we could directly import in the `__ini__.py` file. E.g. for `audb` it would be

```python
from audbackend import Repository
```

instead of

```python
from audb.core.repository import Repository
```

![image](https://user-images.githubusercontent.com/173624/125402081-48354080-e3b4-11eb-9b0d-0b101e6689c0.png)
