### PR TITLE
Suppress backend errors

### DIFF
--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -89,7 +89,11 @@ class Artifactory(Backend):
             self,
             folder: str,
     ):
-        r"""List all files under folder."""
+        r"""List all files under folder.
+
+        If folder does not exist an error should be raised.
+
+        """
 
         folder = self._folder(folder)
         folder = audfactory.path(folder)
@@ -162,17 +166,21 @@ class Artifactory(Backend):
             self,
             path: str,
     ) -> typing.List[str]:
-        r"""Versions of a file."""
+        r"""Versions of a file.
+
+        If path does not exist an error should be raised.
+
+        """
         folder, _ = self.split(path)
         folder = self._folder(folder)
         folder = audfactory.path(folder)
 
-        try:
-            vs = [os.path.basename(str(f)) for f in folder if f.is_dir]
-        except (FileNotFoundError, RuntimeError):
-            vs = []
+        vs = [os.path.basename(str(f)) for f in folder if f.is_dir]
 
         # filter out versions of files with different extension
         vs = [v for v in vs if self._exists(path, v)]
+
+        if not vs:
+            utils.raise_file_not_found_error(path)
 
         return vs

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -55,7 +55,8 @@ class Backend:
             MD5 checksum
 
         Raises:
-            BackendError: if an error is raised on the backend
+            BackendError: if an error is raised on the backend,
+                e.g. ``path`` does not exist
             ValueError: if ``path`` contains invalid character
 
         Examples:
@@ -99,7 +100,9 @@ class Backend:
             ``True`` if file exists
 
         Raises:
-            BackendError: if an error is raised on the backend
+            BackendError: if ``suppress_backend_errors`` is ``False``
+                and an error is raised on the backend,
+                e.g. ``path`` does not exist
             ValueError: if ``path`` contains invalid character
 
         Examples:
@@ -143,7 +146,8 @@ class Backend:
             extracted files
 
         Raises:
-            BackendError: if an error is raised on the backend
+            BackendError: if an error is raised on the backend,
+                e.g. ``src_path`` does not exist
             FileNotFoundError: if ``tmp_root`` does not exist
             PermissionError: if the user lacks write permissions
                 for ``dst_path``
@@ -208,7 +212,8 @@ class Backend:
             full path to local file
 
         Raises:
-            BackendError: if an error is raised on the backend
+            BackendError: if an error is raised on the backend,
+                e.g. ``src_path`` does not exist
             PermissionError: if the user lacks write permissions
                 for ``dst_path``
             ValueError: if ``src_path`` contains invalid character
@@ -288,7 +293,8 @@ class Backend:
             version string
 
         Raises:
-            BackendError: if an error is raised on the backend
+            BackendError: if an error is raised on the backend,
+                e.g. ``path`` does not exist
             ValueError: if ``path`` contains invalid character
 
         Examples:
@@ -343,7 +349,9 @@ class Backend:
             list of tuples (path, version)
 
         Raises:
-            BackendError: if an error is raised on the backend
+            BackendError: if ``suppress_backend_errors`` is ``False``
+                and an error is raised on the backend,
+                e.g. ``folder`` does not exist
             ValueError: if ``folder`` contains invalid character
 
         Examples:
@@ -553,7 +561,8 @@ class Backend:
             version: version string
 
         Raises:
-            BackendError: if an error is raised on the backend
+            BackendError: if an error is raised on the backend,
+                e.g. ``path`` does not exist
             ValueError: if ``path`` contains invalid character
 
         Examples:
@@ -633,7 +642,9 @@ class Backend:
             list of versions in ascending order
 
         Raises:
-            BackendError: if an error is raised on the backend
+            BackendError: if ``suppress_backend_errors`` is ``False``
+                and an error is raised on the backend,
+                e.g. ``path`` does not exist
             ValueError: if ``path`` contains invalid character
 
         Examples:

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -289,7 +289,6 @@ class Backend:
 
         Raises:
             BackendError: if an error is raised on the backend
-            RuntimeError: if no version is found
             ValueError: if ``path`` contains invalid character
 
         Examples:
