### PR TITLE
Fix: support artifactory.exception.ArtifactoryException

### DIFF
--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -130,17 +130,23 @@ class Artifactory(Backend):
         group_id = audfactory.path_to_group_id(folder)
         return audfactory.versions(self.host, self.repository, group_id, name)
 
-    _non_existing_path_error = (RuntimeError, requests.exceptions.HTTPError)
+    _non_existing_path_error = (
+            RuntimeError,
+            requests.exceptions.HTTPError,
+            artifactory.exception.ArtifactoryException,
+    )
     r"""Error expected for non-existing paths.
 
     If a user has no permission to a given path
-    or the path does not exists :func:`audfactory.path`
-    might return a
+    or the path does not exists
+    :func:`audfactory.path` might return a
     ``RuntimeError: 404 page not found``
     or
     ``requests.exceptions.HTTPError: 403 Client Error``
+    or
+    ``artifactory.exception.ArtifactoryException``
     error,
-    which might depend on the instaleld ``dohq-artifactory``
-    version. So we better catch both of them.
+    which depend on the instaleld ``dohq-artifactory`` version.
+    So we better catch all of them.
 
     """

--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -59,8 +59,10 @@ class Artifactory(Backend):
             # RuntimeError: 404 page not found
             # or
             # requests.exceptions.HTTPError: 403 Client Error
+            # or
+            # dohq_artifactory.exception.ArtifactoryException
             return audfactory.path(path).exists()
-        except self._non_existing_path_error:  # pragma: nocover
+        except self._non_existing_path_error:
             return False
 
     def _get_file(
@@ -90,7 +92,7 @@ class Artifactory(Backend):
         path = audfactory.path(url)
         try:
             result = [str(x) for x in path.glob(pattern)]
-        except self._non_existing_path_error:  # pragma: nocover
+        except self._non_existing_path_error:
             result = []
         return result
 

--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -1,3 +1,4 @@
+import dohq_artifactory
 import requests
 import typing
 
@@ -133,7 +134,7 @@ class Artifactory(Backend):
     _non_existing_path_error = (
             RuntimeError,
             requests.exceptions.HTTPError,
-            artifactory.exception.ArtifactoryException,
+            dohq_artifactory.exception.ArtifactoryException,
     )
     r"""Error expected for non-existing paths.
 

--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -55,12 +55,6 @@ class Artifactory(Backend):
     ) -> bool:
         r"""Check if file exists on backend."""
         try:
-            # Can lead to
-            # RuntimeError: 404 page not found
-            # or
-            # requests.exceptions.HTTPError: 403 Client Error
-            # or
-            # dohq_artifactory.exception.ArtifactoryException
             return audfactory.path(path).exists()
         except self._non_existing_path_error:
             return False
@@ -143,13 +137,12 @@ class Artifactory(Backend):
     If a user has no permission to a given path
     or the path does not exists
     :func:`audfactory.path` might return a
-    ``RuntimeError: 404 page not found``
-    or
-    ``requests.exceptions.HTTPError: 403 Client Error``
+    ``RuntimeError``,
+    ``requests.exceptions.HTTPError``
+    for ``dohq_artifactory<0.8``
     or
     ``artifactory.exception.ArtifactoryException``
-    error,
-    which depend on the instaleld ``dohq-artifactory`` version.
+    for ``dohq_artifactory>=0.8``.
     So we better catch all of them.
 
     """

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ classifiers =
 packages = find:
 install_requires =
     audeer >=1.17.1
-    audfactory >=1.0.10
+    audfactory >=1.0.12
 setup_requires =
     setuptools_scm
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,8 +46,16 @@ def cleanup_session():
 
 @pytest.fixture(scope='function', autouse=False)
 def no_artifactory_access_rights():
-    os.environ["ARTIFACTORY_USERNAME"] = "non-existing-user"
-    os.environ["ARTIFACTORY_API_KEY"] = "non-existing-password"
+    current_username = os.environ.get('ARTIFACTORY_USERNAME', False)
+    current_api_key = os.environ.get('ARTIFACTORY_API_KEY', False)
+    os.environ['ARTIFACTORY_USERNAME'] = 'non-existing-user'
+    os.environ['ARTIFACTORY_API_KEY'] = 'non-existing-password'
     yield
-    del os.environ["ARTIFACTORY_USERNAME"]
-    del os.environ["ARTIFACTORY_API_KEY"]
+    if current_username:
+        os.environ["ARTIFACTORY_USERNAME"] = current_username
+    else:
+        del os.environ['ARTIFACTORY_USERNAME']
+    if current_api_key:
+        os.environ['ARTIFACTORY_API_KEY'] = current_api_key
+    else:
+        del os.environ['ARTIFACTORY_API_KEY']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,3 +42,12 @@ def cleanup_session():
     )
     if url.exists():
         url.unlink()
+
+
+@pytest.fixture(scope='function', autouse=False)
+def no_artifactory_access_rights():
+    os.environ["ARTIFACTORY_USERNAME"] = "non-existing-user"
+    os.environ["ARTIFACTORY_API_KEY"] = "non-existing-password"
+    yield
+    del os.environ["ARTIFACTORY_USERNAME"]
+    del os.environ["ARTIFACTORY_API_KEY"]

--- a/tests/test_artifactory.py
+++ b/tests/test_artifactory.py
@@ -1,0 +1,22 @@
+import pytest
+
+import audbackend
+
+
+BACKEND = audbackend.Artifactory(
+    pytest.ARTIFACTORY_HOST,
+    pytest.REPOSITORY_NAME,
+)
+
+
+def test_exists(no_artifactory_access_rights):
+    remote_file = BACKEND.join(
+        pytest.ID,
+        'file.txt',
+    )
+    version = '1.0.0'
+    assert not BACKEND.exists(remote_file, version)
+
+
+def test_glob(no_artifactory_access_rights):
+    assert BACKEND.glob('file*') == []


### PR DESCRIPTION
Closes #72 

`dohq-artifactory` changed the returned error for a non-existing path/HTTP request error to `artifactory.exception.ArtifactoryException`, whcih means we need to update `audbackend.core.artifactory._non_existing_path_error` to catch that error as well.

I added two tests for it by providing wrong Artifactory credentials, which both fail with
```
dohq_artifactory.exception.ArtifactoryException
```
if the proposed changes to the code are not included.