### PR TITLE
WIP: Force same file structure on all backends

### DIFF
--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -31,23 +31,6 @@ class Artifactory(Backend):
         r"""MD5 checksum of file on backend."""
         return audfactory.checksum(path)
 
-    def _path(
-            self,
-            folder: str,
-            name: str,
-            ext: str,
-            version: str,
-    ) -> str:
-        r"""File path on backend."""
-        server_url = audfactory.url(
-            self.host,
-            repository=self.repository,
-            group_id=audfactory.path_to_group_id(folder),
-            name=name,
-            version=version,
-        )
-        return f'{server_url}/{name}-{version}{ext}'
-
     def _exists(
             self,
             path: str,
@@ -104,6 +87,18 @@ class Artifactory(Backend):
             group_id=audfactory.path_to_group_id(path),
         )
         return [p.name for p in audfactory.path(path)]
+
+    def _path(
+            self,
+            path: str,
+    ) -> str:
+        r"""File path on backend."""
+        url = audfactory.url(
+            self.host,
+            repository=self.repository,
+        )
+        url = f'{url}/{path}'
+        return url
 
     def _put_file(
             self,

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -284,10 +284,7 @@ class Backend:
 
     def _path(
             self,
-            folder: str,
-            name: str,
-            ext: str,
-            version: str,
+            path: str,
     ) -> str:  # pragma: no cover
         r"""File path on backend."""
         raise NotImplementedError()
@@ -334,6 +331,7 @@ class Backend:
         """
         utils.check_path_for_allowed_chars(path)
         folder, file = self.split(path)
+
         if ext is None:
             name, ext = os.path.splitext(file)
         elif ext == '':
@@ -347,7 +345,15 @@ class Backend:
                     f"does not end on '{ext}'."
                 )
             name = file[:-len(ext)]
-        return self._path(folder, name, ext, version)
+
+        path = self.join(
+            folder,
+            name,
+            version,
+            f'{name}-{version}{ext}',
+        )
+
+        return self._path(path)
 
     def put_archive(
             self,

--- a/audbackend/core/filesystem.py
+++ b/audbackend/core/filesystem.py
@@ -33,28 +33,6 @@ class FileSystem(Backend):
         r"""MD5 checksum of file on backend."""
         return utils.md5(path)
 
-    def _path(
-            self,
-            folder: str,
-            name: str,
-            ext: str,
-            version: str,
-    ) -> str:
-        r"""File path on backend."""
-        path = os.path.join(
-            self.host,
-            self.repository,
-            folder.replace(self.sep, os.path.sep),
-            name,
-        )
-        if version is not None:
-            path = os.path.join(
-                path,
-                version,
-                f'{name}-{version}{ext}',
-            )
-        return path
-
     def _exists(
             self,
             path: str,
@@ -98,6 +76,18 @@ class FileSystem(Backend):
         )
         return os.listdir(path)
 
+    def _path(
+            self,
+            path: str,
+    ) -> str:
+        r"""File path on backend."""
+        path = os.path.join(
+            self.host,
+            self.repository,
+            path.replace(self.sep, os.path.sep),
+        )
+        return path
+
     def _put_file(
             self,
             src_path: str,
@@ -121,7 +111,8 @@ class FileSystem(Backend):
             name: str,
     ) -> typing.List[str]:
         r"""Versions of a file."""
-        root = self._path(folder, name, '', None)
+        root = self.join(folder, name)
+        root = self._path(root)
         vs = []
         if os.path.exists(root):
             vs = [

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -405,15 +405,12 @@ def test_ls(tmpdir, path, content, expected_content, backend):
             path,
         )
         remote_file = backend.join(backend_path, file)
-        backend_file_path = backend.put_file(
+        backend.put_file(
             local_file,
             remote_file,
             '1.0.0',
         )
-        print('DEBUG: ', backend_file_path)
 
-    print('DEBUG: ', content)
-    print('DEBUG: ', backend.ls(backend_path))
     assert backend.ls(backend_path) == expected_content
 
 


### PR DESCRIPTION
This is alternative solution for #38, but also introduces a more fundamental change regarding the file structure we use on the backends.

Instead of adding a new API function `folder()`, this changes the implementation of `_path()` and as a side effect it can now cope with folders, too. It's probably more elegant as we do not introduce another abstract function and now `_path()` is also easier to implement. I also don't see why a user would need a `folder()` function.

The core change we propose here is to create the file structure already in `path()` and let `_path()` only add host, repository and possibly change the file separator. I think this makes a lot of more sense, since now we ensure that version `1.0.0` of `sub/dir/file.txt` will be stored as `sub/dir/file/1.0.0/file-1.0.0.txt` on all backends. So far this was left to the child implementation, e.g. the backend was allowed to store the file as `sub/dir/file_1.0.0.txt`. But I don't think this is good design. 1. we assume that the developer chooses a format that properly encodes the version, 2. we have the unwanted side-effect that `ls()` may return different results depending on the backend.