@@ -298,15 +297,7 @@ class Backend:
 
         """
         utils.check_path_for_allowed_chars(path)
-
         vs = self.versions(path)
-        if not vs:
-            raise RuntimeError(
-                f"Cannot find a version for "
-                f"'{path}' in "
-                f"'{self.repository}'.",
-            )
-
         return vs[-1]
 
     def _ls(

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -83,12 +83,17 @@ class Backend:
             self,
             path: str,
             version: str,
+            *,
+            suppress_backend_errors: bool = False,
     ) -> bool:
         r"""Check if file exists on backend.
 
         Args:
             path: path to file on backend
             version: version string
+            suppress_backend_errors: if set to ``True``,
+                silently catch errors raised on the backend
+                and return ``False``
 
         Returns:
             ``True`` if file exists
@@ -108,6 +113,8 @@ class Backend:
             self._exists,
             path,
             version,
+            suppress_backend_errors=suppress_backend_errors,
+            fallback_return_value=False,
         )
 
     def get_archive(
@@ -315,6 +322,7 @@ class Backend:
             *,
             latest_version: bool = False,
             pattern: str = None,
+            suppress_backend_errors: bool = False,
     ) -> typing.List[typing.Tuple[str, str]]:
         r"""List all files under folder.
 
@@ -332,6 +340,9 @@ class Backend:
             pattern: if not ``None``,
                 return only files matching the pattern string,
                 see :func:`fnmatch.fnmatch`
+            suppress_backend_errors: if set to ``True``,
+                silently catch errors raised on the backend
+                and return an empty list
 
         Returns:
             list of tuples (path, version)
@@ -354,7 +365,15 @@ class Backend:
         utils.check_path_for_allowed_chars(folder)
         if not folder.endswith('/'):
             folder += '/'
-        paths = utils.call_function_on_backend(self._ls, folder)
+        paths = utils.call_function_on_backend(
+            self._ls,
+            folder,
+            suppress_backend_errors=suppress_backend_errors,
+            fallback_return_value=[],
+        )
+        if not paths:
+            return paths
+
         paths = sorted(paths)
 
         if pattern:
@@ -600,11 +619,16 @@ class Backend:
     def versions(
             self,
             path: str,
+            *,
+            suppress_backend_errors: bool = False,
     ) -> typing.List[str]:
         r"""Versions of a file.
 
         Args:
             path: path to file on backend
+            suppress_backend_errors: if set to ``True``,
+                silently catch errors raised on the backend
+                and return an empty list
 
         Returns:
             list of versions in ascending order
@@ -623,6 +647,8 @@ class Backend:
         vs = utils.call_function_on_backend(
             self._versions,
             path,
+            suppress_backend_errors=suppress_backend_errors,
+            fallback_return_value=[],
         )
 
         return audeer.sort_versions(vs)

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -313,7 +313,11 @@ class Backend:
             self,
             folder: str,
     ) -> typing.List[typing.Tuple[str, str, str]]:  # pragma: no cover
-        r"""List all files under folder."""
+        r"""List all files under folder.
+
+        If folder does not exist an error should be raised.
+
+        """
         raise NotImplementedError()
 
     def ls(
@@ -613,7 +617,11 @@ class Backend:
             self,
             path: str,
     ) -> typing.List[str]:  # pragma: no cover
