### PR TITLE
FIX: ignore empty strings in backend.join()

### DIFF
--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -213,7 +213,9 @@ class Backend:
             path joined by :attr:`Backend.sep`
 
         """
-        return self.sep.join([path] + [p for p in paths])
+        paths = [path] + [p for p in paths]
+        paths = [path for path in paths if path]
+        return self.sep.join(paths)
 
     def latest_version(
             self,

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -214,6 +214,7 @@ class Backend:
 
         """
         paths = [path] + [p for p in paths]
+        # skip part if '' or None
         paths = [path for path in paths if path]
         return self.sep.join(paths)
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -335,6 +335,29 @@ def test_glob(tmpdir, files, pattern, folder, expected, backend):
             pytest.FILE_SYSTEM_HOST,
             pytest.REPOSITORY_NAME,
         ),
+    ]
+)
+@pytest.mark.parametrize(
+    'paths, expected',
+    [
+        ([''], ''),
+        (['', ''], ''),
+        (['file'], 'file'),
+        (['root', 'file'], 'root/file'),
+        (['', 'root', '', '', 'file', ''], 'root/file'),
+    ]
+)
+def test_join(backend, paths, expected):
+    assert backend.join(*paths) == expected
+
+
+@pytest.mark.parametrize(
+    'backend',
+    [
+        audbackend.FileSystem(
+            pytest.FILE_SYSTEM_HOST,
+            pytest.REPOSITORY_NAME,
+        ),
         audbackend.Artifactory(
             pytest.ARTIFACTORY_HOST,
             pytest.REPOSITORY_NAME,

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -344,7 +344,7 @@ def test_glob(tmpdir, files, pattern, folder, expected, backend):
         (['', ''], ''),
         (['file'], 'file'),
         (['root', 'file'], 'root/file'),
-        (['', 'root', '', '', 'file', ''], 'root/file'),
+        (['', 'root', None, '', 'file', ''], 'root/file'),
     ]
 )
 def test_join(backend, paths, expected):


### PR DESCRIPTION
Closes #22

Fixes the problem and adds a test for it.

### Example:

```python
backend = audbackend.create('artifactory', 'http://host', 'repository')
backend.join('', '', 'file.txt')
```
```
file.txt
```
