### PR TITLE
Force archive extension and add support for TAR.GZ

### DIFF
--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -403,8 +403,7 @@ class Backend:
                 Only folders and files below ``src_root``
                 will be included into the archive
             files: relative path to file(s) from ``src_root``
-            dst_path: path to archive on backend,
-                e.g. ``sub/archive.zip``
+            dst_path: path to archive on backend
             version: version string
             tmp_root: directory under which archive is temporarily created.
                 Defaults to temporary directory of system

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -114,7 +114,7 @@ class Backend:
         r"""Get archive from backend and extract.
 
         The archive type is derived from the extension of ``src_path``.
-        See :func:`audeer.create_archive` for supported extensions.
+        See :func:`audeer.extract_archive` for supported extensions.
 
         Args:
             src_path: path to archive on backend
@@ -132,6 +132,7 @@ class Backend:
             FileNotFoundError: if ``tmp_root`` does not exist
             ValueError: if ``src_path`` contains invalid character
             RuntimeError: if extension of ``src_path`` is not supported
+            RuntimeError: if ``src_path`` is a malformed archive
 
         Examples:
             >>> dst_root = audeer.path(tmp, 'dst')

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -111,11 +111,11 @@ class Backend:
             tmp_root: str = None,
             verbose: bool = False,
     ) -> typing.List[str]:
-        r"""Get archive from backend and extract.
+        r"""Get ZIP archive from backend and extract.
 
         Args:
-            src_path: path to archive on backend,
-                e.g. ``media/archive1.zip``.
+            src_path: path to ZIP archive on backend,
+                e.g. ``sub/archive.zip``.
                 If path does not end on ``.zip``
                 it is automatically extended to ``<src_path>.zip``
             dst_root: local destination directory
@@ -390,7 +390,7 @@ class Backend:
             tmp_root: str = None,
             verbose: bool = False,
     ):
-        r"""Create archive and put on backend.
+        r"""Create ZIP archive and put on backend.
 
         The operation is silently skipped,
         if an archive with the same checksum
@@ -401,8 +401,8 @@ class Backend:
                 Only folders and files below ``src_root``
                 will be included into the archive
             files: relative path to file(s) from ``src_root``
-            dst_path: path to archive on backend,
-                e.g. ``media/archive1.zip``.
+            dst_path: path to ZIP archive on backend,
+                e.g. ``sub/archive.zip``.
                 If path does not end on ``.zip``
                 it is automatically extended to ``<dst_path>.zip``
             version: version string

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -114,8 +114,10 @@ class Backend:
         r"""Get archive from backend and extract.
 
         Args:
-            src_path: path to archive on backend without extension,
-                e.g. ``media/archive1``
+            src_path: path to archive on backend,
+                e.g. ``media/archive1.zip``.
+                If path does not end on ``.zip``
+                it is automatically extended to ``<src_path>.zip``
             dst_root: local destination directory
             version: version string
             tmp_root: directory under which archive is temporarily extracted.
@@ -132,11 +134,12 @@ class Backend:
 
         Examples:
             >>> dst_root = audeer.path(tmp, 'dst')
-            >>> backend.get_archive('folder/name', dst_root, '1.0.0')
+            >>> backend.get_archive('folder/name.zip', dst_root, '1.0.0')
             ['src.pth']
 
         """
-        src_path += '.zip'
+        if not src_path.endswith('.zip'):
+            src_path += '.zip'
         utils.check_path_for_allowed_chars(src_path)
 
         with tempfile.TemporaryDirectory(dir=tmp_root) as tmp:
@@ -398,8 +401,10 @@ class Backend:
                 Only folders and files below ``src_root``
                 will be included into the archive
             files: relative path to file(s) from ``src_root``
-            dst_path: path to archive on backend without extension,
-                e.g. ``media/archive1``
+            dst_path: path to archive on backend,
+                e.g. ``media/archive1.zip``.
+                If path does not end on ``.zip``
+                it is automatically extended to ``<dst_path>.zip``
             version: version string
             tmp_root: directory under which archive is temporarily created.
                 Defaults to temporary directory of system
@@ -414,12 +419,13 @@ class Backend:
             >>> backend.exists('folder/name.zip', '2.0.0')
             False
             >>> files = ['src.pth']
-            >>> backend.put_archive(tmp, files, 'folder/name', '2.0.0')
+            >>> backend.put_archive(tmp, files, 'folder/name.zip', '2.0.0')
             >>> backend.exists('folder/name.zip', '2.0.0')
             True
 
         """
