### PR TITLE
WIP: Add Backend.folder()

### DIFF
--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -62,6 +62,17 @@ class Artifactory(Backend):
         except self._non_existing_path_error:  # pragma: nocover
             return False
 
+    def _folder(
+            self,
+            path: str,
+    ) -> str:
+        r"""Folder path on backend."""
+        return audfactory.url(
+            self.host,
+            repository=self.repository,
+            group_id=audfactory.path_to_group_id(path),
+        )
+
     def _get_file(
             self,
             src_path: str,
@@ -98,11 +109,6 @@ class Artifactory(Backend):
             path: str,
     ):
         r"""List content of path."""
-        path = audfactory.url(
-            self.host,
-            repository=self.repository,
-            group_id=audfactory.path_to_group_id(path),
-        )
         return [p.name for p in audfactory.path(path)]
 
     def _put_file(

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -116,8 +116,8 @@ class Backend:
             >>> import audbackend
             >>> backend = audbackend.FileSystem('~/my-host', 'data')
             >>> path = backend.folder('a/dir')
-            >>> os.path.sep.join(path.split(os.path.sep)[-4:])
-            'my-host/data/a/dir'
+            >>> os.path.basename(path)
+            'dir'
 
         """
         utils.check_path_for_allowed_chars(path)

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -93,6 +93,43 @@ class Backend:
         path = self.path(path, version, ext=ext)
         return self._exists(path)
 
+    def folder(
+            self,
+            path: str,
+    ) -> str:
+        r"""Folder path on backend.
+
+        This converts a folder path on the backend
+        from the form it is presented to a user
+        to the actual path on the backend storage.
+
+        Args:
+            path: relative path to folder in repository
+
+        Returns:
+            folder path on backend
+
+        Raises:
+            ValueError: if ``path`` contains invalid character
+
+        Example:
+            >>> import audbackend
+            >>> backend = audbackend.FileSystem('~/my-host', 'data')
+            >>> path = backend.folder('a/dir')
+            >>> backend.sep.join(path.split(backend.sep)[-4:])
+            'my-host/data/a/dir'
+
+        """
+        utils.check_path_for_allowed_chars(path)
+        return self._folder(path)
+
+    def _folder(
+            self,
+            path: str,
+    ) -> str:  # pragma: no cover
+        r"""Folder path on backend."""
+        raise NotImplementedError()
+
     def get_archive(
             self,
             src_path: str,
@@ -277,9 +314,14 @@ class Backend:
             folder content
 
         Raises:
-            RuntimeError: if ``path`` does not exist on backend
+            FileNotFoundError: if ``path`` does not exist on backend
 
         """
+        path = self.folder(path)
+        if not self._exists(path):
+            raise FileNotFoundError(
+                errno.ENOENT, os.strerror(errno.ENOENT), path,
+            )
         return sorted(self._ls(path))
 
     def _path(

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -116,7 +116,7 @@ class Backend:
             >>> import audbackend
             >>> backend = audbackend.FileSystem('~/my-host', 'data')
             >>> path = backend.folder('a/dir')
-            >>> backend.sep.join(path.split(backend.sep)[-4:])
+            >>> os.path.sep.join(path.split(os.path.sep)[-4:])
             'my-host/data/a/dir'
 
         """

--- a/audbackend/core/filesystem.py
+++ b/audbackend/core/filesystem.py
@@ -62,6 +62,17 @@ class FileSystem(Backend):
         r"""Check if file exists on backend."""
         return os.path.exists(path)
 
+    def _folder(
+            self,
+            path: str,
+    ) -> str:
+        r"""Folder path on backend."""
+        return os.path.join(
+            self.host,
+            self.repository,
+            path.replace(self.sep, os.path.sep),
+        )
+
     def _get_file(
             self,
             src_path: str,
@@ -91,11 +102,6 @@ class FileSystem(Backend):
             path: str,
     ):
         r"""List content of path."""
-        path = os.path.join(
-            self.host,
-            self.repository,
-            path.replace(self.sep, os.path.sep),
-        )
         return os.listdir(path)
 
     def _put_file(

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -405,16 +405,16 @@ def test_ls(tmpdir, path, content, expected_content, backend):
             path,
         )
         remote_file = backend.join(backend_path, file)
-        backend_file_path = backend.put_file(
+        backend.put_file(
             local_file,
             remote_file,
             '1.0.0',
         )
-        print('DEBUG: ', backend_file_path)
 
-    print('DEBUG: ', content)
-    print('DEBUG: ', backend.ls(backend_path))
     assert backend.ls(backend_path) == expected_content
+
+    with pytest.raises(FileNotFoundError):
+        backend.ls('does/not/exist')
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
As discussed in #37 we need a method `folder()` that converts a folder path to its backend form. It is now used within `ls()` to check if the path exists and make sure we always raise a `FileNotFoundError`error if it does not. It also fixes the docstring that was wrongly stating we raise a `RuntimeError` in that case. A test is added to verify we raise the correct error.

![image](https://user-images.githubusercontent.com/10383417/165576649-87b38407-e57b-4f15-850a-473ecb3e8215.png)
