### PR TITLE
Add audbackend.Backend.ls()

### DIFF
--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -88,6 +88,18 @@ class Artifactory(Backend):
             result = []
         return result
 
+    def _ls(
+            self,
+            path: str,
+    ):
+        r"""List content of path."""
+        path = audfactory.url(
+            self.host,
+            repository=self.repository,
+            group_id=audfactory.path_to_group_id(path),
+        )
+        return [p.name for p in audfactory.path(path)]
+
     def _put_file(
             self,
             src_path: str,

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -243,6 +243,31 @@ class Backend:
             )
         return vs[-1]
 
+    def _ls(
+            self,
+            path: str,
+    ) -> typing.List:  # pragma: no cover
+        r"""List content of path."""
+        raise NotImplementedError()
+
+    def ls(
+            self,
+            path: str,
+    ) -> typing.List:
+        r"""List content of path.
+
+        Args:
+            path: relative path to folder in repository
+
+        Returns:
+            folder content
+
+        Raises:
+            RuntimeError: if ``path`` does not exist on backend
+
+        """
+        return sorted(self._ls(path))
+
     def _path(
             self,
             folder: str,

--- a/audbackend/core/filesystem.py
+++ b/audbackend/core/filesystem.py
@@ -85,6 +85,18 @@ class FileSystem(Backend):
         matches = glob.glob(path, recursive=True)
         return [os.path.join(root, folder, match) for match in matches]
 
+    def _ls(
+            self,
+            path: str,
+    ):
+        r"""List content of path."""
+        path = os.path.join(
+            self.host,
+            self.repository,
+            path.replace(self.sep, os.path.sep),
+        )
+        return os.listdir(path)
+
     def _put_file(
             self,
             src_path: str,

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -329,6 +329,54 @@ def test_glob(tmpdir, files, pattern, folder, expected, backend):
 
 
 @pytest.mark.parametrize(
+    'path, content, expected_content',
+    [
+        (
+            'folder1',
+            ['file.txt', 'folder/abc.txt'],
+            ['file', 'folder'],
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    'backend',
+    [
+        audbackend.FileSystem(
+            pytest.FILE_SYSTEM_HOST,
+            pytest.REPOSITORY_NAME,
+        ),
+        audbackend.Artifactory(
+            pytest.ARTIFACTORY_HOST,
+            pytest.REPOSITORY_NAME,
+        ),
+    ]
+)
+def test_ls(tmpdir, path, content, expected_content, backend):
+
+    for file in content:
+        local_file = os.path.join(tmpdir, file)
+        audeer.mkdir(os.path.dirname(local_file))
+        with open(local_file, 'w'):
+            pass
+        backend_path = backend.join(
+            pytest.ID,
+            'test_ls',
+            path,
+        )
+        remote_file = backend.join(backend_path, file)
+        backend_file_path = backend.put_file(
+            local_file,
+            remote_file,
+            '1.0.0',
+        )
+        print('DEBUG: ', backend_file_path)
+
+    print('DEBUG: ', content)
+    print('DEBUG: ', backend.ls(backend_path))
+    assert backend.ls(backend_path) == expected_content
+
+
+@pytest.mark.parametrize(
     'backend',
     [
         audbackend.FileSystem(


### PR DESCRIPTION
This adds `audbackend.Backend.ls()` as a method to show the content of a folder on the backend.

The idea is to provide a solution so a user have not to use `glob()` to find files in a repo.

I tested it in `audb` to make `audb.available()` faster (see https://github.com/audeering/audb/pull/131):
* Execution time using `glob()`: 237s
* Execution time using `ls()`: 100s