### PR TITLE
Add audbackend.delete()

### DIFF
--- a/audbackend/__init__.py
+++ b/audbackend/__init__.py
@@ -1,6 +1,7 @@
 from audbackend.core.api import (
     available,
     create,
+    delete,
     register,
 )
 from audbackend.core.artifactory import Artifactory

--- a/audbackend/core/api.py
+++ b/audbackend/core/api.py
@@ -141,22 +141,10 @@ def delete(
             has been registered
 
     Examples:
-        >>> create(
-        ...     'file-system',
-        ...     'host',
-        ...     'doctest',
-        ... ).ls()
+        >>> create('file-system', 'host', 'doctest').ls()
         [('a.zip', '1.0.0'), ('a/b.ext', '1.0.0'), ('name.ext', '1.0.0'), ('name.ext', '2.0.0')]
-        >>> delete(
-        ...     'file-system',
-        ...     'host',
-        ...     'doctest',
-        ... )
-        >>> create(
-        ...     'file-system',
-        ...     'host',
-        ...     'doctest',
-        ... ).ls()
+        >>> delete('file-system', 'host', 'doctest')
+        >>> create('file-system', 'host', 'doctest').ls()
         []
 
     """  # noqa: E501

--- a/audbackend/core/api.py
+++ b/audbackend/core/api.py
@@ -87,11 +87,7 @@ def create(
             has been registered
 
     Examples:
-        >>> create(
-        ...     'file-system',
-        ...     'host',
-        ...     'doctest',
-        ... )
+        >>> create('file-system', 'host', 'doctest')
         ('audbackend.core.filesystem.FileSystem', 'host', 'doctest')
 
     """

--- a/audbackend/core/api.py
+++ b/audbackend/core/api.py
@@ -17,7 +17,7 @@ r"""Backend registry."""
 
 
 def available() -> typing.Dict[str, typing.List[Backend]]:
-    r"""List available backends.
+    r"""List available backend instances.
 
     Returns a dictionary with
     registered backend aliases as keys
@@ -26,7 +26,7 @@ def available() -> typing.Dict[str, typing.List[Backend]]:
     (see :func:`audbackend.create`).
 
     Returns:
-        dictionary with backends
+        dictionary with backend instances
 
     Examples:
         >>> list(available())
@@ -54,7 +54,9 @@ def create(
 ) -> Backend:
     r"""Create backend instance.
 
-    Returns an instance of the class
+    Returns a backend instance for the
+    ``repository`` on the ``host``.
+    The instance is an object of the class
     registered under the alias ``name``
     with :func:`audbackend.register`.
 
@@ -69,7 +71,7 @@ def create(
     is raised.
 
     Use :func:`audbackend.available`
-    to list available backend aliases.
+    to list available backend instances.
 
     Args:
         name: alias under which backend class is registered
@@ -88,9 +90,9 @@ def create(
         >>> create(
         ...     'file-system',
         ...     'host',
-        ...     'repo',
+        ...     'doctest',
         ... )
-        ('audbackend.core.filesystem.FileSystem', 'host', 'repo')
+        ('audbackend.core.filesystem.FileSystem', 'host', 'doctest')
 
     """
     if name not in backend_registry:
@@ -113,6 +115,54 @@ def create(
             repository,
         )
     return backends[name][host][repository]
+
+
+def delete(
+        name: str,
+        host: str,
+        repository: str,
+):
+    r"""Delete repository and remove backend instance.
+
+    .. warning:: Deletes the repository and all its content.
+
+    If an instance of the backend exists,
+    it will be removed from the available instances.
+    See also :func:`audbackend.available`.
+
+    Args:
+        name: alias under which backend class is registered
+        host: host address
+        repository: repository name
+
+    Raises:
+        BackendError: if an error is raised on the backend
+        ValueError: if no backend class with alias ``name``
+            has been registered
+
+    Examples:
+        >>> create(
+        ...     'file-system',
+        ...     'host',
+        ...     'doctest',
+        ... ).ls()
+        [('a.zip', '1.0.0'), ('a/b.ext', '1.0.0'), ('name.ext', '1.0.0'), ('name.ext', '2.0.0')]
+        >>> delete(
+        ...     'file-system',
+        ...     'host',
+        ...     'doctest',
+        ... )
+        >>> create(
+        ...     'file-system',
+        ...     'host',
+        ...     'doctest',
+        ... ).ls()
+        []
+
+    """  # noqa: E501
+    backend = create(name, host, repository)
+    utils.call_function_on_backend(backend._delete)
+    backends[name][host].pop(repository)
 
 
 def register(

--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -59,6 +59,12 @@ class Artifactory(Backend):
         path = path.replace('/', self.sep)
         return path
 
+    def _delete(
+            self,
+    ):
+        r"""Delete repository and all its content."""
+        self._repo.delete()
+
     def _exists(
             self,
             path: str,

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -72,6 +72,12 @@ class Backend:
             version,
         )
 
+    def _delete(
+            self,
+    ):  # pragma: no cover
+        r"""Delete repository and all its content."""
+        raise NotImplementedError()
+
     def _exists(
             self,
             path: str,

--- a/audbackend/core/filesystem.py
+++ b/audbackend/core/filesystem.py
@@ -50,6 +50,12 @@ class FileSystem(Backend):
         path = path.replace(os.path.sep, self.sep)
         return path
 
+    def _delete(
+            self,
+    ):
+        r"""Delete repository and all its content."""
+        audeer.rmdir(self._root)
+
     def _exists(
             self,
             path: str,

--- a/docs/api-src/audbackend.rst
+++ b/docs/api-src/audbackend.rst
@@ -38,5 +38,6 @@ the following classes and functions are available.
     Repository
     available
     create
+    delete
     md5
     register

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@ import pytest
 
 import audeer
 
+import audbackend
+
 
 pytest.ROOT = os.path.dirname(os.path.realpath(__file__))
 
@@ -12,11 +14,25 @@ pytest.HOSTS = {
     'file-system': os.path.join(pytest.ROOT, 'host'),
 }
 
-# list of backends that will be tested
+# list of backends that will be tested by default
 pytest.BACKENDS = [
     'artifactory',
     'file-system',
 ]
+
+
+@pytest.fixture(scope='function', autouse=False)
+def backend(request):
+
+    name = request.param
+    host = pytest.HOSTS[name]
+    repository = f'unittest-{audeer.uid()[:8]}'
+
+    backend = audbackend.create(name, host, repository)
+
+    yield backend
+
+    audbackend.delete(name, host, repository)
 
 
 @pytest.fixture(scope='package', autouse=True)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,55 @@
+import pytest
+
+import audeer
+
+import audbackend
+
+
+@pytest.mark.parametrize(
+    'name, host, repository, cls',
+    [
+        (
+            'file-system',
+            pytest.HOSTS['file-system'],
+            f'unittest-{audeer.uid()[:8]}',
+            audbackend.FileSystem,
+        ),
+        (
+            'artifactory',
+            pytest.HOSTS['artifactory'],
+            f'unittest-{audeer.uid()[:8]}',
+            audbackend.Artifactory,
+        ),
+        pytest.param(  # backend does not exist
+            'bad-backend',
+            None,
+            None,
+            None,
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        pytest.param(  # host does not exist
+            'artifactory',
+            'bad-host',
+            'repo',
+            None,
+            marks=pytest.mark.xfail(raises=audbackend.BackendError),
+        ),
+        pytest.param(  # invalid repository name
+            'artifactory',
+            pytest.HOSTS['artifactory'],
+            'bad/repo',
+            None,
+            marks=pytest.mark.xfail(raises=audbackend.BackendError),
+        ),
+    ]
+)
+def test_api(name, host, repository, cls):
+
+    backend = audbackend.create(name, host, repository)
+
+    assert isinstance(backend, cls)
+    assert backend in audbackend.available()[name]
+
+    audbackend.delete(name, host, repository)
+
+    assert backend not in audbackend.available()[name]

--- a/tests/test_artifactory.py
+++ b/tests/test_artifactory.py
@@ -4,20 +4,11 @@ import audbackend
 import audeer
 
 
-@pytest.fixture(scope='function')
-def backend(request):
-
-    backend = audbackend.Artifactory(
-        pytest.HOSTS['artifactory'],
-        f'unittest-{audeer.uid()[:8]}',
-    )
-
-    yield backend
-
-    # TODO: replace with audbackend.delete() when available
-    backend._repo.delete()
-
-
+@pytest.mark.parametrize(
+    'backend',
+    ['artifactory'],
+    indirect=True,
+)
 def test_errors(tmpdir, backend, no_artifactory_access_rights):
 
     local_file = audeer.touch(


### PR DESCRIPTION
Closes #92 

This adds `audbackend.delete()` as counterpart to `audbackend.create()`, i.e. it deletes the respository and removes the instance from the available backend instances. Since it is not directly available as function of `Backend` it avoids the problem that a user does, e.g.:

```
backend = audbackend.create(...)
backend.delete()
backend.ls()  # would fail since repository was deleted
```

![image](https://user-images.githubusercontent.com/10383417/233389874-9e2843c3-2975-482e-a302-64f5500b44f7.png)

Other changes:

* The docstring of `audbackend.available()` and `audbackend.create()` are slightly improved
* All function so the API are not tested in `tests/test_api.py`
* The fixture that generates the backend objects is moved to `tests/conftest.py` and shared by all test files