### PR TITLE
TST: let pytest handle tmp dirs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,10 +21,10 @@ pytest.UID = audeer.uid()[:8]
 
 
 @pytest.fixture(scope='session', autouse=False)
-def hosts(tmp_path_factory):
+def hosts(tmpdir_factory):
     return {
         'artifactory': 'https://audeering.jfrog.io/artifactory',
-        'file-system': tmp_path_factory.mktemp('host').as_posix(),
+        'file-system': str(tmpdir_factory.mktemp('host')),
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ pytest.BACKENDS = [
 pytest.UID = audeer.uid()[:8]
 
 
-@pytest.fixture(scope='session', autouse=False)
+@pytest.fixture(scope='package', autouse=False)
 def hosts(tmpdir_factory):
     return {
         'artifactory': 'https://audeering.jfrog.io/artifactory',

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,13 +10,13 @@ import audbackend
     [
         (
             'file-system',
-            pytest.HOSTS['file-system'],
+            'file-system',
             f'unittest-{audeer.uid()[:8]}',
             audbackend.FileSystem,
         ),
         (
             'artifactory',
-            pytest.HOSTS['artifactory'],
+            'artifactory',
             f'unittest-{audeer.uid()[:8]}',
             audbackend.Artifactory,
         ),
@@ -36,14 +36,17 @@ import audbackend
         ),
         pytest.param(  # invalid repository name
             'artifactory',
-            pytest.HOSTS['artifactory'],
+            'artifactory',
             'bad/repo',
             None,
             marks=pytest.mark.xfail(raises=audbackend.BackendError),
         ),
     ]
 )
-def test_api(name, host, repository, cls):
+def test_api(hosts, name, host, repository, cls):
+
+    if host is not None and host in hosts:
+        host = hosts[name]
 
     error_msg = (
         "A backend class with name 'bad' does not exist."


### PR DESCRIPTION
This removes creating the file-system host in the current folder, but use a pytest temp folder instead.