### PR TITLE
Reimplement Backend.ls()

### DIFF
--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -125,7 +125,7 @@ class Artifactory(Backend):
 
         # <host>/<repository>/<folder>/<name>/<version>/<name>-<version><ext>
         # ->
-        # (<folder>/<name><ext>, <version>, <ext>)
+        # (<folder>/<name><ext>, <ext>, <version>)
 
         result = []
         for full_path in paths:
@@ -142,7 +142,7 @@ class Artifactory(Backend):
             ext = file[len(name) + len(version) + 1:]
             path = self.join(folder, f'{name}{ext}')
 
-            result.append((path, version, ext))
+            result.append((path, ext, version))
 
         return result
 

--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -69,7 +69,10 @@ class Artifactory(Backend):
         folder, file = self.split(path)
         name, _ = utils.splitext(file, ext)
 
-        path = f'{self.host}/{self.repository}/{folder}/{name}'
+        if folder:
+            path = f'{self.host}/{self.repository}/{folder}/{name}'
+        else:
+            path = f'{self.host}/{self.repository}/{name}'
 
         return path
 
@@ -109,15 +112,40 @@ class Artifactory(Backend):
 
     def _ls(
             self,
-            path: str,
+            folder: str,
     ):
-        r"""List content of path."""
-        path = audfactory.url(
-            self.host,
-            repository=self.repository,
-            group_id=audfactory.path_to_group_id(path),
-        )
-        return [p.name for p in audfactory.path(path)]
+        r"""List content of folder."""
+        root = self._folder(folder, '')
+
+        path = audfactory.path(root)
+        try:
+            paths = [str(x) for x in path.glob("**/*") if x.is_file()]
+        except self._non_existing_path_error:  # pragma: nocover
+            paths = []
+
+        # <host>/<repository>/<folder>/<name>/<version>/<name>-<version>.<ext>
+        # ->
+        # (<folder>/<name>.<ext>, <version>, <ext>)
+
+        result = []
+        for full_path in paths:
+
+            host_repo = f'{self.host}/{self.repository}'
+            full_path = full_path[len(host_repo) + 1:]  # remove host and repo
+
+            tokens = full_path.split(os.path.sep)
+            file = tokens[-1]
+            version = tokens[-2]
+            name = tokens[-3]
+            folder = os.path.sep.join(tokens[:-3])
+            ext = file[len(name) + len(version) + 1:]
+            path = os.path.join(folder, f'{name}{ext}')
+            if ext:
+                ext = ext[1:]  # remove .
+
+            result.append((path, version, ext))
+
+        return result
 
     def _path(
             self,

--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -116,7 +116,7 @@ class Artifactory(Backend):
     ):
         r"""List all files under folder.
 
-        Returns an empty list if folder does not exist.
+        Return an empty list if no files match or folder does not exist.
 
         """
         root = self._folder(folder, '')

--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -132,14 +132,15 @@ class Artifactory(Backend):
 
             host_repo = f'{self.host}/{self.repository}'
             full_path = full_path[len(host_repo) + 1:]  # remove host and repo
+            full_path = full_path.replace('/', self.sep)
+            tokens = full_path.split('/')
 
-            tokens = full_path.split(os.path.sep)
             file = tokens[-1]
             version = tokens[-2]
             name = tokens[-3]
-            folder = os.path.sep.join(tokens[:-3])
+            folder = self.sep.join(tokens[:-3])
             ext = file[len(name) + len(version) + 1:]
-            path = os.path.join(folder, f'{name}{ext}')
+            path = self.join(folder, f'{name}{ext}')
             if ext:
                 ext = ext[1:]  # remove .
 

--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -114,7 +114,11 @@ class Artifactory(Backend):
             self,
             folder: str,
     ):
-        r"""List all files under folder."""
+        r"""List all files under folder.
+
+        Returns an empty list if folder does not exist.
+
+        """
         root = self._folder(folder, '')
 
         path = audfactory.path(root)

