### PR TITLE
Update to audeer>=1.20.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    audeer >=1.19.0
+    audeer >=1.20.0
     dohq-artifactory >=0.8.1
 setup_requires =
     setuptools_scm

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -59,7 +59,13 @@ def test_archive(tmpdir, files, name, folder, version, tmp_root, backend):
     if tmp_root is not None:
         tmp_root = audeer.path(tmpdir, tmp_root)
 
-    files_as_list = [files] if isinstance(files, str) else files
+    if os.name == 'nt':
+        if isinstance(files, str):
+            files = files.replace('/', os.sep)
+        elif files:
+            files = [file.replace('/', os.sep) for file in files]
+
+    files_as_list = audeer.to_list(files)
     for file in files_as_list:
         path = os.path.join(tmpdir, file)
         audeer.mkdir(os.path.dirname(path))


### PR DESCRIPTION
With `audeer>=1.20.0` we can now rely on `audeer.md5` and use `files=None` with `audeer.create_archive()`.