### PR TITLE
Raise generic backend error

### DIFF
--- a/audbackend/__init__.py
+++ b/audbackend/__init__.py
@@ -5,6 +5,7 @@ from audbackend.core.api import (
 )
 from audbackend.core.artifactory import Artifactory
 from audbackend.core.backend import Backend
+from audbackend.core.errors import BackendError
 from audbackend.core.filesystem import FileSystem
 from audbackend.core.repository import Repository
 from audbackend.core.utils import md5

--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -6,6 +6,7 @@ import typing
 
 import audfactory
 
+from audbackend.core import utils
 from audbackend.core.backend import Backend
 
 
@@ -88,12 +89,12 @@ class Artifactory(Backend):
 
         """
         folder = self._folder(folder)
-
         folder = audfactory.path(folder)
-        try:
-            paths = [str(x) for x in folder.glob("**/*") if x.is_file()]
-        except self._non_existing_path_error:  # pragma: nocover
-            paths = []
+
+        if not folder.exists():
+            utils.raise_file_not_found_error(str(folder))
+
+        paths = [str(x) for x in folder.glob("**/*") if x.is_file()]
 
         # <host>/<repository>/<folder>/<name>
         # ->

--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -83,11 +83,8 @@ class Artifactory(Backend):
             self,
             folder: str,
     ):
-        r"""List all files under folder.
+        r"""List all files under folder."""
 
-        Return an empty list if no files match or folder does not exist.
-
-        """
         folder = self._folder(folder)
         folder = audfactory.path(folder)
 

--- a/audbackend/core/errors.py
+++ b/audbackend/core/errors.py
@@ -1,0 +1,18 @@
+class BackendError(Exception):
+    r"""Wrapper for any error raised on the backend.
+
+    Args:
+        exception: exception raised by backend
+
+    """
+    def __init__(
+            self,
+            exception: Exception,
+    ):
+        self.exception = exception
+        r"""Exception raised by backend."""
+
+        super().__init__(
+            'An exception was raised by the backend, '
+            'please see stack trace for further information.'
+        )

--- a/audbackend/core/filesystem.py
+++ b/audbackend/core/filesystem.py
@@ -75,12 +75,13 @@ class FileSystem(Backend):
             self,
             folder: str,
     ):
-        r"""List all files under folder.
+        r"""List all files under folder."""
 
-        Return an empty list if no files match or folder does not exist.
-
-        """
         folder = self._folder(folder)
+
+        if not os.path.exists(folder):
+            utils.raise_file_not_found_error(folder)
+
         paths = audeer.list_file_names(folder, recursive=True)
 
         # <host>/<repository>/<folder>/<version>/<name>

--- a/audbackend/core/utils.py
+++ b/audbackend/core/utils.py
@@ -6,9 +6,22 @@ import typing
 
 import audeer
 
+from audbackend.core.errors import BackendError
+
 
 BACKEND_ALLOWED_CHARS = '[A-Za-z0-9/._-]+'
 BACKEND_ALLOWED_CHARS_COMPILED = re.compile(BACKEND_ALLOWED_CHARS)
+
+
+def call_function_on_backend(
+        function: typing.Callable,
+        *args,
+        **kwargs,
+) -> typing.Any:
+    try:
+        return function(*args, **kwargs)
+    except Exception as ex:
+        raise BackendError(ex)
 
 
 def check_path_for_allowed_chars(path):
@@ -57,14 +70,7 @@ def md5_read_chunk(
         yield data
 
 
-def raise_file_not_found_error(
-        path: str,
-        *,
-        version: str = None,
-):
-    if version:
-        path = f'{path} with version {version}'
-
+def raise_file_not_found_error(path: str):
     raise FileNotFoundError(
         errno.ENOENT,
         os.strerror(errno.ENOENT),

--- a/docs/api-src/audbackend.rst
+++ b/docs/api-src/audbackend.rst
@@ -34,6 +34,7 @@ the following classes and functions are available.
     :toctree:
     :nosignatures:
 
+    BackendError
     Repository
     available
     create

--- a/tests/test_artifactory.py
+++ b/tests/test_artifactory.py
@@ -19,5 +19,7 @@ def test_exists(no_artifactory_access_rights):
     assert not BACKEND.exists(remote_file, version)
 
 
-def test_ls(no_artifactory_access_rights):
-    assert BACKEND.ls() == []
+# TODO: re-enable once we have solved
+#  https://github.com/audeering/audbackend/issues/86
+# def test_ls(no_artifactory_access_rights):
+#     assert BACKEND.ls() == []


### PR DESCRIPTION
Relates to #84 

Currently we raise a `FileNotFoundError` in (almost) every occasion where an error on the backend occurs. But this can be misleading as there can be various reasons why an operation on the backend fails, e.g. a temporary connection issue. 

Here we introduce the more generic `BackendError` as suggested in:

![image](https://user-images.githubusercontent.com/10383417/232532944-b4d4ffb4-1f96-4b1d-be73-43ea165a62df.png)

Furthermore, we encourage the backend to raise the native exceptions, e.g. checks if a file exists are removed and `_ls()` no longer should return an empty list if the folder does not exist.

![image](https://user-images.githubusercontent.com/10383417/232536768-7628301d-06af-445b-9cc1-ca643f7e394c.png)

### Example

Example how to access the original error raised by the backend:

```python
try:
    backend.checksum('does-not-exist', '1.0.0')
except audbackend.BackendError as ex:
    print(ex.exception)
```
```
[Errno 2] No such file or directory: '/my/host/does-not-exist/1.0.0/does-not-exist'
```

