### PR TITLE
Check for path name before creating archive

### DIFF
--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -381,7 +381,7 @@ class Backend:
             FileNotFoundError: if one or more files do not exist
 
         """
-        utils.check_path_for_allowed_chars(dst_path)
+        # utils.check_path_for_allowed_chars(dst_path)
         src_root = audeer.safe_path(src_root)
 
         if isinstance(files, str):

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -381,7 +381,7 @@ class Backend:
             FileNotFoundError: if one or more files do not exist
 
         """
-        # utils.check_path_for_allowed_chars(dst_path)
+        utils.check_path_for_allowed_chars(dst_path)
         src_root = audeer.safe_path(src_root)
 
         if isinstance(files, str):

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -1,15 +1,11 @@
 import errno
 import os
-import re
 import tempfile
 import typing
 
 import audeer
 
 from audbackend.core import utils
-
-
-BACKEND_ALLOWED_CHARS = '[A-Za-z0-9/._-]+'
 
 
 class Backend:
@@ -336,12 +332,7 @@ class Backend:
             'archive1-1.0.0.tar.gz'
 
         """
-        allowed_chars = re.compile(BACKEND_ALLOWED_CHARS)
-        if allowed_chars.fullmatch(path) is None:
-            raise ValueError(
-                f"Invalid path name '{path}', "
-                f"allowed characters are '{BACKEND_ALLOWED_CHARS}'."
-            )
+        utils.check_path_for_allowed_chars(path)
         folder, file = self.split(path)
         if ext is None:
             name, ext = os.path.splitext(file)
@@ -390,6 +381,7 @@ class Backend:
             FileNotFoundError: if one or more files do not exist
 
         """
+        utils.check_path_for_allowed_chars(dst_path)
         src_root = audeer.safe_path(src_root)
 
         if isinstance(files, str):

--- a/audbackend/core/utils.py
+++ b/audbackend/core/utils.py
@@ -1,7 +1,12 @@
 import hashlib
+import re
 import typing
 
 import audeer
+
+
+BACKEND_ALLOWED_CHARS = '[A-Za-z0-9/._-]+'
+BACKEND_ALLOWED_CHARS_COMPILED = re.compile(BACKEND_ALLOWED_CHARS)
 
 
 def md5(
@@ -26,3 +31,11 @@ def md5_read_chunk(
         if not data:
             break
         yield data
+
+
+def check_path_for_allowed_chars(path):
+    if BACKEND_ALLOWED_CHARS_COMPILED.fullmatch(path) is None:
+        raise ValueError(
+            f"Invalid path name '{path}', "
+            f"allowed characters are '{BACKEND_ALLOWED_CHARS}'."
+        )

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -89,6 +89,9 @@ def test_archive(tmpdir, files, name, folder, version, backend):
 
     assert backend.get_archive(archive, tmpdir, version) == files_as_list
 
+    with pytest.raises(ValueError):
+        backend.put_archive(tmpdir, files, 'broken_name?', version)
+
 
 @pytest.mark.parametrize(
     'name, host, cls',


### PR DESCRIPTION
We check that a given path name includes only allowed chars.
But for `audbackend.Backend.put_archive()` we did first create the archive and only afterwards checked for the correct path name.
This has two disadvantages:
* it can take some time before the error is raised as the archive is first created
* on Windows it might fail before as it cannot create the archive locally, compare https://github.com/audeering/audb/runs/5320867038?check_suite_focus=true

I added a test for using a non-supported archive name, which fails for the `master` under Widnows with an `OSError`, see https://github.com/audeering/audbackend/runs/5321158317?check_suite_focus=true
I then added the check for the correct name at the beginning of `put_archive()`, which now raises our custom `ValueError`.