-        dst_path += '.zip'
+        if not dst_path.endswith('.zip'):
+            dst_path += '.zip'
         utils.check_path_for_allowed_chars(dst_path)
         src_root = audeer.safe_path(src_root)
 

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -111,13 +111,13 @@ class Backend:
             tmp_root: str = None,
             verbose: bool = False,
     ) -> typing.List[str]:
-        r"""Get ZIP archive from backend and extract.
+        r"""Get archive from backend and extract.
+
+        The archive type is derived from the extension of ``src_path``.
+        See :func:`audeer.create_archive` for supported extensions.
 
         Args:
-            src_path: path to ZIP archive on backend,
-                e.g. ``sub/archive.zip``.
-                If path does not end on ``.zip``
-                it is automatically extended to ``<src_path>.zip``
+            src_path: path to archive on backend
             dst_root: local destination directory
             version: version string
             tmp_root: directory under which archive is temporarily extracted.
@@ -131,6 +131,7 @@ class Backend:
             FileNotFoundError: if archive does not exist on backend
             FileNotFoundError: if ``tmp_root`` does not exist
             ValueError: if ``src_path`` contains invalid character
+            RuntimeError: if extension of ``src_path`` is not supported
 
         Examples:
             >>> dst_root = audeer.path(tmp, 'dst')
@@ -138,8 +139,6 @@ class Backend:
             ['src.pth']
 
         """
-        if not src_path.endswith('.zip'):
-            src_path += '.zip'
         utils.check_path_for_allowed_chars(src_path)
 
         with tempfile.TemporaryDirectory(dir=tmp_root) as tmp:
@@ -390,7 +389,10 @@ class Backend:
             tmp_root: str = None,
             verbose: bool = False,
     ):
-        r"""Create ZIP archive and put on backend.
+        r"""Create archive and put on backend.
+
+        The archive type is derived from the extension of ``dst_path``.
+        See :func:`audeer.create_archive` for supported extensions.
 
         The operation is silently skipped,
         if an archive with the same checksum
@@ -401,10 +403,8 @@ class Backend:
                 Only folders and files below ``src_root``
                 will be included into the archive
             files: relative path to file(s) from ``src_root``
-            dst_path: path to ZIP archive on backend,
-                e.g. ``sub/archive.zip``.
-                If path does not end on ``.zip``
-                it is automatically extended to ``<dst_path>.zip``
+            dst_path: path to archive on backend,
+                e.g. ``sub/archive.zip``
             version: version string
             tmp_root: directory under which archive is temporarily created.
                 Defaults to temporary directory of system
@@ -414,6 +414,7 @@ class Backend:
             FileNotFoundError: if one or more files do not exist
             FileNotFoundError: if ``tmp_root`` does not exist
             ValueError: if ``dst_path`` contains invalid character
+            RuntimeError: if extension of ``dst_path`` is not supported
 
         Examples:
             >>> backend.exists('folder/name.zip', '2.0.0')
@@ -424,8 +425,6 @@ class Backend:
             True
 
         """
-        if not dst_path.endswith('.zip'):
-            dst_path += '.zip'
         utils.check_path_for_allowed_chars(dst_path)
         src_root = audeer.safe_path(src_root)
 

--- a/audbackend/core/conftest.py
+++ b/audbackend/core/conftest.py
@@ -20,7 +20,7 @@ def create_backend(doctest_namespace):
         )
         src_file = 'src.pth'
         src_path = audeer.touch(audeer.path(tmp, src_file))
