### PR TITLE
TST: correcting suggested repo cleanup command

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,7 @@ def backend(hosts, request):
                 error_msg = (
                     f'Cleaning up of repo {repository} failed.\n'
                     'Please delete remaining repositories manually with:\n'
-                    f"'audbackend.delete({name}, {host}, {repository})'"
+                    f"audbackend.delete('{name}', '{host}', '{repository}')"
                 )
                 raise RuntimeError(error_msg)
             time.sleep(1)


### PR DESCRIPTION
Seeing

![image](https://user-images.githubusercontent.com/173624/234821969-cc8c783a-8794-4540-99ad-8b5d64436e5d.png)

I realized that we forgot `''` in the suggested command, which is fixed in this pull request.