### PR TITLE
Require audeer>=1.19.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    audeer >=1.18.1
+    audeer >=1.19.0
     audfactory >=1.0.12
 setup_requires =
     setuptools_scm


### PR DESCRIPTION
In https://github.com/audeering/audbackend/pull/96 we introduced to use `audeer.list_dir_names(..., hidden=True)` which requires `audeer` >=1.19.0.