-        r"""Versions of a file."""
+        r"""Versions of a file.
+
+        If path does not exist an error should be raised.
+
+        """
         raise NotImplementedError()
 
     def versions(

--- a/audbackend/core/filesystem.py
+++ b/audbackend/core/filesystem.py
@@ -152,15 +152,15 @@ class FileSystem(Backend):
         folder, _ = self.split(path)
         folder = self._folder(folder)
 
-        if os.path.exists(folder):
-            vs = audeer.list_dir_names(
-                folder,
-                basenames=True,
-            )
-        else:
-            vs = []
+        vs = audeer.list_dir_names(
+            folder,
+            basenames=True,
+        )
 
         # filter out versions of files with different extension
         vs = [v for v in vs if self._exists(path, v)]
+
+        if not vs:
+            utils.raise_file_not_found_error(path)
 
         return vs

--- a/audbackend/core/utils.py
+++ b/audbackend/core/utils.py
@@ -16,12 +16,17 @@ BACKEND_ALLOWED_CHARS_COMPILED = re.compile(BACKEND_ALLOWED_CHARS)
 def call_function_on_backend(
         function: typing.Callable,
         *args,
+        suppress_backend_errors: bool = False,
+        fallback_return_value: typing.Any = None,
         **kwargs,
 ) -> typing.Any:
     try:
         return function(*args, **kwargs)
     except Exception as ex:
-        raise BackendError(ex)
+        if suppress_backend_errors:
+            return fallback_return_value
+        else:
+            raise BackendError(ex)
 
 
 def check_path_for_allowed_chars(path):

--- a/tests/test_artifactory.py
+++ b/tests/test_artifactory.py
@@ -29,9 +29,16 @@ def test_errors(tmpdir, backend, no_artifactory_access_rights):
     )
     version = '1.0.0'
 
+    # --- exists ---
     with pytest.raises(audbackend.BackendError):
         backend.exists(remote_file, version)
+    assert backend.exists(
+        remote_file,
+        version,
+        suppress_backend_errors=True,
+    ) == False
 
+    # --- put_file ---
     with pytest.raises(audbackend.BackendError):
         backend.put_file(
             local_file,
@@ -39,11 +46,22 @@ def test_errors(tmpdir, backend, no_artifactory_access_rights):
             version,
         )
 
+    # --- latest_version ---
     with pytest.raises(audbackend.BackendError):
         backend.latest_version(remote_file)
 
+    # --- ls ---
     with pytest.raises(audbackend.BackendError):
         backend.ls('/')
+    assert backend.ls(
+        '/',
+        suppress_backend_errors=True,
+    ) == []
 
+    # --- versions ---
     with pytest.raises(audbackend.BackendError):
         backend.versions(remote_file)
+    assert backend.versions(
+        remote_file,
+        suppress_backend_errors=True,
+    ) == []

--- a/tests/test_artifactory.py
+++ b/tests/test_artifactory.py
@@ -36,7 +36,7 @@ def test_errors(tmpdir, backend, no_artifactory_access_rights):
         remote_file,
         version,
         suppress_backend_errors=True,
-    ) == False
+    ) is False
 
     # --- put_file ---
     with pytest.raises(audbackend.BackendError):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -542,8 +542,10 @@ def test_versions(tmpdir, dst_path, backend):
     audeer.touch(src_path)
 
     # empty backend
-    assert not backend.versions(dst_path)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(audbackend.BackendError):
+        backend.versions(dst_path)
+    assert not backend.versions(dst_path, suppress_backend_errors=True)
+    with pytest.raises(audbackend.BackendError):
         backend.latest_version(dst_path)
 
     # v1

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -315,7 +315,7 @@ def test_errors(tmpdir, backend):
         f"Cannot find a version for '{file_missing}' "
         f"in '{backend.repository}'"
     )
-    with pytest.raises(RuntimeError, match=error_msg):
+    with pytest.raises(audbackend.BackendError, match=error_backend):
         backend.latest_version(file_missing)
     # `path` contains invalid character
     with pytest.raises(ValueError, match=error_invalid_char):


### PR DESCRIPTION
Closes https://github.com/audeering/audbackend/issues/61

This adds the argument `suppress_backend_errors` to the following functions:

![image](https://user-images.githubusercontent.com/10383417/233158521-63b16774-00aa-4c41-90c1-d791a5b2e5cd.png)

![image](https://user-images.githubusercontent.com/10383417/233158457-577ee438-2180-41b5-b475-d2a5a107cab2.png)

![image](https://user-images.githubusercontent.com/10383417/233158363-6091acea-8875-4c43-b83b-42dcdbd3035d.png)

 `Backend._ls()` and `Backend._versions()` are now supposed to raise an error if the `path` does not exist.