### PR TITLE
Create repository if it does not exist

### DIFF
--- a/audbackend/core/api.py
+++ b/audbackend/core/api.py
@@ -30,8 +30,8 @@ def available() -> typing.Dict[str, typing.List[Backend]]:
     Examples:
         >>> list(available())
         ['artifactory', 'file-system']
-        >>> available()['artifactory']
-        [('audbackend.core.artifactory.Artifactory', 'https://host.com', 'repo')]
+        >>> available()['file-system']
+        [('audbackend.core.filesystem.FileSystem', 'host', 'doctest')]
 
     """  # noqa: E501
     result = {}
@@ -66,11 +66,11 @@ def create(
 
     Examples:
         >>> create(
-        ...     'artifactory',
-        ...     'https://host.com',
+        ...     'file-system',
+        ...     'host',
         ...     'repo',
         ... )
-        ('audbackend.core.artifactory.Artifactory', 'https://host.com', 'repo')
+        ('audbackend.core.filesystem.FileSystem', 'host', 'repo')
 
     """
     if name not in backend_registry:

--- a/audbackend/core/api.py
+++ b/audbackend/core/api.py
@@ -3,6 +3,7 @@ import typing
 from audbackend.core.artifactory import Artifactory
 from audbackend.core.backend import Backend
 from audbackend.core.filesystem import FileSystem
+from audbackend.core import utils
 
 
 backends = {}
