### PR TITLE
Calculate md5 with audeer

### DIFF
--- a/audbackend/__init__.py
+++ b/audbackend/__init__.py
@@ -10,7 +10,6 @@ from audbackend.core.backend import Backend
 from audbackend.core.errors import BackendError
 from audbackend.core.filesystem import FileSystem
 from audbackend.core.repository import Repository
-from audbackend.core.utils import md5
 
 
 __all__ = []

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -274,7 +274,7 @@ class Backend:
 
         if (
             not os.path.exists(dst_path)
-            or utils.md5(dst_path) != self.checksum(src_path, version)
+            or audeer.md5(dst_path) != self.checksum(src_path, version)
         ):
             utils.call_function_on_backend(
                 self._get_file,
@@ -588,7 +588,7 @@ class Backend:
         if not os.path.exists(src_path):
             utils.raise_file_not_found_error(src_path)
 
-        checksum = utils.md5(src_path)
+        checksum = audeer.md5(src_path)
 
         # skip if file with same checksum already exists
         if (

--- a/audbackend/core/filesystem.py
+++ b/audbackend/core/filesystem.py
@@ -38,7 +38,7 @@ class FileSystem(Backend):
     ) -> str:
         r"""MD5 checksum of file on backend."""
         path = self._path(path, version)
-        return utils.md5(path)
+        return audeer.md5(path)
 
     def _collapse(
             self,

--- a/audbackend/core/utils.py
+++ b/audbackend/core/utils.py
@@ -55,43 +55,6 @@ def check_path(path, sep) -> str:
     return path
 
 
-def md5(
-        file: str,
-        chunk_size: int = 8192,
-) -> str:
-    r"""Calculate MD5 checksum.
-
-    Args:
-        file: path to file
-        chunk_size: chunk size (does not have an influence on the result)
-
-    Returns:
-        checksum
-
-    Examples:
-        >>> md5('src.pth')
-        'd41d8cd98f00b204e9800998ecf8427e'
-
-    """
-    file = audeer.path(file)
-    with open(file, 'rb') as fp:
-        hasher = hashlib.md5()
-        for chunk in md5_read_chunk(fp, chunk_size):
-            hasher.update(chunk)
-        return hasher.hexdigest()
-
-
-def md5_read_chunk(
-        fp: typing.IO,
-        chunk_size: int = 8192,
-):
-    while True:
-        data = fp.read(chunk_size)
-        if not data:
-            break
-        yield data
-
-
 def raise_file_exists_error(path: str):
     raise FileExistsError(
         errno.EEXIST,

--- a/audbackend/core/utils.py
+++ b/audbackend/core/utils.py
@@ -1,10 +1,7 @@
 import errno
-import hashlib
 import os
 import re
 import typing
-
-import audeer
 
 from audbackend.core.errors import BackendError
 

--- a/docs/api-src/audbackend.rst
+++ b/docs/api-src/audbackend.rst
@@ -40,5 +40,4 @@ the following classes and functions are available.
     available
     create
     delete
-    md5
     register

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -416,7 +416,7 @@ def test_file(tmpdir, src_path, dst_path, version, backend):
 
     backend.get_file(dst_path, src_path, version)
     assert os.path.exists(src_path)
-    assert backend.checksum(dst_path, version) == audbackend.md5(src_path)
+    assert backend.checksum(dst_path, version) == audeer.md5(src_path)
 
     backend.remove_file(dst_path, version)
     assert not backend.exists(dst_path, version)


### PR DESCRIPTION
This removes `audbackend.md5`. 

Usually we would probably deprecate it first, but since we have so many breaking changes, I guess it's fine to remove it.