### PR TITLE
TST: add cleanup of leftover Artifactory repos

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,7 +74,7 @@ def backend(request):
     r"""Create and delete a repository on the backend."""
     name = request.param
     host = pytest.HOSTS[name]
-    repository = f'unittest-{audeer.uid()[:8]}'
+    repository = f'unittest-{pytest.UID}-{audeer.uid()[:8]}'
 
     backend = audbackend.create(name, host, repository)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,10 @@ def cleanup_artifactory():
     (https://github.com/audeering/audbackend/issues/97),
     we try to clean up the host
     everytime we run the tests.
+    If this fails
+    a ``RuntimeError`` is raised
+    and the user then needs to clean up
+    the repository manually.
 
     """
 
@@ -56,8 +60,13 @@ def cleanup_artifactory():
         for repo in repos:
             try:
                 audbackend.delete(name, host, repo)
-            except audbackend.BackendError:
-                pass
+            except audbackend.BackendError as ex:
+                raise RuntimeError(
+                    f'Cleaning up of repo {repo} failed. '
+                    f'Please try to clean up manually with: '
+                    f"'audbackend.delete({name}, {host}, {repo})' ."
+                    f'The original error message was {ex}.'
+                )
 
 
 @pytest.fixture(scope='function', autouse=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,16 +57,23 @@ def cleanup_artifactory():
             repo for repo in repos
             if repo.startswith(f'unittest-{pytest.UID}')
         ]
+        remaining_repos = repos.copy()
         for repo in repos:
             try:
                 audbackend.delete(name, host, repo)
+                remaining_repos.remove(repo)
             except audbackend.BackendError as ex:
-                raise RuntimeError(
-                    f'Cleaning up of repo {repo} failed. '
-                    f'Please try to clean up manually with: '
-                    f"'audbackend.delete({name}, {host}, {repo})' ."
-                    f'The original error message was {ex}.'
+                error_msg = (
+                    f'Cleaning up of repo {repo} failed.\n'
+                    'Please delete remaining repositories manually with:\n'
                 )
+                for remaining_repo in remaining_repos:
+                    error_msg += (
+                        f"'audbackend.delete({name}, {host}, "
+                        f"{remaining_repo})',\n"
+                    )
+                error_msg += f'The original error message was {ex}.'
+                raise RuntimeError(error_msg)
 
 
 @pytest.fixture(scope='function', autouse=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 import pytest
 
@@ -21,45 +22,62 @@ pytest.BACKENDS = [
     'file-system',
 ]
 
+# UID for test session
+# Repositories on the host will be named
+# unittest-<session-uid>-<repository-uid>
+pytest.UID = audeer.uid()[:8]
+
+
+@pytest.fixture(scope='session', autouse=True)
+def cleanup_artifactory():
+    r"""Remove letover unit test repositories on Artifactory.
+
+    As removing a unit test repsoitory
+    in the ``backend()`` fixture
+    might fail
+    (https://github.com/audeering/audbackend/issues/97),
+    we try to clean up the host
+    everytime we run the tests.
+
+    """
+
+    yield
+
+    # Delete leftover repositories
+    name = 'artifactory'
+    host = pytest.HOSTS[name]
+    r = audfactory.rest_api_get(f'{host}/api/repositories')
+    if r.status_code == 200:
+        repos = [entry['key'] for entry in r.json()]
+        repos = [
+            repo for repo in repos
+            if repo.startswith(f'unittest-{pytest.UID}')
+        ]
+        for repo in repos:
+            try:
+                audbackend.delete(name, host, repo)
+            except audbackend.BackendError:
+                pass
+
 
 @pytest.fixture(scope='function', autouse=False)
 def backend(request):
-    r"""Create and delete a repository on the backend.
-
-    Deleting a repository might fail on Artifactory hosts,
-    hence we catch the error
-    and instead look for leftover repositories
-    at the beginning and clean try to clean them.
-
-    """
+    r"""Create and delete a repository on the backend."""
     name = request.param
     host = pytest.HOSTS[name]
     repository = f'unittest-{audeer.uid()[:8]}'
-
-    # Clean up possible left over repos on Artifactory host
-    if name == 'artifactory':
-        r = audfactory.rest_api_get(f'{host}/api/repositories')
-        if r.status_code == 200:
-            repos = [entry['key'] for entry in r.json()]
-            repos = [
-                repo for repo in repos
-                if repo != 'unittests-public' and repo.startswith('unittest-')
-            ]
-            for repo in repos:
-                try:
-                    audbackend.delete(name, host, repo)
-                except audbackend.BackendError:
-                    pass
 
     backend = audbackend.create(name, host, repository)
 
     yield backend
 
     # Deleting repositories on Artifactory might fail
-    try:
-        audbackend.delete(name, host, repository)
-    except audbackend.BackendError:
-        pass
+    for _ in range(3):
+        try:
+            audbackend.delete(name, host, repository)
+            break
+        except audbackend.BackendError:
+            time.sleep(1)
 
 
 @pytest.fixture(scope='package', autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 import audeer
+import audfactory
 
 import audbackend
 
@@ -23,16 +24,42 @@ pytest.BACKENDS = [
 
 @pytest.fixture(scope='function', autouse=False)
 def backend(request):
+    r"""Create and delete a repository on the backend.
 
+    Deleting a repository might fail on Artifactory hosts,
+    hence we catch the error
+    and instead look for leftover repositories
+    at the beginning and clean try to clean them.
+
+    """
     name = request.param
     host = pytest.HOSTS[name]
     repository = f'unittest-{audeer.uid()[:8]}'
+
+    # Clean up possible left over repos on Artifactory host
+    if name == 'artifactory':
+        r = audfactory.rest_api_get(f'{host}/api/repositories')
+        if r.status_code == 200:
+            repos = [entry['key'] for entry in r.json()]
+            repos = [
+                repo for repo in repos
+                if repo != 'unittests-public' and repo.startswith('unittest-')
+            ]
+            for repo in repos:
+                try:
+                    audbackend.delete(name, host, repo)
+                except audbackend.BackendError:
+                    pass
 
     backend = audbackend.create(name, host, repository)
 
     yield backend
 
-    audbackend.delete(name, host, repository)
+    # Deleting repositories on Artifactory might fail
+    try:
+        audbackend.delete(name, host, repository)
+    except audbackend.BackendError:
+        pass
 
 
 @pytest.fixture(scope='package', autouse=True)


### PR DESCRIPTION
Closes #97 

This introduces two steps to try to remove repositories on Artifactory

* It tries up to 3 times to remove the repo and catches `BackendErrors` in the `backend()` fixture. After that it raises a `RuntimeError` and asks the user to manually delete the repo.
* In addition, it adds a session UID to the repo name, so it is easier to recognize remaining repositories on the host