### PR TITLE
Properly handle dots in backend folder on Artifactory

### DIFF
--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -67,14 +67,9 @@ class Artifactory(Backend):
 
         """
         folder, file = self.split(path)
-        name, ext = utils.splitext(file, ext)
+        name, _ = utils.splitext(file, ext)
 
-        path = audfactory.url(
-            self.host,
-            repository=self.repository,
-            group_id=audfactory.path_to_group_id(folder),
-            name=name,
-        )
+        path = f'{self.host}/{self.repository}/{folder}/{name}'
 
         return path
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -305,6 +305,12 @@ def test_exists(tmpdir, backend):
             None,
         ),
         (
+            os.path.join('dir.to', 'file.ext'),
+            'dir.to/file.ext',
+            '1.0.0',
+            None,
+        ),
+        (
             os.path.join('dir', 'to', 'file.ext'),
             'alias.ext',
             '1.0.0',
@@ -341,12 +347,7 @@ def test_file(tmpdir, local_file, remote_file, version, ext, backend):
     assert not backend.exists(remote_file, version, ext=ext)
     backend.put_file(local_file, remote_file, version, ext=ext)
     # operation will be skipped
-    backend.put_file(
-        local_file,
-        remote_file,
-        version,
-        ext=ext,
-    )
+    backend.put_file(local_file, remote_file, version, ext=ext)
     assert backend.exists(remote_file, version, ext=ext)
 
     backend.get_file(remote_file, local_file, version, ext=ext)
@@ -355,11 +356,6 @@ def test_file(tmpdir, local_file, remote_file, version, ext, backend):
 
     backend.remove_file(remote_file, version, ext=ext)
     assert not backend.exists(remote_file, version, ext=ext)
-
-    if ext is None:
-        _, ext = os.path.splitext(local_file)
-    else:
-        ext = '.' + ext
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #51  

Fixed by not relying on `audfactory.url()` to create url as it converts `.` to `/`.

`audfactory.url()` is still used in `Artfactory.ls()` and `Artifactory.glob()`, but these functions will be changed / removed anyway, see #46 