### PR TITLE
Fix return value type hint of Backend._get_file()

### DIFF
--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -141,7 +141,7 @@ class Backend:
             src_path: str,
             dst_path: str,
             verbose: bool,
-    ) -> str:  # pragma: no cover
+    ):  # pragma: no cover
         r"""Get file from backend."""
         raise NotImplementedError()
 


### PR DESCRIPTION
`Backend._get_file()` does not return a value.