### PR TITLE
Remove dependency to audfactory

### DIFF
--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -114,7 +114,8 @@ class Artifactory(Backend):
     ) -> str:
         r"""MD5 checksum of file on backend."""
         path = self._path(path, version)
-        return audfactory.checksum(str(path))
+        checksum = artifactory.ArtifactoryPath.stat(path).md5
+        return checksum
 
     def _collapse(
             self,
@@ -215,7 +216,11 @@ class Artifactory(Backend):
 
             root, _ = self.split(path)
             root = self._expand(root)
-            root = audfactory.path(root)
+            root = _artifactory_path(
+                root,
+                self._username,
+                self._apikey,
+            )
             vs = [os.path.basename(str(f)) for f in root if f.is_dir]
 
             # filter out other files with same root and version

--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -102,11 +102,8 @@ def _deploy(
 
     if not dst_path.parent.exists():
         dst_path.parent.mkdir()
-    with open(src_path, "rb") as fobj:
-        dst_path.deploy(
-            fobj,
-            md5=md5,
-        )
+    with open(src_path, 'rb') as fd:
+        dst_path.deploy(fd, md5=md5)
 
     if verbose:  # pragma: no cover
         # Final clearing of progress line
@@ -119,7 +116,7 @@ def _download(
         *,
         chunk: int = 4 * 1024,
         verbose=False,
-) -> str:
+):
     r"""Download an artifact.
 
     Args:
@@ -150,10 +147,10 @@ def _download(
                             dst_fp.write(data)
                             dst_size += n_data
                             pbar.update(n_data)
-        except (KeyboardInterrupt, Exception):
+        except (KeyboardInterrupt, Exception):  # pragma: no cover
             # Clean up broken artifact files
             if os.path.exists(dst_path):
-                os.remove(dst_path)  # pragma: no cover
+                os.remove(dst_path)
             raise
 
 

--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -5,7 +5,6 @@ import artifactory
 import dohq_artifactory
 
 import audeer
-import audfactory
 
 from audbackend.core import utils
 from audbackend.core.backend import Backend

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ classifiers =
 packages = find:
 install_requires =
     audeer >=1.19.0
-    audfactory >=1.0.12
+    dohq-artifactory >=0.8.1
 setup_requires =
     setuptools_scm
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,20 +65,3 @@ def cleanup_coverage():
     )
     for file in audeer.list_file_names(path):
         os.remove(file)
-
-
-@pytest.fixture(scope='function', autouse=False)
-def no_artifactory_access_rights():
-    current_username = os.environ.get('ARTIFACTORY_USERNAME', False)
-    current_api_key = os.environ.get('ARTIFACTORY_API_KEY', False)
-    os.environ['ARTIFACTORY_USERNAME'] = 'non-existing-user'
-    os.environ['ARTIFACTORY_API_KEY'] = 'non-existing-password'
-    yield
-    if current_username:
-        os.environ["ARTIFACTORY_USERNAME"] = current_username
-    else:
-        del os.environ['ARTIFACTORY_USERNAME']
-    if current_api_key:
-        os.environ['ARTIFACTORY_API_KEY'] = current_api_key
-    else:
-        del os.environ['ARTIFACTORY_API_KEY']

--- a/tests/test_artifactory.py
+++ b/tests/test_artifactory.py
@@ -9,7 +9,10 @@ import audeer
     ['artifactory'],
     indirect=True,
 )
-def test_errors(tmpdir, backend, no_artifactory_access_rights):
+def test_errors(tmpdir, backend):
+
+    backend._username = 'non-existing'
+    backend._apikey = 'non-existing'
 
     local_file = audeer.touch(
         audeer.path(tmpdir, 'file.txt')


### PR DESCRIPTION
Closes #50 #90 

* The functions to authenticate and download / deploy an artifact are extracted from `audfactory` and implemented in the `Artifactory` class
* Authentication done only once when the backend is created and re-used afterwards
* The dependency to `audfactory` is removed and a dependency to `dohq-artifactory` is set instead

