### PR TITLE
put_file(): pass checksum to implementation

### DIFF
--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -55,6 +55,7 @@ def _authentication(host) -> typing.Tuple[str, str]:
 def _deploy(
         src_path: str,
         dst_path: artifactory.ArtifactoryPath,
+        checksum: str,
         *,
         verbose: bool = False,
 ):
@@ -70,9 +71,8 @@ def _deploy(
     if not dst_path.parent.exists():
         dst_path.parent.mkdir()
 
-    md5 = utils.md5(src_path)
     with open(src_path, 'rb') as fd:
-        dst_path.deploy(fd, md5=md5)
+        dst_path.deploy(fd, md5=checksum)
 
     if verbose:  # pragma: no cover
         # Clear progress line
@@ -331,11 +331,12 @@ class Artifactory(Backend):
             src_path: str,
             dst_path: str,
             version: str,
+            checksum: str,
             verbose: bool,
     ):
         r"""Put file to backend."""
         dst_path = self._path(dst_path, version)
-        _deploy(src_path, dst_path, verbose=verbose)
+        _deploy(src_path, dst_path, checksum, verbose=verbose)
 
     def _remove_file(
             self,

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -534,6 +534,7 @@ class Backend:
             src_path: str,
             dst_path: str,
             version: str,
+            checksum: str,
             verbose: bool,
     ):  # pragma: no cover
         r"""Put file to backend."""
@@ -580,16 +581,19 @@ class Backend:
         if not os.path.exists(src_path):
             utils.raise_file_not_found_error(src_path)
 
+        checksum = utils.md5(src_path)
+
         # skip if file with same checksum already exists
-        if not (
-            self.exists(dst_path, version)
-            and self.checksum(dst_path, version) == utils.md5(src_path)
+        if (
+            not self.exists(dst_path, version)
+            or self.checksum(dst_path, version) != checksum
         ):
             utils.call_function_on_backend(
                 self._put_file,
                 src_path,
                 dst_path,
                 version,
+                checksum,
                 verbose,
             )
 

--- a/audbackend/core/filesystem.py
+++ b/audbackend/core/filesystem.py
@@ -182,6 +182,7 @@ class FileSystem(Backend):
             src_path: str,
             dst_path: str,
             version: str,
+            checksum: str,
             verbose: bool,
     ):
         r"""Put file to backend."""


### PR DESCRIPTION
In `put_file()` we calculate the checksum to determine if the same file already exists on the backend. If the check fails, we can pass the checksum on to the backend to avoid it is calculated again or differently.