@@ -62,6 +63,7 @@ def create(
         backend object
 
     Raises:
+        BackendError: if an error is raised on the backend
         ValueError: if registry name does not exist
 
     Examples:
@@ -87,7 +89,11 @@ def create(
         backends[name][host] = {}
     if repository not in backends[name][host]:
         backend = backend_registry[name]
-        backends[name][host][repository] = backend(host, repository)
+        backends[name][host][repository] = utils.call_function_on_backend(
+            backend,
+            host,
+            repository,
+        )
     return backends[name][host][repository]
 
 

--- a/audbackend/core/api.py
+++ b/audbackend/core/api.py
@@ -68,8 +68,8 @@ def create(
     :class:`audbackend.BackendError`
     is raised.
 
-    Use :func:`audbackend.avilable`
-    to list available backend alias.
+    Use :func:`audbackend.available`
+    to list available backend aliases.
 
     Args:
         name: alias under which backend class is registered

--- a/audbackend/core/api.py
+++ b/audbackend/core/api.py
@@ -20,7 +20,7 @@ def available() -> typing.Dict[str, typing.List[Backend]]:
     r"""List available backends.
 
     Returns a dictionary with
-    registered backend names as keys
+    registered backend aliases as keys
     (see :func:`audbackend.register`)
     and a list with backend instances as values
     (see :func:`audbackend.create`).
@@ -52,10 +52,27 @@ def create(
         host: str,
         repository: str,
 ) -> Backend:
-    r"""Create backend.
+    r"""Create backend instance.
+
+    Returns an instance of the class
+    registered under the alias ``name``
+    with :func:`audbackend.register`.
+
+    If the ``repository``
+    does not yet exist
+    on the ``host``
+    it will be created.
+    If this is not possible
+    (e.g. user lacks permission)
+    an error of type
+    :class:`audbackend.BackendError`
+    is raised.
+
+    Use :func:`audbackend.avilable`
+    to list available backend alias.
 
     Args:
-        name: backend registry name
+        name: alias under which backend class is registered
         host: host address
         repository: repository name
 
@@ -64,7 +81,8 @@ def create(
 
     Raises:
         BackendError: if an error is raised on the backend
-        ValueError: if registry name does not exist
+        ValueError: if no backend class with alias ``name``
+            has been registered
 
     Examples:
         >>> create(
@@ -101,13 +119,14 @@ def register(
         name: str,
         cls: typing.Type[Backend],
 ):
-    r"""Register backend.
+    r"""Register backend class.
 
-    If a backend with this name already exists,
+    If there is already a backend class
+    registered under the alias ``name``
     it will be overwritten.
 
     Args:
-        name: backend registry name
+        name: alias under which backend class is registered
         cls: backend class
 
     Examples:

--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -9,9 +9,7 @@ from audbackend.core.backend import Backend
 
 
 class Artifactory(Backend):
-    r"""Artifactory backend.
-
-    Store files and archives on Artifactory.
+    r"""Backend for Artifactory.
 
     Args:
         host: host address
@@ -27,7 +25,9 @@ class Artifactory(Backend):
         super().__init__(host, repository)
 
         self.root = f'{self.host}/{self.repository}'
-        audfactory.path(self.root).mkdir()
+        path = audfactory.path(self.root)
+        if not path.exists():
+            audfactory.path(self.root).mkdir()
 
     def _checksum(
             self,

--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -26,6 +26,9 @@ class Artifactory(Backend):
     ):
         super().__init__(host, repository)
 
+        self.root = f'{self.host}/{self.repository}'
+        audfactory.path(self.root).mkdir()
+
     def _checksum(
             self,
             path: str,
@@ -59,7 +62,7 @@ class Artifactory(Backend):
         folder = folder.replace(self.sep, '/')
         if not folder.startswith('/'):
             folder = '/' + folder
-        folder = f'{self.host}/{self.repository}{folder}'
+        folder = f'{self.root}{folder}'
         if not folder.endswith('/'):
             folder = folder + '/'
         return folder
@@ -96,8 +99,7 @@ class Artifactory(Backend):
         result = []
         for full_path in paths:
 
-            host_repo = f'{self.host}/{self.repository}'
-            full_path = full_path[len(host_repo) + 1:]  # remove host and repo
+            full_path = full_path[len(self.root) + 1:]  # remove host and repo
             full_path = full_path.replace('/', self.sep)
             tokens = full_path.split('/')
 

--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -17,7 +17,6 @@ class Artifactory(Backend):
         repository: repository name
 
     """
-
     def __init__(
             self,
             host,

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -145,8 +145,7 @@ class Backend:
             ValueError: if ``src_path`` contains invalid character
 
         Examples:
-            >>> dst_root = audeer.path(tmp, 'dst')
-            >>> backend.get_archive('a.zip', dst_root, '1.0.0')
+            >>> backend.get_archive('a.zip', '.', '1.0.0')
             ['src.pth']
 
         """
@@ -208,11 +207,10 @@ class Backend:
             ValueError: if ``src_path`` contains invalid character
 
         Examples:
-            >>> dst_path = audeer.path(tmp, 'dst.pth')
-            >>> os.path.exists(dst_path)
+            >>> os.path.exists('dst.pth')
             False
-            >>> _ = backend.get_file('name.ext', dst_path, '1.0.0')
-            >>> os.path.exists(dst_path)
+            >>> _ = backend.get_file('name.ext', 'dst.pth', '1.0.0')
+            >>> os.path.exists('dst.pth')
             True
 
         """
@@ -418,8 +416,7 @@ class Backend:
         Examples:
             >>> backend.exists('a.tar.gz', '1.0.0')
             False
-            >>> files = ['src.pth']
-            >>> backend.put_archive(tmp, files, 'name.tar.gz', '1.0.0')
+            >>> backend.put_archive('.', ['src.pth'], 'name.tar.gz', '1.0.0')
             >>> backend.exists('name.tar.gz', '1.0.0')
             True
 
@@ -500,8 +497,7 @@ class Backend:
         Examples:
             >>> backend.exists('folder/name.ext', '3.0.0')
             False
-            >>> src_path = audeer.path(tmp, 'src.pth')
-            >>> backend.put_file(src_path, 'folder/name.ext', '3.0.0')
+            >>> backend.put_file('src.pth', 'folder/name.ext', '3.0.0')
             >>> backend.exists('folder/name.ext', '3.0.0')
             True
 

--- a/audbackend/core/conftest.py
+++ b/audbackend/core/conftest.py
@@ -29,7 +29,6 @@ def prepare_docstring_tests(doctest_namespace):
             backend.put_file(file, 'name.ext', version)
 
         doctest_namespace['backend'] = backend
-        # doctest_namespace['tmp'] = tmp
 
         yield
 

--- a/audbackend/core/conftest.py
+++ b/audbackend/core/conftest.py
@@ -1,29 +1,36 @@
+import os
 import tempfile
+
 import pytest
 
 import audbackend
 import audeer
 
 
-@pytest.fixture(autouse=True)
-def create_backend(doctest_namespace):
+@pytest.fixture(scope='function', autouse=True)
+def prepare_docstring_tests(doctest_namespace):
+
     with tempfile.TemporaryDirectory() as tmp:
-        audbackend.create(
-            'artifactory',
-            'https://host.com',
-            'repo',
-        )
+
+        current_dir = os.getcwd()
+        os.chdir(tmp)
+
         backend = audbackend.create(
             'file-system',
-            tmp,
+            'host',
             'doctest',
         )
-        src_file = 'src.pth'
-        src_path = audeer.touch(audeer.path(tmp, src_file))
-        backend.put_archive(tmp, [src_file], 'a.zip', '1.0.0')
+
+        file = 'src.pth'
+        audeer.touch(file)
+        backend.put_archive('.', [file], 'a.zip', '1.0.0')
+        backend.put_file(file, 'a/b.ext', '1.0.0')
         for version in ['1.0.0', '2.0.0']:
-            backend.put_file(src_path, 'name.ext', version)
-        backend.put_file(src_path, 'a/b.ext', '1.0.0')
+            backend.put_file(file, 'name.ext', version)
+
         doctest_namespace['backend'] = backend
-        doctest_namespace['tmp'] = tmp
+        # doctest_namespace['tmp'] = tmp
+
         yield
+
+        os.chdir(current_dir)

--- a/audbackend/core/filesystem.py
+++ b/audbackend/core/filesystem.py
@@ -23,7 +23,9 @@ class FileSystem(Backend):
             host: str,
             repository: str,
     ):
-        super().__init__(audeer.path(host), repository)
+        super().__init__(host, repository)
+
+        self.root = audeer.mkdir(audeer.path(host, repository))
 
     def _checksum(
             self,
@@ -57,7 +59,7 @@ class FileSystem(Backend):
         folder = folder.replace(self.sep, os.path.sep)
         if folder.startswith(os.path.sep):
             folder = folder[1:]
-        folder = os.path.join(self.host, self.repository, folder)
+        folder = audeer.path(self.root, folder)
         return folder
 
     def _get_file(
@@ -91,8 +93,7 @@ class FileSystem(Backend):
         result = []
         for full_path in paths:
 
-            host_repo = os.path.join(self.host, self.repository)
-            full_path = full_path[len(host_repo) + 1:]  # remove host and repo
+            full_path = full_path[len(self.root) + 1:]  # remove host and repo
             full_path = full_path.replace(os.path.sep, self.sep)
             tokens = full_path.split(self.sep)
 

--- a/audbackend/core/filesystem.py
+++ b/audbackend/core/filesystem.py
@@ -23,9 +23,9 @@ class FileSystem(Backend):
     ):
         super().__init__(host, repository)
 
-        self.root = audeer.path(host, repository)
-        if not os.path.exists(self.root):
-            audeer.mkdir(self.root)
+        self._root = audeer.path(host, repository)
+        if not os.path.exists(self._root):
+            audeer.mkdir(self._root)
 
     def _checksum(
             self,
@@ -59,7 +59,7 @@ class FileSystem(Backend):
         folder = folder.replace(self.sep, os.path.sep)
         if folder.startswith(os.path.sep):
             folder = folder[1:]
-        folder = audeer.path(self.root, folder)
+        folder = audeer.path(self._root, folder)
         return folder
 
     def _get_file(
@@ -93,7 +93,7 @@ class FileSystem(Backend):
         result = []
         for full_path in paths:
 
-            full_path = full_path[len(self.root) + 1:]  # remove host and repo
+            full_path = full_path[len(self._root) + 1:]  # remove host and repo
             full_path = full_path.replace(os.path.sep, self.sep)
             tokens = full_path.split(self.sep)
 

--- a/audbackend/core/filesystem.py
+++ b/audbackend/core/filesystem.py
@@ -9,9 +9,7 @@ from audbackend.core.backend import Backend
 
 
 class FileSystem(Backend):
-    r"""File system backend.
-
-    Store files and archives on a file system.
+    r"""Backend for file system.
 
     Args:
         host: host directory
@@ -25,7 +23,9 @@ class FileSystem(Backend):
     ):
         super().__init__(host, repository)
 
-        self.root = audeer.mkdir(audeer.path(host, repository))
+        self.root = audeer.path(host, repository)
+        if not os.path.exists(self.root):
+            audeer.mkdir(self.root)
 
     def _checksum(
             self,

--- a/audbackend/core/utils.py
+++ b/audbackend/core/utils.py
@@ -46,8 +46,7 @@ def md5(
         checksum
 
     Examples:
-        >>> path = audeer.path(tmp, 'src.pth')
-        >>> md5(path)
+        >>> md5('src.pth')
         'd41d8cd98f00b204e9800998ecf8427e'
 
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,7 @@ pytest.BACKENDS = [
 ]
 
 
-@pytest.fixture(scope='session', autouse=True)
+@pytest.fixture(scope='package', autouse=True)
 def cleanup_session():
 
     # clean up old coverage files

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,22 +1,15 @@
 import os
-import shutil
 
 import pytest
 
 import audeer
-import audfactory
 
 
 pytest.ROOT = os.path.dirname(os.path.realpath(__file__))
-uid = audeer.uid()[:8]
 
 pytest.HOSTS = {
     'artifactory': 'https://audeering.jfrog.io/artifactory',
-    'file-system': os.path.join(pytest.ROOT, 'file-system'),
-}
-pytest.REPOSITORIES = {
-    'artifactory': f'unittests-public/{uid}/',
-    'file-system': uid + os.sep,
+    'file-system': os.path.join(pytest.ROOT, 'host'),
 }
 
 # list of backends that will be tested
@@ -39,19 +32,8 @@ def cleanup_session():
 
     yield
 
-    # clean up file system
     if os.path.exists(pytest.HOSTS['file-system']):
-        shutil.rmtree(pytest.HOSTS['file-system'])
-
-    # clean up Artifactory
-    url = audfactory.path(
-        audfactory.url(
-            pytest.HOSTS['artifactory'],
-            repository=pytest.REPOSITORIES['artifactory'],
-        ),
-    )
-    if url.exists():
-        url.unlink()
+        os.rmdir(pytest.HOSTS['file-system'])
 
 
 @pytest.fixture(scope='function', autouse=False)

--- a/tests/test_artifactory.py
+++ b/tests/test_artifactory.py
@@ -35,10 +35,7 @@ def test_errors(tmpdir, no_artifactory_access_rights):
         BACKEND.latest_version(remote_file)
 
     with pytest.raises(audbackend.BackendError):
+        BACKEND.ls('/')
+
+    with pytest.raises(audbackend.BackendError):
         BACKEND.versions(remote_file)
-
-
-# TODO: re-enable once we have solved
-#  https://github.com/audeering/audbackend/issues/86
-# def test_ls(no_artifactory_access_rights):
-#     assert BACKEND.ls() == []

--- a/tests/test_artifactory.py
+++ b/tests/test_artifactory.py
@@ -4,38 +4,46 @@ import audbackend
 import audeer
 
 
-BACKEND = audbackend.Artifactory(
-    pytest.HOSTS['artifactory'],
-    pytest.REPOSITORIES['artifactory'],
-)
+@pytest.fixture(scope='function')
+def backend(request):
+
+    backend = audbackend.Artifactory(
+        pytest.HOSTS['artifactory'],
+        f'unittest-{audeer.uid()[:8]}',
+    )
+
+    yield backend
+
+    # TODO: replace with audbackend.delete() when available
+    backend._repo.delete()
 
 
-def test_errors(tmpdir, no_artifactory_access_rights):
+def test_errors(tmpdir, backend, no_artifactory_access_rights):
 
     local_file = audeer.touch(
         audeer.path(tmpdir, 'file.txt')
     )
-    remote_file = BACKEND.join(
+    remote_file = backend.join(
         audeer.uid()[:8],
         'file.txt',
     )
     version = '1.0.0'
 
     with pytest.raises(audbackend.BackendError):
-        BACKEND.exists(remote_file, version)
+        backend.exists(remote_file, version)
 
     with pytest.raises(audbackend.BackendError):
-        BACKEND.put_file(
+        backend.put_file(
             local_file,
             remote_file,
             version,
         )
 
     with pytest.raises(audbackend.BackendError):
-        BACKEND.latest_version(remote_file)
+        backend.latest_version(remote_file)
 
     with pytest.raises(audbackend.BackendError):
-        BACKEND.ls('/')
+        backend.ls('/')
 
     with pytest.raises(audbackend.BackendError):
-        BACKEND.versions(remote_file)
+        backend.versions(remote_file)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -148,12 +148,12 @@ def test_archive(tmpdir, files, name, folder, version, tmp_root, backend):
             f'unittest-{audeer.uid()[:8]}',
             audbackend.FileSystem,
         ),
-        # (
-        #     'artifactory',
-        #     pytest.HOSTS['artifactory'],
-        #     f'unittest-{audeer.uid()[:8]}',
-        #     audbackend.Artifactory,
-        # ),
+        (
+            'artifactory',
+            pytest.HOSTS['artifactory'],
+            f'unittest-{audeer.uid()[:8]}',
+            audbackend.Artifactory,
+        ),
         pytest.param(  # backend does not exist
             'bad-backend',
             None,

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -134,25 +134,38 @@ def test_archive(tmpdir, files, name, folder, version, tmp_root, backend):
 
 
 @pytest.mark.parametrize(
-    'name, cls',
+    'name, host, repository, cls',
     [
         (
             'file-system',
+            pytest.HOSTS['file-system'],
+            pytest.REPOSITORIES['file-system'],
             audbackend.FileSystem,
         ),
         (
             'artifactory',
+            pytest.HOSTS['artifactory'],
+            pytest.REPOSITORIES['artifactory'],
             audbackend.Artifactory,
         ),
         pytest.param(  # backend does not exist
-            'does-not-exist',
+            'bad-backend',
+            None,
+            None,
             None,
             marks=pytest.mark.xfail(raises=ValueError),
-        )
+        ),
+        pytest.param(  # cannot create repository
+            'artifactory',
+            'bad-host',
+            'bad-repo',
+            None,
+            marks=pytest.mark.xfail(raises=audbackend.BackendError),
+        ),
     ]
 )
-def test_create(name, cls):
-    backend = audbackend.create(name, 'host', 'repository')
+def test_create(name, host, repository, cls):
+    backend = audbackend.create(name, host, repository)
     assert isinstance(backend, cls)
 
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -437,10 +437,8 @@ def test_file(tmpdir, src_path, dst_path, version, backend):
 )
 def test_ls(tmpdir, backend):
 
-    # TODO: re-enable once we have solved
-    #  https://github.com/audeering/audbackend/issues/86
-    # assert backend.ls() == []
-    # assert backend.ls('/') == []
+    assert backend.ls() == []
+    assert backend.ls('/') == []
 
     sub_content = [  # files in sub directory
         ('sub/file.foo', '1.0.0'),


### PR DESCRIPTION
Relates to #89, https://github.com/audeering/audbackend/issues/86, #24 

When a backend is created it will create the repository if it does not exist. This may raise a `BackendError` and the docstring has been extended accordingly:

![image](https://user-images.githubusercontent.com/10383417/233053098-98e4bdec-451f-4a3b-a861-60c278127a0b.png)

![image](https://user-images.githubusercontent.com/10383417/233055623-53c00eb4-5cc5-4729-9b90-3d2af175f833.png)

![image](https://user-images.githubusercontent.com/10383417/233052975-c71c5d02-ac40-433f-8194-755a4b9fa2bc.png)

Other changes:

* It is no longer possible to use a folder inside an Artifactory repository as repository
* To avoid a BackendError is now raised in the docstring examples, the Artifactory backend has been removed. 
* The docstring examples have been further simplified by directly setting the working directory to the temporary folder.
* The test for listing an empty repository is re-enabled.