### PR TITLE
Depend on audfactory>=1.0.8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ classifiers =
 packages = find:
 install_requires =
     audeer >=1.17.1
-    audfactory >=1.0.3
+    audfactory >=1.0.8
     dohq-artifactory ==0.7.742
 setup_requires =
     setuptools_scm


### PR DESCRIPTION
Closes #34.

As we introduced support for Python 3.9 in `audfactory` v1.0.8, I think it does not harm to request that version here as we want to support Python 3.9 here as well.