### PR TITLE
Add available() to list available backends

### DIFF
--- a/audbackend/__init__.py
+++ b/audbackend/__init__.py
@@ -1,4 +1,5 @@
 from audbackend.core.api import (
+    available,
     create,
     register,
 )

--- a/audbackend/core/api.py
+++ b/audbackend/core/api.py
@@ -18,8 +18,14 @@ r"""Backend registry."""
 def available() -> typing.Dict[str, typing.List[Backend]]:
     r"""List available backends.
 
+    Returns a dictionary with
+    registered backend names as keys
+    (see :func:`audbackend.register`)
+    and a list with backend instances as values
+    (see :func:`audbackend.create`).
+
     Returns:
-        sorted dictionary with backends
+        dictionary with backends
 
     Examples:
         >>> list(available())

--- a/audbackend/core/api.py
+++ b/audbackend/core/api.py
@@ -31,9 +31,9 @@ def available() -> typing.Dict[str, typing.List[Backend]]:
         >>> list(available())
         ['artifactory', 'file-system']
         >>> available()['artifactory']
-        [('Artifactory', 'https://audeering.jfrog.io/artifactory', 'repo')]
+        [('audbackend.core.artifactory.Artifactory', 'https://host.com', 'repo')]
 
-    """
+    """  # noqa: E501
     result = {}
 
     for name in sorted(backend_registry):
@@ -67,10 +67,10 @@ def create(
     Example:
         >>> create(
         ...     'artifactory',
-        ...     'https://audeering.jfrog.io/artifactory',
+        ...     'https://host.com',
         ...     'repo',
         ... )
-        ('Artifactory', 'https://audeering.jfrog.io/artifactory', 'repo')
+        ('audbackend.core.artifactory.Artifactory', 'https://host.com', 'repo')
 
     """
     if name not in backend_registry:

--- a/audbackend/core/api.py
+++ b/audbackend/core/api.py
@@ -15,7 +15,7 @@ backend_registry = {
 r"""Backend registry."""
 
 
-def available() -> typing.Dict[str, typing.List[typing.Tuple[str, str]]]:
+def available() -> typing.Dict[str, typing.List[Backend]]:
     r"""List available backends.
 
     Returns:

--- a/audbackend/core/api.py
+++ b/audbackend/core/api.py
@@ -22,12 +22,6 @@ def available() -> typing.Dict[str, typing.List[Backend]]:
         sorted dictionary with backends
 
     Examples:
-        >>> create(
-        ...     'artifactory',
-        ...     'https://audeering.jfrog.io/artifactory',
-        ...     'repo',
-        ... )
-        ('Artifactory', 'https://audeering.jfrog.io/artifactory', 'repo')
         >>> list(available())
         ['artifactory', 'file-system']
         >>> available()['artifactory']

--- a/audbackend/core/api.py
+++ b/audbackend/core/api.py
@@ -15,6 +15,37 @@ backend_registry = {
 r"""Backend registry."""
 
 
+def available() -> typing.Dict[str, typing.List[typing.Tuple[str, str]]]:
+    r"""List available backends.
+
+    Returns:
+        sorted dictionary with backends
+
+    Examples:
+        >>> create(
+        ...     'artifactory',
+        ...     'https://audeering.jfrog.io/artifactory',
+        ...     'repo',
+        ... )
+        ('Artifactory', 'https://audeering.jfrog.io/artifactory', 'repo')
+        >>> list(available())
+        ['artifactory', 'file-system']
+        >>> available()['artifactory']
+        [('Artifactory', 'https://audeering.jfrog.io/artifactory', 'repo')]
+
+    """
+    result = {}
+
+    for name in sorted(backend_registry):
+        result[name] = []
+        if name in backends:
+            for repository in backends[name].values():
+                for backend in repository.values():
+                    result[name].append(backend)
+
+    return result
+
+
 def create(
         name: str,
         host: str,
@@ -34,9 +65,12 @@ def create(
         ValueError: if registry name does not exist
 
     Example:
-        >>> backend = create('file-system', tmp, 'doctest')
-        >>> backend.repository
-        'doctest'
+        >>> create(
+        ...     'artifactory',
+        ...     'https://audeering.jfrog.io/artifactory',
+        ...     'repo',
+        ... )
+        ('Artifactory', 'https://audeering.jfrog.io/artifactory', 'repo')
 
     """
     if name not in backend_registry:

--- a/audbackend/core/api.py
+++ b/audbackend/core/api.py
@@ -27,7 +27,7 @@ def available() -> typing.Dict[str, typing.List[Backend]]:
     Returns:
         dictionary with backends
 
-    Examples:
+    Example:
         >>> list(available())
         ['artifactory', 'file-system']
         >>> available()['artifactory']

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -27,6 +27,9 @@ class Backend:
         self.repository = repository
         r"""Repository name."""
 
+    def __repr__(self) -> str:
+        return str((self.__class__.__name__, self.host, self.repository))
+
     def _checksum(
             self,
             path: str,

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -28,7 +28,8 @@ class Backend:
         r"""Repository name."""
 
     def __repr__(self) -> str:
-        return str((self.__class__.__name__, self.host, self.repository))
+        name = f'{self.__class__.__module__}.{self.__class__.__name__}'
+        return str((name, self.host, self.repository))
 
     def _checksum(
             self,

--- a/audbackend/core/conftest.py
+++ b/audbackend/core/conftest.py
@@ -10,7 +10,7 @@ def create_backend(doctest_namespace):
     with tempfile.TemporaryDirectory() as tmp:
         audbackend.create(
             'artifactory',
-            'https://audeering.jfrog.io/artifactory',
+            'https://host.com',
             'repo',
         )
         backend = audbackend.create(

--- a/audbackend/core/conftest.py
+++ b/audbackend/core/conftest.py
@@ -8,6 +8,11 @@ import audeer
 @pytest.fixture(autouse=True)
 def create_backend(doctest_namespace):
     with tempfile.TemporaryDirectory() as tmp:
+        audbackend.create(
+            'artifactory',
+            'https://audeering.jfrog.io/artifactory',
+            'repo',
+        )
         backend = audbackend.create(
             'file-system',
             tmp,

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -30,6 +30,11 @@ Backend
 .. autoclass:: Backend
     :members:
 
+available
+---------
+
+.. autofunction:: available
+
 create
 ------
 


### PR DESCRIPTION
Closes #55 

![image](https://user-images.githubusercontent.com/10383417/207285322-ce582bc1-f3d7-41d6-87cc-9590ded8bdbb.png)

Note that `Backend.__repr__()` is now implemented to have a nicer representation of the backend objects. The docstring example of `Backend.create()` has been improved accordingly.