### PR TITLE
TST: test for all Backend errors

### DIFF
--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -130,9 +130,11 @@ class Backend:
         Raises:
             FileNotFoundError: if archive does not exist on backend
             FileNotFoundError: if ``tmp_root`` does not exist
-            ValueError: if ``src_path`` contains invalid character
+            PermissionError: if the user lacks write permissions
+                for ``dst_path``
             RuntimeError: if extension of ``src_path`` is not supported
             RuntimeError: if ``src_path`` is a malformed archive
+            ValueError: if ``src_path`` contains invalid character
 
         Examples:
             >>> dst_root = audeer.path(tmp, 'dst')
@@ -192,7 +194,9 @@ class Backend:
             full path to local file
 
         Raises:
-            FileNotFoundError: if file does not exist on backend
+            FileNotFoundError: if ``src_path`` does not exist on backend
+            PermissionError: if the user lacks write permissions
+                for ``dst_path``
             ValueError: if ``src_path`` contains invalid character
 
         Examples:
@@ -259,7 +263,7 @@ class Backend:
             version string
 
         Raises:
-            RuntimeError: if file does not exist on backend
+            RuntimeError: if ``path`` does not exist on backend
             ValueError: if ``path`` contains invalid character
 
         Examples:
@@ -459,7 +463,7 @@ class Backend:
             file path on backend
 
         Raises:
-            FileNotFoundError: if local file does not exist
+            FileNotFoundError: if ``src_path`` does not exist
             ValueError: if ``dst_path`` contains invalid character
 
         Examples:
@@ -502,7 +506,7 @@ class Backend:
             version: version string
 
         Raises:
-            FileNotFoundError: if file does not exist on backend
+            FileNotFoundError: if ``path`` does not exist on backend
             ValueError: if ``path`` contains invalid character
 
         Examples:

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -307,10 +307,7 @@ def test_errors(tmpdir, backend):
             version,
         )
     # `files` missing
-    error_msg = re.escape(
-        "No such file or directory: "
-        f"'{audeer.path(tmpdir, file_missing)}'"
-    )
+    error_msg = 'No such file or directory: ...'
     with pytest.raises(FileNotFoundError, match=error_msg):
         backend.put_archive(tmpdir, file_missing, archive, version)
     # `dst_path` contains invalid character
@@ -323,10 +320,7 @@ def test_errors(tmpdir, backend):
 
     # --- put_file ---
     # `src_path` does not exists
-    error_msg = re.escape(
-        "No such file or directory: "
-        f"'{audeer.path(tmpdir, file_missing)}'"
-    )
+    error_msg = 'No such file or directory: ...'
     with pytest.raises(FileNotFoundError, match=error_msg):
         backend.put_file(audeer.path(tmpdir, file_missing), file, version)
     # `dst_path` contains invalid character

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -278,7 +278,7 @@ def test_errors(tmpdir, backend):
 
     # --- latest_version ---
     # `path` missing