-        backend.put_archive(tmp, [src_file], 'folder/name', '1.0.0')
+        backend.put_archive(tmp, [src_file], 'folder/name.zip', '1.0.0')
         for version in ['1.0.0', '2.0.0']:
             backend.put_file(src_path, 'folder/name.ext', version)
         doctest_namespace['backend'] = backend

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -22,31 +22,24 @@ def backend(request):
     [
         (
             [],
-            'empty',
+            'empty.zip',
             None,
             '1.0.0',
             None,
         ),
         (
             'file.ext',
-            'not-empty',
+            'not-empty.zip',
             None,
             '1.0.0',
             None,
         ),
         (
             ['file.ext', 'dir/to/file.ext'],
-            'not-empty',
+            'not-empty.zip',
             'group',
             '1.0.0',
             None,
-        ),
-        (
-            ['file.ext', 'dir/to/file.ext'],
-            'not-empty',
-            'group',
-            '2.0.0',
-            'tmp',
         ),
         (
             ['file.ext', 'dir/to/file.ext'],
@@ -55,6 +48,22 @@ def backend(request):
             '2.0.0',
             'tmp',
         ),
+        (
+            ['file.ext', 'dir/to/file.ext'],
+            'not-empty.tar.gz',
+            'group',
+            '2.0.0',
+            'tmp',
+        ),
+        # extension not supported
+        pytest.param(
+            ['file.ext', 'dir/to/file.ext'],
+            'not-supported.bad',
+            'group',
+            '2.0.0',
+            'tmp',
+            marks=pytest.mark.xfail(raises=RuntimeError),
+        )
     ],
 )
 @pytest.mark.parametrize(
@@ -106,10 +115,7 @@ def test_archive(tmpdir, files, name, folder, version, tmp_root, backend):
         version,
         tmp_root=tmp_root,
     )
-    if archive.endswith('.zip'):
-        assert backend.exists(archive, version)
-    else:
-        assert backend.exists(archive + '.zip', version)
+    assert backend.exists(archive, version)
 
     # if a tmp_root is given but does not exist,
     # get_archive() should fail
@@ -147,7 +153,7 @@ def test_archive(tmpdir, files, name, folder, version, tmp_root, backend):
         pytest.param(  # backend does not exist
             'does-not-exist',
             None,
-            marks=pytest.mark.xfail(raises=ValueError)
+            marks=pytest.mark.xfail(raises=ValueError),
         )
     ]
 )

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -48,6 +48,13 @@ def backend(request):
             '2.0.0',
             'tmp',
         ),
+        (
+            ['file.ext', 'dir/to/file.ext'],
+            'not-empty.zip',
+            'group',
+            '2.0.0',
+            'tmp',
+        ),
     ],
 )
 @pytest.mark.parametrize(
@@ -99,7 +106,10 @@ def test_archive(tmpdir, files, name, folder, version, tmp_root, backend):
         version,
         tmp_root=tmp_root,
     )
-    assert backend.exists(archive + '.zip', version)
+    if archive.endswith('.zip'):
+        assert backend.exists(archive, version)
+    else:
+        assert backend.exists(archive + '.zip', version)
 
     # if a tmp_root is given but does not exist,
     # get_archive() should fail

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -230,8 +230,8 @@ def test_errors(tmpdir, backend):
             '1.0.0',
         )
 
-    error_msg = rf"Invalid path name 'missing.txt\?', " \
-                rf"allowed characters are '\[A-Za-z0-9/\._-\]\+'"
+    error_msg = r"Invalid path name 'missing.txt\?', " \
+                r"allowed characters are '\[A-Za-z0-9/\._-\]\+'"
     with pytest.raises(ValueError, match=error_msg):
         backend.put_file(
             'missing.txt',


### PR DESCRIPTION
Closes #78 

The methods `Backend.put_archive()` and `Backend.get_archive()` do no longer extend the archive name with `.zip`. Instead the user has to provide the extension. In addition to ZIP, also TAR.GZ is now supported.

![image](https://user-images.githubusercontent.com/10383417/231715222-9009f68f-289b-42ca-9e88-7070266514b7.png)

![image](https://user-images.githubusercontent.com/10383417/231701397-5770caf3-cdd3-4bca-9125-c5b7ab5a25a0.png)
