### PR TITLE
Backend.ls(): support full path

### DIFF
--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -103,16 +103,15 @@ class Artifactory(Backend):
     ):
         r"""List all files under (sub-)path."""
 
-        if path.endswith('/'):
+        if path.endswith('/'):  # find files under sub-path
 
-            # find files under sub-path
             path = self._expand(path)
             path = audfactory.path(path)
             if not path.exists():
                 utils.raise_file_not_found_error(str(path))
             paths = [str(x) for x in path.glob("**/*") if x.is_file()]
 
-        else:
+        else:  # find versions of path
 
             root, _ = self.split(path)
             root = self._expand(root)

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -332,16 +332,16 @@ class Backend:
         with path and version.
         It is possible to provide a sub-path
         e.g. ``/sub/path/``.
-        In that case all files 
-        that start with the sub-path are returned.         
+        In that case all files
+        that start with the sub-path are returned.
         When ``path`` is set to ``'/'``
         a (possibly empty) list with
-        all files on the backend is returned.        
+        all files on the backend is returned.
 
         Args:
             path: (sub-)path on backend.
                 If a sub-path is provided,
-                it has to end on ``/`` 
+                it has to end on ``/``
             latest_version: if multiple versions of a file exist,
                 only include the latest
             pattern: if not ``None``,

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -267,8 +267,8 @@ class Backend:
             ValueError: if joined path contains invalid character
 
         Examples:
-            >>> backend.join('folder', 'name.ext')
-            'folder/name.ext'
+            >>> backend.join('sub', 'name.ext')
+            'sub/name.ext'
 
         """
         paths = [path] + [p for p in paths]
@@ -308,7 +308,7 @@ class Backend:
 
     def _ls(
             self,
-            folder: str,
+            path: str,
     ) -> typing.List[typing.Tuple[str, str, str]]:  # pragma: no cover
         r"""List all files under (sub-)path.
 
@@ -521,10 +521,10 @@ class Backend:
             ValueError: if ``dst_path`` contains invalid character
 
         Examples:
-            >>> backend.exists('folder/name.ext', '3.0.0')
+            >>> backend.exists('sub/name.ext', '3.0.0')
             False
-            >>> backend.put_file('src.pth', 'folder/name.ext', '3.0.0')
-            >>> backend.exists('folder/name.ext', '3.0.0')
+            >>> backend.put_file('src.pth', 'sub/name.ext', '3.0.0')
+            >>> backend.exists('sub/name.ext', '3.0.0')
             True
 
         """
@@ -594,28 +594,28 @@ class Backend:
             self,
             path: str,
     ) -> typing.Tuple[str, str]:
-        r"""Split path on backend into folder and basename.
+        r"""Split path on backend into root and basename.
 
         Args:
             path: path containing :attr:`Backend.sep` as separator
 
         Returns:
-            tuple containing (folder, basename)
+            tuple containing (root, basename)
 
         Raises:
             ValueError: if ``path`` contains invalid character
 
         Examples:
-            >>> backend.split('folder/name.ext')
-            ('folder', 'name.ext')
+            >>> backend.split('sub/name.ext')
+            ('sub', 'name.ext')
 
         """
         utils.check_path_for_allowed_chars(path)
 
-        folder = self.sep.join(path.split(self.sep)[:-1])
+        root = self.sep.join(path.split(self.sep)[:-1])
         basename = path.split(self.sep)[-1]
 