--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -61,7 +61,7 @@ class Artifactory(Backend):
     ) -> str:
         r"""Convert to backend folder.
 
-        <folder>/<name>.<ext>
+        <folder>/<name><ext>
         ->
         <host>/<repository>/<folder>/<name>/
 
@@ -114,7 +114,7 @@ class Artifactory(Backend):
             self,
             folder: str,
     ):
-        r"""List content of folder."""
+        r"""List all files under folder."""
         root = self._folder(folder, '')
 
         path = audfactory.path(root)
@@ -123,9 +123,9 @@ class Artifactory(Backend):
         except self._non_existing_path_error:  # pragma: nocover
             paths = []
 
-        # <host>/<repository>/<folder>/<name>/<version>/<name>-<version>.<ext>
+        # <host>/<repository>/<folder>/<name>/<version>/<name>-<version><ext>
         # ->
-        # (<folder>/<name>.<ext>, <version>, <ext>)
+        # (<folder>/<name><ext>, <version>, <ext>)
 
         result = []
         for full_path in paths:
@@ -141,8 +141,6 @@ class Artifactory(Backend):
             folder = self.sep.join(tokens[:-3])
             ext = file[len(name) + len(version) + 1:]
             path = self.join(folder, f'{name}{ext}')
-            if ext:
-                ext = ext[1:]  # remove .
 
             result.append((path, version, ext))
 

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -332,18 +332,18 @@ class Backend:
     ) -> typing.List[typing.Tuple[str, str, str]]:
         r"""List all files under folder.
 
-        For each match,
-        path, version and extension is returned.
-        If extension is not empty,
+        Returns a sorted list of tuples
+        with path, version and file extension.
+        If file extension is not empty,
         it starts with a dot.
         If folder does not exist,
-        the result is an empty list.
+        an empty list is returned.
 
         Args:
             folder: folder on backend
 
         Returns:
-            sorted list of tuples (path, version, extension)
+            list of tuples
 
         Raises:
             ValueError: if ``folder`` contains invalid character

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -335,7 +335,7 @@ class Backend:
         r"""List all files under folder.
 
         Returns a sorted list of tuples
-        with path, version and file extension.
+        with path, extension and version.
         If file extension is not empty,
         it starts with a dot.
 
@@ -345,7 +345,7 @@ class Backend:
                 only include the latest
 
         Returns:
-            list of tuples
+            list of tuples (path, extension, version)
 
         Raises:
             FileNotFoundError: if ``folder`` does not exist
@@ -353,9 +353,9 @@ class Backend:
 
         Example:
             >>> backend.ls('folder')[:2]
-            [('folder/name.ext', '1.0.0', '.ext'), ('folder/name.ext', '2.0.0', '.ext')]
+            [('folder/name.ext', '.ext', '1.0.0'), ('folder/name.ext', '.ext', '2.0.0')]
             >>> backend.ls('folder', latest_version=True)[:1]
-            [('folder/name.ext', '2.0.0', '.ext')]
+            [('folder/name.ext', '.ext', '2.0.0')]
 
         """  # noqa: E501
         utils.check_path_for_allowed_chars(folder)
@@ -372,7 +372,7 @@ class Backend:
         if latest_version:
             # d[path, ext] = ['1.0.0', '2.0.0']
             d = {}
-            for p, v, e in paths:
+            for p, e, v in paths:
                 key = (p, e)
                 if key not in d:
                     d[key] = []
@@ -381,7 +381,7 @@ class Backend:
             for key, vs in d.items():
                 d[key] = audeer.sort_versions(vs)[-1]
             # [(path, ext, '2.0.0'), ...]
-            paths = [(p, v, e) for (p, e), v in d.items()]
+            paths = [(p, e, v) for (p, e), v in d.items()]
 
         return paths
 

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -349,8 +349,8 @@ class Backend:
             ValueError: if ``folder`` contains invalid character
 
         Example:
-            >>> backend.ls('folder')
-            [('folder/name.ext', '1.0.0', '.ext'), ('folder/name.ext', '2.0.0', '.ext'), ('folder/name.zip', '1.0.0', '.zip')]
+            >>> backend.ls('folder')[:2]
+            [('folder/name.ext', '1.0.0', '.ext'), ('folder/name.ext', '2.0.0', '.ext')]
 
         """  # noqa: E501
         utils.check_path_for_allowed_chars(folder)

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -337,9 +337,7 @@ class Backend:
         Returns a sorted list of tuples
         with path, version and file extension.
         If file extension is not empty,
-        it starts with a dot.
-        If folder does not exist,
-        an empty list is returned.
+        it starts with a dot.        
 
         Args:
             folder: folder on backend
@@ -350,6 +348,7 @@ class Backend:
             list of tuples
 
         Raises:
+            FileNotFoundError: if ``folder`` does not exist
             ValueError: if ``folder`` contains invalid character
 
         Example:
@@ -362,6 +361,9 @@ class Backend:
         utils.check_path_for_allowed_chars(folder)
         paths = self._ls(folder)
         paths = sorted(paths)
+
+        if len(paths) == 0:
+            utils.raise_file_not_found_error(folder)
 
         if latest_version:
             # d[path, ext] = ['1.0.0', '2.0.0']

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -321,7 +321,7 @@ class Backend:
 
     def _ls(
             self,
-            path: str,
+            folder: str,
     ) -> typing.List[typing.Tuple[str, str, str]]:  # pragma: no cover
         r"""List all files under folder."""
         raise NotImplementedError()

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -359,6 +359,8 @@ class Backend:
 
         """  # noqa: E501
         utils.check_path_for_allowed_chars(folder)
+        if not folder.endswith('/'):
+            folder += '/'
         paths = self._ls(folder)
         paths = sorted(paths)
 

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -291,7 +291,7 @@ class Backend:
         r"""Latest version of a file.
 
         Args:
-            path: relative path to file in repository
+            path: path to file on backend
             ext: file extension, if ``None`` uses characters after last dot
 
         Returns:
@@ -328,21 +328,27 @@ class Backend:
 
     def ls(
             self,
-            path: str,
-    ) -> typing.List[str]:
-        r"""List content of path.
+            folder: str,
+    ) -> typing.List[typing.Tuple[str, str, str]]:
+        r"""List all files under folder.
+
+        If folder does not exist,
+        an empty list is returned.
 
         Args:
-            path: relative path to folder in repository
+            folder: folder on backend
 
         Returns:
-            folder content
+            list of tuples (path, version, ext)
 
         Raises:
-            RuntimeError: if ``path`` does not exist on backend
+            ValueError: if ``folder`` contains invalid character
 
         """
-        return sorted(self._ls(path))
+        utils.check_path_for_allowed_chars(folder)
+        paths = self._ls(folder)
+
+        return sorted(paths)
 
     def put_archive(
             self,

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -325,7 +325,7 @@ class Backend:
     ) -> typing.List[typing.Tuple[str, str, str]]:  # pragma: no cover
         r"""List all files under folder.
 
-        Returns an empty list if folder does not exist.
+        Return an empty list if no files match or folder does not exist.
 
         """
         raise NotImplementedError()

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -328,7 +328,7 @@ class Backend:
 
     def ls(
             self,
-            folder: str,
+            folder: str = '/',
             *,
             latest_version: bool = False,
     ) -> typing.List[typing.Tuple[str, str, str]]:

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -348,7 +348,11 @@ class Backend:
         Raises:
             ValueError: if ``folder`` contains invalid character
 
-        """
+        Example:
+            >>> backend.ls('folder')
+            [('folder/name.ext', '1.0.0', '.ext'), ('folder/name.ext', '2.0.0', '.ext'), ('folder/name.zip', '1.0.0', '.zip')]
+
+        """  # noqa: E501
         utils.check_path_for_allowed_chars(folder)
         paths = self._ls(folder)
 

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -370,7 +370,7 @@ class Backend:
                 utils.raise_file_not_found_error(folder)
 
         if latest_version:
-            # d[path, ext] = ['1.0.0', '2.0.0']
+            # d[(path, ext)] = ['1.0.0', '2.0.0']
             d = {}
             for p, e, v in paths:
                 key = (p, e)

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -322,8 +322,8 @@ class Backend:
     def _ls(
             self,
             path: str,
-    ) -> typing.List:  # pragma: no cover
-        r"""List content of path."""
+    ) -> typing.List[typing.Tuple[str, str, str]]:  # pragma: no cover
+        r"""List all files under folder."""
         raise NotImplementedError()
 
     def ls(
@@ -332,14 +332,18 @@ class Backend:
     ) -> typing.List[typing.Tuple[str, str, str]]:
         r"""List all files under folder.
 
+        For each match,
+        path, version and extension is returned.
+        If extension is not empty,
+        it starts with a dot.
         If folder does not exist,
-        an empty list is returned.
+        the result is an empty list.
 
         Args:
             folder: folder on backend
 
         Returns:
-            list of tuples (path, version, ext)
+            sorted list of tuples (path, version, extension)
 
         Raises:
             ValueError: if ``folder`` contains invalid character

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -336,8 +336,6 @@ class Backend:
 
         Returns a sorted list of tuples
         with path, extension and version.
-        If file extension is not empty,
-        it starts with a dot.
 
         Args:
             folder: folder on backend

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -363,9 +363,8 @@ class Backend:
         paths = sorted(paths)
 
         if len(paths) == 0:
-            if folder == '/':  # noqa
-                # capture special case that
-                # there are no files on the backend
+            if folder == '/':  # pragma: no cover
+                # special case that there are no files on the backend
                 return []
             else:
                 utils.raise_file_not_found_error(folder)

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -323,7 +323,11 @@ class Backend:
             self,
             folder: str,
     ) -> typing.List[typing.Tuple[str, str, str]]:  # pragma: no cover
-        r"""List all files under folder."""
+        r"""List all files under folder.
+
+        Returns an empty list if folder does not exist.
+
+        """
         raise NotImplementedError()
 
     def ls(

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -380,7 +380,7 @@ class Backend:
             # d[(path, ext)] = '2.0.0'
             for key, vs in d.items():
                 d[key] = audeer.sort_versions(vs)[-1]
-            # [(path, ext, '2.0.0'), ...]
+            # [(path, ext, '2.0.0')]
             paths = [(p, e, v) for (p, e), v in d.items()]
 
         return paths

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -337,7 +337,7 @@ class Backend:
         Returns a sorted list of tuples
         with path, version and file extension.
         If file extension is not empty,
-        it starts with a dot.        
+        it starts with a dot.
 
         Args:
             folder: folder on backend

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -340,6 +340,10 @@ class Backend:
 
         Returns a sorted list of tuples
         with path, extension and version.
+        When ``folder`` is set to the
+        root of the backend (``'/'``)
+        a (possibly empty) list with
+        all files on the backend is returned.
 
         Args:
             folder: folder on backend

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -377,7 +377,7 @@ class Backend:
                 if key not in d:
                     d[key] = []
                 d[key].append(v)
-            # d[path, ext] = '2.0.0'
+            # d[(path, ext)] = '2.0.0'
             for key, vs in d.items():
                 d[key] = audeer.sort_versions(vs)[-1]
             # [(path, ext, '2.0.0'), ...]

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -367,7 +367,7 @@ class Backend:
         paths = sorted(paths)
 
         if len(paths) == 0:
-            if folder == '/':  # pragma: no cover
+            if folder == '/':
                 # special case that there are no files on the backend
                 return []
             else:

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -363,7 +363,12 @@ class Backend:
         paths = sorted(paths)
 
         if len(paths) == 0:
-            utils.raise_file_not_found_error(folder)
+            if folder == '/':  # noqa
+                # capture special case that
+                # there are no files on the backend
+                return []
+            else:
+                utils.raise_file_not_found_error(folder)
 
         if latest_version:
             # d[path, ext] = ['1.0.0', '2.0.0']

--- a/audbackend/core/filesystem.py
+++ b/audbackend/core/filesystem.py
@@ -99,15 +99,35 @@ class FileSystem(Backend):
 
     def _ls(
             self,
-            path: str,
+            folder: str,
     ):
-        r"""List content of path."""
-        path = os.path.join(
-            self.host,
-            self.repository,
-            path.replace(self.sep, os.path.sep),
-        )
-        return os.listdir(path)
+        r"""List content of folder."""
+        root = self._folder(folder, '')
+        paths = audeer.list_file_names(root, recursive=True)
+
+        # <host>/<repository>/<folder>/<name>/<version>/<name>-<version>.<ext>
+        # ->
+        # (<folder>/<name>.<ext>, <version>, <ext>)
+
+        result = []
+        for full_path in paths:
+
+            host_repo = os.path.join(self.host, self.repository)
+            full_path = full_path[len(host_repo) + 1:]  # remove host and repo
+
+            tokens = full_path.split(os.path.sep)
+            file = tokens[-1]
+            version = tokens[-2]
+            name = tokens[-3]
+            folder = os.path.sep.join(tokens[:-3])
+            ext = file[len(name) + len(version) + 1:]
+            path = os.path.join(folder, f'{name}{ext}')
+            if ext:
+                ext = ext[1:]  # remove .
+
+            result.append((path, version, ext))
+
+        return result
 
     def _path(
             self,

--- a/audbackend/core/filesystem.py
+++ b/audbackend/core/filesystem.py
@@ -53,7 +53,7 @@ class FileSystem(Backend):
     ) -> str:
         r"""Convert to backend folder.
 
