### PR TITLE
DOC: fix return type of Backend.ls()

### DIFF
--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -320,7 +320,7 @@ class Backend:
             folder: str = '/',
             *,
             latest_version: bool = False,
-    ) -> typing.List[typing.Tuple[str, str, str]]:
+    ) -> typing.List[typing.Tuple[str, str]]:
         r"""List all files under folder.
 
         Returns a sorted list of tuples


### PR DESCRIPTION
Something we overlooked in https://github.com/audeering/audbackend/pull/62:

The return type of `audbackend.Backend.ls()` needs to be updated as it no longer returns the file extension, but only name and version.

![image](https://user-images.githubusercontent.com/173624/231669944-b52a83fd-9633-46a8-8e64-8ffa3adb0109.png)
