### PR TITLE
Catch 403 Error for Artifactory backend paths

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ packages = find:
 install_requires =
     audeer >=1.12.0
     audfactory >=1.0.3
+    dohq-artifactory ==0.7.742
 setup_requires =
     setuptools_scm
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -177,6 +177,36 @@ def test_errors(tmpdir, backend):
 
 
 @pytest.mark.parametrize(
+    'backend',
+    [
+        audbackend.FileSystem(
+            pytest.FILE_SYSTEM_HOST,
+            pytest.REPOSITORY_NAME,
+        ),
+        audbackend.Artifactory(
+            pytest.ARTIFACTORY_HOST,
+            pytest.REPOSITORY_NAME,
+        ),
+    ]
+)
+def test_exists(tmpdir, backend):
+    file = 'test.txt'
+    version = '1.0.0'
+    local_file = os.path.join(tmpdir, file)
+    audeer.mkdir(os.path.dirname(local_file))
+    with open(local_file, 'w'):
+        pass
+    remote_file = backend.join(
+        pytest.ID,
+        'test_exists',
+        file,
+    )
+    backend.put_file(local_file, remote_file, version)
+    assert backend.exists(remote_file, version)
+    assert not backend.exists('non-existing-file.txt', version)
+
+
+@pytest.mark.parametrize(
     'local_file, remote_file, version, ext',
     [
         (
@@ -277,6 +307,14 @@ def test_file(tmpdir, local_file, remote_file, version, ext, backend):
             f'{pytest.ID}/test_glob/path/to',
             ['path/to/file.ext'],
         ),
+        # Test nion-existing path on server
+        (
+            [],
+            f'{pytest.ID}/test_non-existing-path/**/*.ext',
+            None,
+            [],
+        ),
+
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #26 

When accessing a non-existing path or a path where you don't have the permission to access it, you might experience a 403 error returned from Artifactory. This started happening only since a few days and most likely it depends on the version of `dohq-artifactory` and maybe if you have anonymous access enabled or not.

Here, we don't care, but just catch the corresponding error in order to return a proper `False` for `exists()` and an empty list for `glob()`.