-        <folder>/<name>.<ext>
+        <folder>/<name><ext>
         ->
         <host>/<repository>/<folder>/<name>/
 
@@ -101,13 +101,13 @@ class FileSystem(Backend):
             self,
             folder: str,
     ):
-        r"""List content of folder."""
+        r"""List all files under folder."""
         root = self._folder(folder, '')
         paths = audeer.list_file_names(root, recursive=True)
 
-        # <host>/<repository>/<folder>/<name>/<version>/<name>-<version>.<ext>
+        # <host>/<repository>/<folder>/<name>/<version>/<name>-<version><ext>
         # ->
-        # (<folder>/<name>.<ext>, <version>, <ext>)
+        # (<folder>/<name><ext>, <version>, <ext>)
 
         result = []
         for full_path in paths:
@@ -123,8 +123,6 @@ class FileSystem(Backend):
             folder = self.sep.join(tokens[:-3])
             ext = file[len(name) + len(version) + 1:]
             path = self.join(folder, f'{name}{ext}')
-            if ext:
-                ext = ext[1:]  # remove .
 
             result.append((path, version, ext))
 

--- a/audbackend/core/filesystem.py
+++ b/audbackend/core/filesystem.py
@@ -107,7 +107,7 @@ class FileSystem(Backend):
 
         # <host>/<repository>/<folder>/<name>/<version>/<name>-<version><ext>
         # ->
-        # (<folder>/<name><ext>, <version>, <ext>)
+        # (<folder>/<name><ext>, <ext>, <version>)
 
         result = []
         for full_path in paths:
@@ -124,7 +124,7 @@ class FileSystem(Backend):
             ext = file[len(name) + len(version) + 1:]
             path = self.join(folder, f'{name}{ext}')
 
-            result.append((path, version, ext))
+            result.append((path, ext, version))
 
         return result
 

--- a/audbackend/core/filesystem.py
+++ b/audbackend/core/filesystem.py
@@ -114,8 +114,9 @@ class FileSystem(Backend):
 
             host_repo = os.path.join(self.host, self.repository)
             full_path = full_path[len(host_repo) + 1:]  # remove host and repo
+            full_path = full_path.replace(os.path.sep, self.sep)
+            tokens = full_path.split(self.sep)
 
-            tokens = full_path.split(os.path.sep)
             file = tokens[-1]
             version = tokens[-2]
             name = tokens[-3]

--- a/audbackend/core/filesystem.py
+++ b/audbackend/core/filesystem.py
@@ -122,7 +122,7 @@ class FileSystem(Backend):
             name = tokens[-3]
             folder = os.path.sep.join(tokens[:-3])
             ext = file[len(name) + len(version) + 1:]
-            path = os.path.join(folder, f'{name}{ext}')
+            path = self.join(folder, f'{name}{ext}')
             if ext:
                 ext = ext[1:]  # remove .
 

--- a/audbackend/core/filesystem.py
+++ b/audbackend/core/filesystem.py
@@ -103,7 +103,7 @@ class FileSystem(Backend):
     ):
         r"""List all files under folder.
 
-        Returns an empty list if folder does not exist.
+        Return an empty list if no files match or folder does not exist.
 
         """
         root = self._folder(folder, '')