-        return folder, basename
+        return root, basename
 
     def _versions(
             self,

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -330,10 +330,15 @@ class Backend:
 
         Returns a sorted list of tuples
         with path and version.
-        It is possible to provide a sub-path
-        e.g. ``/sub/path/``.
-        In that case all files
-        that start with the sub-path are returned.
+        If a full path
+        (e.g. ``/sub/file.ext``)
+        is provdided,
+        all versions of the path are returned.
+        If a sub-path
+        (e.g. ``/sub/``)
+        is provided,
+        all files that start with
+        the sub-path are returned.
         When ``path`` is set to ``'/'``
         a (possibly empty) list with
         all files on the backend is returned.

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -340,8 +340,7 @@ class Backend:
 
         Args:
             path: (sub-)path on backend.
-                If a sub-path is provided,
-                it has to end on ``/``
+                A sub-path must end on ``/``
             latest_version: if multiple versions of a file exist,
                 only include the latest
             pattern: if not ``None``,
@@ -363,10 +362,12 @@ class Backend:
         Examples:
             >>> backend.ls()
             [('a.zip', '1.0.0'), ('a/b.ext', '1.0.0'), ('name.ext', '1.0.0'), ('name.ext', '2.0.0')]
-            >>> backend.ls(pattern='*.ext')
-            [('a/b.ext', '1.0.0'), ('name.ext', '1.0.0'), ('name.ext', '2.0.0')]
             >>> backend.ls(latest_version=True)
             [('a.zip', '1.0.0'), ('a/b.ext', '1.0.0'), ('name.ext', '2.0.0')]
+            >>> backend.ls('name.ext')
+            [('name.ext', '1.0.0'), ('name.ext', '2.0.0')]
+            >>> backend.ls(pattern='*.ext')
+            [('a/b.ext', '1.0.0'), ('name.ext', '1.0.0'), ('name.ext', '2.0.0')]
             >>> backend.ls('a/')
             [('a/b.ext', '1.0.0')]
 

--- a/audbackend/core/filesystem.py
+++ b/audbackend/core/filesystem.py
@@ -103,11 +103,11 @@ class FileSystem(Backend):
                 utils.raise_file_not_found_error(path)
             paths = audeer.list_file_names(path, recursive=True)
         else:
-            folder, _ = self.split(path)
-            if not os.path.exists(folder):
+            root, _ = self.split(path)
+            if not os.path.exists(root):
                 utils.raise_file_not_found_error(path)
             vs = audeer.list_dir_names(
-                folder,
+                root,
                 basenames=True,
             )
             # consider only folders that are version strings
@@ -116,14 +116,14 @@ class FileSystem(Backend):
                 if audeer.is_semantic_version(v)
             ]
             # keep only existing paths to filter out
-            # versions of other files in same folder
+            # versions of other files under same root
             paths = [p for p in paths if os.path.exists(p)]
             if not paths:
                 utils.raise_file_not_found_error(path)
 
-        # <host>/<repository>/<folder>/<version>/<name>
+        # <host>/<repository>/<root>/<version>/<name>
         # ->
-        # (<folder>/<name>, <version>)
+        # (<root>/<name>, <version>)
 
         result = []
         for p in paths:
@@ -147,13 +147,13 @@ class FileSystem(Backend):
     ) -> str:
         r"""Convert to backend path.
 
-        <host>/<repository>/<folder>/<name>
+        <host>/<repository>/<root>/<name>
         ->
-        <host>/<repository>/<folder>/<version>/<name>
+        <host>/<repository>/<root>/<version>/<name>
 
         """
-        folder, name = self.split(path)
-        path = os.path.join(folder, version, name)
+        root, name = self.split(path)
+        path = os.path.join(root, version, name)
         return path
 
     def _put_file(

--- a/audbackend/core/filesystem.py
+++ b/audbackend/core/filesystem.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import typing
 
 import audeer
 

--- a/audbackend/core/filesystem.py
+++ b/audbackend/core/filesystem.py
@@ -22,7 +22,7 @@ class FileSystem(Backend):
     ):
         super().__init__(host, repository)
 
-        self._root = audeer.path(host, repository)
+        self._root = audeer.path(host, repository) + os.sep
         if not os.path.exists(self._root):
             audeer.mkdir(self._root)
 
@@ -46,7 +46,7 @@ class FileSystem(Backend):
         <path>
 
         """
-        path = path[len(self._root) + 1:]  # remove host and repo
+        path = path[len(self._root):]  # remove host and repo
         path = path.replace(os.path.sep, self.sep)
         return path
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ pytest.HOSTS = {
 
 # list of backends that will be tested
 pytest.BACKENDS = [
-    # 'artifactory',
+    'artifactory',
     'file-system',
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ pytest.HOSTS = {
 
 # list of backends that will be tested
 pytest.BACKENDS = [
-    'artifactory',
+    # 'artifactory',
     'file-system',
 ]
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -492,10 +492,10 @@ def test_ls(tmpdir, backend):
         ('/', True, None, content_latest),
         ('/', False, '*.foo', sub_content),
         ('/', True, '*.foo', sub_content_latest),
-        ('sub', False, None, sub_content),
-        ('sub', True, None, sub_content_latest),
-        ('sub', False, '*.bar', []),
-        ('sub', True, '*.bar', []),
+        ('sub/', False, None, sub_content),
+        ('sub/', True, None, sub_content_latest),
+        ('sub/', False, '*.bar', []),
+        ('sub/', True, '*.bar', []),
     ]:
         assert backend.ls(
             folder,


### PR DESCRIPTION
Closes #59 #95 

![image](https://user-images.githubusercontent.com/10383417/233322484-fa8c719f-0d6f-4447-9931-1705a226442e.png)

Additional changes:

* `Backend.versions()` is now implemented based on `Backend.ls()` and `Backend._versions()` is removed
* The use of the word `folder` is avoided and instead we talk about `sub-path`