-    error_msg = (
+    error_msg = re.escape(
         f"Cannot find a version for '{file_missing}' "
         f"in '{backend.repository}'"
     )
@@ -298,7 +298,7 @@ def test_errors(tmpdir, backend):
 
     # --- put_archive ---
     # `src_root` missing
-    error_msg = (
+    error_msg = re.escape(
         "No such file or directory: "
         f"'{audeer.path(tmpdir, folder_missing, file)}'"
     )
@@ -310,7 +310,7 @@ def test_errors(tmpdir, backend):
             version,
         )
     # `files` missing
-    error_msg = (
+    error_msg = re.escape(
         "No such file or directory: "
         f"'{audeer.path(tmpdir, file_missing)}'"
     )
@@ -326,7 +326,7 @@ def test_errors(tmpdir, backend):
 
     # --- put_file ---
     # `src_path` does not exists
-    error_msg = (
+    error_msg = re.escape(
         "No such file or directory: "
         f"'{audeer.path(tmpdir, file_missing)}'"
     )

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -298,7 +298,7 @@ def test_errors(tmpdir, backend):
 
     # --- put_archive ---
     # `src_root` missing
-    error_msg = re.escape(
+    error_msg = (
         "No such file or directory: "
         f"'{audeer.path(tmpdir, folder_missing, file)}'"
     )

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -174,7 +174,7 @@ def test_errors(tmpdir, backend):
     # Create local read-only folder
     folder_read_only = audeer.mkdir(audeer.path(tmpdir, 'read-only-folder'))
     if platform.system() == 'Windows':
-        os.system(f'attrib +r {folder_read_only}')
+        os.system(f'attrib -w {folder_read_only}')
     else:
         os.chmod(folder_read_only, stat.S_IRUSR)
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -173,10 +173,7 @@ def test_errors(tmpdir, backend):
 
     # Create local read-only folder
     folder_read_only = audeer.mkdir(audeer.path(tmpdir, 'read-only-folder'))
-    if platform.system() == 'Windows':
-        os.system(f'attrib -w {folder_read_only}')
-    else:
-        os.chmod(folder_read_only, stat.S_IRUSR)
+    os.chmod(folder_read_only, stat.S_IRUSR)
 
     # File names and error messages
     # for common errors
@@ -246,10 +243,10 @@ def test_errors(tmpdir, backend):
     with pytest.raises(RuntimeError, match=error_msg):
         backend.get_archive('malformed.zip', tmpdir, version)
     # no write permissions to `dst_path`
-    # if not platform.system() == 'Windows':
-    # Currently we don't know how to provoke permission error on Windows
-    with pytest.raises(PermissionError, match=error_read_only):
-        backend.get_archive(archive, folder_read_only, version)
+    if not platform.system() == 'Windows':
+        # Currently we don't know how to provoke permission error on Windows
+        with pytest.raises(PermissionError, match=error_read_only):
+            backend.get_archive(archive, folder_read_only, version)
 
     # --- get_file ---
     # `src_path` missing

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import re
 import stat
 
@@ -215,7 +216,12 @@ def test_errors(tmpdir, backend):
     with pytest.raises(ValueError, match=error_invalid_char):
         backend.get_archive(file_invalid_char, tmpdir, version)
     # `tmp_root` does not exist
-    error_msg = "No such file or directory: 'non-existing/..."
+    if platform.system() == 'Windows':
+        error_msg = (
+            "The system cannot find the path specified: 'non-existing..."
+        )
+    else:
+        error_msg = "No such file or directory: 'non-existing/..."
     with pytest.raises(FileNotFoundError, match=error_msg):
         backend.get_archive(archive, tmpdir, version, tmp_root='non-existing')
     # extension of `src_path` is not supported

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -302,6 +302,8 @@ def test_errors(tmpdir, backend):
         "No such file or directory: "
         f"'{audeer.path(tmpdir, folder_missing, file)}'"
     )
+    if platform.system() == 'Windows':
+        error_msg = re.escape('[Errno 2] ' + error_msg)
     with pytest.raises(FileNotFoundError, match=error_msg):
         backend.put_archive(
             audeer.path(tmpdir, folder_missing),

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -298,12 +298,7 @@ def test_errors(tmpdir, backend):
 
     # --- put_archive ---
     # `src_root` missing
-    error_msg = (
-        "No such file or directory: "
-        f"'{audeer.path(tmpdir, folder_missing, file)}'"
-    )
-    if platform.system() == 'Windows':
-        error_msg = re.escape('[Errno 2] ' + error_msg)
+    error_msg = 'No such file or directory: ...'
     with pytest.raises(FileNotFoundError, match=error_msg):
         backend.put_archive(
             audeer.path(tmpdir, folder_missing),

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -173,7 +173,10 @@ def test_errors(tmpdir, backend):
 
     # Create local read-only folder
     folder_read_only = audeer.mkdir(audeer.path(tmpdir, 'read-only-folder'))
-    os.chmod(folder_read_only, stat.S_IRUSR)
+    if platform.system() == 'Windows':
+        os.system(f'attrib +r {folder_read_only}')
+    else:
+        os.chmod(folder_read_only, stat.S_IRUSR)
 
     # File names and error messages
     # for common errors
@@ -243,10 +246,10 @@ def test_errors(tmpdir, backend):
     with pytest.raises(RuntimeError, match=error_msg):
         backend.get_archive('malformed.zip', tmpdir, version)
     # no write permissions to `dst_path`
-    if not platform.system() == 'Windows':
-        # Currently we don't know how to provoke permission error on Windows
-        with pytest.raises(PermissionError, match=error_read_only):
-            backend.get_archive(archive, folder_read_only, version)
+    # if not platform.system() == 'Windows':
+    # Currently we don't know how to provoke permission error on Windows
+    with pytest.raises(PermissionError, match=error_read_only):
+        backend.get_archive(archive, folder_read_only, version)
 
     # --- get_file ---
     # `src_path` missing

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -256,8 +256,10 @@ def test_errors(tmpdir, backend):
     with pytest.raises(ValueError, match=error_invalid_char):
         backend.get_file(file_invalid_char, tmpdir, version)
     # no write permissions to `dst_path`
-    with pytest.raises(PermissionError, match=error_read_only):
-        backend.get_file(file, folder_read_only, version)
+    if not platform.system() == 'Windows':
+        # Currently we don't know how to provoke permission error on Windows
+        with pytest.raises(PermissionError, match=error_read_only):
+            backend.get_file(file, folder_read_only, version)
 
     # --- join ---
     # joined path contains invalid char

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -243,8 +243,10 @@ def test_errors(tmpdir, backend):
     with pytest.raises(RuntimeError, match=error_msg):
         backend.get_archive('malformed.zip', tmpdir, version)
     # no write permissions to `dst_path`
-    with pytest.raises(PermissionError, match=error_read_only):
-        backend.get_archive(archive, folder_read_only, version)
+    if not platform.system() == 'Windows':
+        # Currently we don't know how to provoke permission error on Windows
+        with pytest.raises(PermissionError, match=error_read_only):
+            backend.get_archive(archive, folder_read_only, version)
 
     # --- get_file ---
     # `src_path` missing


### PR DESCRIPTION
This documents `PermissionError` for `Backend.get_archive()` and `Backend.get_file()` if the user has no local write permissions.

In addition, it adds tests for all errors we currently have documented in `audbackend.Backend` methods,
and fixes a few typos in the docstrings.