--- a/audbackend/core/filesystem.py
+++ b/audbackend/core/filesystem.py
@@ -101,7 +101,11 @@ class FileSystem(Backend):
             self,
             folder: str,
     ):
-        r"""List all files under folder."""
+        r"""List all files under folder.
+
+        Returns an empty list if folder does not exist.
+
+        """
         root = self._folder(folder, '')
         paths = audeer.list_file_names(root, recursive=True)
 

--- a/audbackend/core/filesystem.py
+++ b/audbackend/core/filesystem.py
@@ -120,7 +120,7 @@ class FileSystem(Backend):
             file = tokens[-1]
             version = tokens[-2]
             name = tokens[-3]
-            folder = os.path.sep.join(tokens[:-3])
+            folder = self.sep.join(tokens[:-3])
             ext = file[len(name) + len(version) + 1:]
             path = self.join(folder, f'{name}{ext}')
             if ext:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,20 +12,23 @@ import audfactory
 pytest.ROOT = os.path.dirname(os.path.realpath(__file__))
 pytest.ID = audeer.uid()
 
+# Artifactory
 pytest.ARTIFACTORY_HOST = 'https://audeering.jfrog.io/artifactory'
 pytest.ARTIFACTORY_REPOSITORY = f'unittests-public/{pytest.ID}'
 pytest.ARTIFACTORY_BACKEND = audbackend.Artifactory(
-    'https://audeering.jfrog.io/artifactory',
-    f'unittests-public/{pytest.ID}',
+    pytest.ARTIFACTORY_HOST,
+    pytest.ARTIFACTORY_REPOSITORY,
 )
 
+# file system
 pytest.FILE_SYSTEM_HOST = audeer.path(pytest.ROOT, 'host')
 pytest.FILE_SYSTEM_REPOSITORY = os.path.join('unittests-public', pytest.ID)
 pytest.FILE_SYSTEM_BACKEND = audbackend.FileSystem(
     pytest.FILE_SYSTEM_HOST,
-    os.path.join('unittests-public', pytest.ID)
+    pytest.FILE_SYSTEM_REPOSITORY,
 )
 
+# list of all backends that will be tested by default
 pytest.BACKENDS = [
     pytest.FILE_SYSTEM_BACKEND,
     pytest.ARTIFACTORY_BACKEND,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import glob
 import os
 import shutil
 
@@ -43,7 +42,7 @@ def cleanup_session():
         pytest.ROOT,
         '.coverage.*',
     )
-    for file in glob.glob(path):
+    for file in audeer.list_file_names(path):
         os.remove(file)
 
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,40 +4,56 @@ import shutil
 
 import pytest
 
+import audbackend
 import audeer
 import audfactory
 
 
-pytest.ROOT = audeer.safe_path(
-    os.path.join(
-        os.path.dirname(os.path.realpath(__file__)),
-        'tmp',
-    )
-)
+pytest.ROOT = os.path.dirname(os.path.realpath(__file__))
+pytest.ID = audeer.uid()
 
 pytest.ARTIFACTORY_HOST = 'https://audeering.jfrog.io/artifactory'
-pytest.FILE_SYSTEM_HOST = os.path.join(pytest.ROOT, 'repo')
-pytest.ID = audeer.uid()
-pytest.REPOSITORY_NAME = 'unittests-public'
+pytest.ARTIFACTORY_REPOSITORY = f'unittests-public/{pytest.ID}'
+pytest.ARTIFACTORY_BACKEND = audbackend.Artifactory(
+    'https://audeering.jfrog.io/artifactory',
+    f'unittests-public/{pytest.ID}',
+)
+
+pytest.FILE_SYSTEM_HOST = audeer.path(pytest.ROOT, 'host')
+pytest.FILE_SYSTEM_REPOSITORY = os.path.join('unittests-public', pytest.ID)
+pytest.FILE_SYSTEM_BACKEND = audbackend.FileSystem(
+    pytest.FILE_SYSTEM_HOST,
+    os.path.join('unittests-public', pytest.ID)
+)
+
+pytest.BACKENDS = [
+    pytest.FILE_SYSTEM_BACKEND,
+    pytest.ARTIFACTORY_BACKEND,
+]
 
 
 @pytest.fixture(scope='session', autouse=True)
 def cleanup_session():
-    path = os.path.join(
+
+    # clean up old coverage files
+    path = audeer.path(
         pytest.ROOT,
-        '..',
         '.coverage.*',
     )
     for file in glob.glob(path):
         os.remove(file)
+
     yield
-    if os.path.exists(pytest.ROOT):
-        shutil.rmtree(pytest.ROOT)
+
+    # clean up file system
+    if os.path.exists(pytest.FILE_SYSTEM_HOST):
+        shutil.rmtree(pytest.FILE_SYSTEM_HOST)
+
+    # clean up Artifactory
     url = audfactory.path(
         audfactory.url(
             pytest.ARTIFACTORY_HOST,
-            repository=pytest.REPOSITORY_NAME,
-            group_id=pytest.ID,
+            repository=pytest.ARTIFACTORY_REPOSITORY,
         ),
     )
     if url.exists():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,28 +9,21 @@ import audfactory
 
 
 pytest.ROOT = os.path.dirname(os.path.realpath(__file__))
-pytest.ID = audeer.uid()
+uid = audeer.uid()[:8]
 
-# Artifactory
-pytest.ARTIFACTORY_HOST = 'https://audeering.jfrog.io/artifactory'
-pytest.ARTIFACTORY_REPOSITORY = f'unittests-public/{pytest.ID}'
-pytest.ARTIFACTORY_BACKEND = audbackend.Artifactory(
-    pytest.ARTIFACTORY_HOST,
-    pytest.ARTIFACTORY_REPOSITORY,
-)
+pytest.HOSTS = {
+    'artifactory': 'https://audeering.jfrog.io/artifactory',
+    'file-system': os.path.join(pytest.ROOT, 'file-system'),
+}
+pytest.REPOSITORIES = {
+    'artifactory': f'unittests-public/{uid}/',
+    'file-system': uid + os.sep,
+}
 
-# file system
-pytest.FILE_SYSTEM_HOST = audeer.path(pytest.ROOT, 'host')
-pytest.FILE_SYSTEM_REPOSITORY = os.path.join('unittests-public', pytest.ID)
-pytest.FILE_SYSTEM_BACKEND = audbackend.FileSystem(
-    pytest.FILE_SYSTEM_HOST,
-    pytest.FILE_SYSTEM_REPOSITORY,
-)
-
-# list of all backends that will be tested by default
+# list of backends that will be tested
 pytest.BACKENDS = [
-    pytest.FILE_SYSTEM_BACKEND,
-    pytest.ARTIFACTORY_BACKEND,
+    # 'artifactory',
+    'file-system',
 ]
 
 
@@ -48,14 +41,14 @@ def cleanup_session():
     yield
 
     # clean up file system
-    if os.path.exists(pytest.FILE_SYSTEM_HOST):
-        shutil.rmtree(pytest.FILE_SYSTEM_HOST)
+    if os.path.exists(pytest.HOSTS['file-system']):
+        shutil.rmtree(pytest.HOSTS['file-system'])
 
     # clean up Artifactory
     url = audfactory.path(
         audfactory.url(
-            pytest.ARTIFACTORY_HOST,
-            repository=pytest.ARTIFACTORY_REPOSITORY,
+            pytest.HOSTS['artifactory'],
+            repository=pytest.REPOSITORIES['artifactory'],
         ),
     )
     if url.exists():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ pytest.REPOSITORIES = {
 
 # list of backends that will be tested
 pytest.BACKENDS = [
-    # 'artifactory',
+    'artifactory',
     'file-system',
 ]
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -490,8 +490,7 @@ def test_ls(tmpdir, backend):
     # test
 
     for folder, expected, expected_latest in [
-        ('', content, content_latest),
-        ('./', content, content_latest),
+        ('/', content, content_latest),
         ('sub', sub_content, sub_content_latest),
         ('does-not-exist', [], []),
     ]:

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -465,7 +465,7 @@ def test_ls(tmpdir, backend):
     content = [  # three files with different extensions
         (f'{prefix}/file.tar.gz', '1.0.0', ''),
         (f'{prefix}/file.tar.gz', '1.0.0', None),
-        (f'{prefix}/file.tar.gz', '1.0.0', 'tar.gz'),
+        (f'{prefix}/file.tar.gz', '1.0.0', '.tar.gz'),
     ] + sub_content
 
     # create content
@@ -490,7 +490,7 @@ def test_ls(tmpdir, backend):
     ]:
         folder = backend.join(prefix, folder)
         expected = [  # replace ext where it is None
-            (path, version, path.split('.')[-1] if ext is None else ext)
+            (path, version, f".{path.split('.')[-1]}" if ext is None else ext)
             for path, version, ext in expected
         ]
         assert backend.ls(folder) == sorted(expected)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -462,15 +462,15 @@ def test_ls(tmpdir, backend):
     )
 
     sub_content = [  # two versions of same file
-        (f'{prefix}/sub/file.txt', '1.0.0', None),
-        (f'{prefix}/sub/file.txt', '2.0.0', None),
+        (f'{prefix}/sub/file.txt', None, '1.0.0'),
+        (f'{prefix}/sub/file.txt', None, '2.0.0'),
     ]
     sub_content_latest = sub_content[-1:]
 
     content = [  # three files with different extensions
-        (f'{prefix}/file.tar.gz', '1.0.0', ''),
-        (f'{prefix}/file.tar.gz', '1.0.0', None),
-        (f'{prefix}/file.tar.gz', '1.0.0', '.tar.gz'),
+        (f'{prefix}/file.tar.gz', '', '1.0.0'),
+        (f'{prefix}/file.tar.gz', None, '1.0.0'),
+        (f'{prefix}/file.tar.gz', '.tar.gz', '1.0.0'),
     ]
     content_latest = content
 
@@ -480,7 +480,7 @@ def test_ls(tmpdir, backend):
     # create content
 
     tmp_file = os.path.join(tmpdir, '~')
-    for path, version, ext in content:
+    for path, ext, version in content:
         audeer.touch(tmp_file)
         backend.put_file(
             tmp_file,
@@ -498,15 +498,15 @@ def test_ls(tmpdir, backend):
         folder = backend.join(prefix, folder)
 
         expected = [  # replace ext where it is None
-            (p, v, f".{p.split('.')[-1]}" if e is None else e)
-            for p, v, e in expected
+            (p, f".{p.split('.')[-1]}" if e is None else e, v)
+            for p, e, v in expected
         ]
         expected = sorted(expected)
         assert backend.ls(folder) == expected
 
         expected_latest = [  # replace ext where it is None
-            (p, v, f".{p.split('.')[-1]}" if e is None else e)
-            for p, v, e in expected_latest
+            (p, f".{p.split('.')[-1]}" if e is None else e, v)
+            for p, e, v in expected_latest
         ]
         expected_latest = sorted(expected_latest)
         assert backend.ls(folder, latest_version=True) == expected_latest

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -251,6 +251,8 @@ def test_errors(tmpdir, backend):
             remote_file,
             '1.0.0',
         )
+    with pytest.raises(FileNotFoundError):
+        backend.ls(remote_file)
 
 
 @pytest.mark.parametrize(
@@ -492,7 +494,6 @@ def test_ls(tmpdir, backend):
     for folder, expected, expected_latest in [
         ('/', content, content_latest),
         ('sub', sub_content, sub_content_latest),
-        ('does-not-exist', [], []),
     ]:
         folder = backend.join(prefix, folder)
 


### PR DESCRIPTION
Relates to #46 

Closes https://github.com/audeering/audbackend/issues/10 #25  #37 https://github.com/audeering/audbackend/issues/48 #49

![image](https://user-images.githubusercontent.com/10383417/207636875-6ff18f8f-dada-4cfb-a797-e961a7846918.png)

This re-implements `Backend.ls()` by not returning the path on the backend, but a list of virtual paths together with version and extension, so we can close #10 and #25 

In the test we now create three files that have the same virtual path, but we set a different extension. If a backend does not translate it into three different paths, the test will fail, so we can close #49 

We now raise a `FileNotFoundError` error  folder does not exist, so we can close #37 