### PR TITLE
Check version argument

### DIFF
--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -75,7 +75,8 @@ class Backend:
             'd41d8cd98f00b204e9800998ecf8427e'
 
         """
-        path = utils.check_path(path, self.sep)
+        path = utils.check_path(path)
+        version = utils.check_version(version)
 
         return utils.call_function_on_backend(
             self._checksum,
@@ -138,7 +139,8 @@ class Backend:
             True
 
         """
-        path = utils.check_path(path, self.sep)
+        path = utils.check_path(path)
+        version = utils.check_version(version)
 
         return utils.call_function_on_backend(
             self._exists,
@@ -190,7 +192,8 @@ class Backend:
             ['src.pth']
 
         """
-        src_path = utils.check_path(src_path, self.sep)
+        src_path = utils.check_path(src_path)
+        version = utils.check_version(version)
 
         with tempfile.TemporaryDirectory(dir=tmp_root) as tmp:
 
@@ -260,7 +263,8 @@ class Backend:
             True
 
         """
-        src_path = utils.check_path(src_path, self.sep)
+        src_path = utils.check_path(src_path)
+        version = utils.check_version(version)
 
         dst_path = audeer.path(dst_path)
         dst_root = os.path.dirname(dst_path)
@@ -315,13 +319,13 @@ class Backend:
             '/sub/f.ext'
 
         """
-        path = utils.check_path(path, self.sep)
+        path = utils.check_path(path)
 
         paths = [path] + [p for p in paths]
         paths = [path for path in paths if path]  # remove empty or None
         path = self.sep.join(paths)
 
-        path = utils.check_path(path, self.sep)
+        path = utils.check_path(path)
 
         return path
 
@@ -348,7 +352,7 @@ class Backend:
             '2.0.0'
 
         """
-        path = utils.check_path(path, self.sep)
+        path = utils.check_path(path)
         vs = self.versions(path)
         return vs[-1]
 
@@ -425,7 +429,7 @@ class Backend:
             [('/a/b.ext', '1.0.0')]
 
         """  # noqa: E501
-        path = utils.check_path(path, self.sep)
+        path = utils.check_path(path)
         paths = utils.call_function_on_backend(
             self._ls,
             path,
@@ -507,7 +511,8 @@ class Backend:
             True
 
         """
-        dst_path = utils.check_path(dst_path, self.sep)
+        dst_path = utils.check_path(dst_path)
+        version = utils.check_version(version)
         src_root = audeer.path(src_root)
 
         if tmp_root is not None:
@@ -580,7 +585,9 @@ class Backend:
             True
 
         """
-        dst_path = utils.check_path(dst_path, self.sep)
+        dst_path = utils.check_path(dst_path)
+        version = utils.check_version(version)
+
         if not os.path.exists(src_path):
             utils.raise_file_not_found_error(src_path)
 
@@ -633,7 +640,8 @@ class Backend:
             False
 
         """
-        path = utils.check_path(path, self.sep)
+        path = utils.check_path(path)
+        version = utils.check_version(version)
 
         utils.call_function_on_backend(
             self._remove_file,
@@ -644,7 +652,7 @@ class Backend:
     @property
     def sep(self) -> str:
         r"""File separator on backend."""
-        return '/'
+        return utils.BACKEND_SEPARATOR
 
     def split(
             self,
@@ -673,7 +681,7 @@ class Backend:
             ('/sub/', 'f.ext')
 
         """
-        path = utils.check_path(path, self.sep)
+        path = utils.check_path(path)
 
         root = self.sep.join(path.split(self.sep)[:-1]) + self.sep
         basename = path.split(self.sep)[-1]

--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -67,8 +67,10 @@ class Backend:
         Raises:
             BackendError: if an error is raised on the backend,
                 e.g. ``path`` does not exist
-            ValueError: if ``path`` contains invalid character
-                or does not start with ``'/'``
+            ValueError: if ``path`` does not start with ``'/'`` or
+                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``version`` is empty or
+                does not match ``'[A-Za-z0-9._-]+'``
 
         Examples:
             >>> backend.checksum('/f.ext', '1.0.0')
@@ -131,8 +133,10 @@ class Backend:
             BackendError: if ``suppress_backend_errors`` is ``False``
                 and an error is raised on the backend,
                 e.g. ``path`` does not exist
-            ValueError: if ``path`` contains invalid character
-                or does not start with ``'/'``
+            ValueError: if ``path`` does not start with ``'/'`` or
+                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``version`` is empty or
+                does not match ``'[A-Za-z0-9._-]+'``
 
         Examples:
             >>> backend.exists('/f.ext', '1.0.0')
@@ -184,8 +188,10 @@ class Backend:
                 for ``dst_path``
             RuntimeError: if extension of ``src_path`` is not supported
                 or ``src_path`` is a malformed archive
-            ValueError: if ``src_path`` contains invalid character
-                or does not start with ``'/'``
+            ValueError: if ``src_path`` does not start with ``'/'`` or
+                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``version`` is empty or
+                does not match ``'[A-Za-z0-9._-]+'``
 
         Examples:
             >>> backend.get_archive('/a.zip', '.', '1.0.0')
@@ -252,8 +258,10 @@ class Backend:
                 e.g. ``src_path`` does not exist
             PermissionError: if the user lacks write permissions
                 for ``dst_path``
-            ValueError: if ``src_path`` contains invalid character
-                or does not start with ``'/'``
+            ValueError: if ``src_path`` does not start with ``'/'`` or
+                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``version`` is empty or
+                does not match ``'[A-Za-z0-9._-]+'``
 
         Examples:
             >>> os.path.exists('dst.pth')
@@ -344,8 +352,8 @@ class Backend:
         Raises:
             BackendError: if an error is raised on the backend,
                 e.g. ``path`` does not exist
-            ValueError: if ``path`` contains invalid character
-                or does not start with ``'/'``
+            ValueError: if ``path`` does not start with ``'/'`` or
+                does not match ``'[A-Za-z0-9/._-]+'``
 
         Examples:
             >>> backend.latest_version('/f.ext')
@@ -413,8 +421,8 @@ class Backend:
             BackendError: if ``suppress_backend_errors`` is ``False``
                 and an error is raised on the backend,
                 e.g. ``path`` does not exist
-            ValueError: if ``path`` contains invalid character
-                or does not start with ``'/'``
+            ValueError: if ``path`` does not start with ``'/'`` or
+                does not match ``'[A-Za-z0-9/._-]+'``
 
         Examples:
             >>> backend.ls()
@@ -500,8 +508,10 @@ class Backend:
             RuntimeError: if ``dst_path`` does not end with
                 ``zip`` or ``tar.gz``
                 or a file in ``files`` is not below ``root``
-            ValueError: if ``dst_path`` contains invalid character
-                or does not start with ``'/'``
+            ValueError: if ``dst_path`` does not start with ``'/'`` or
+                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``version`` is empty or
+                does not match ``'[A-Za-z0-9._-]+'``
 
         Examples:
             >>> backend.exists('/a.tar.gz', '1.0.0')
@@ -574,8 +584,10 @@ class Backend:
         Raises:
             BackendError: if an error is raised on the backend
             FileNotFoundError: if ``src_path`` does not exist
-            ValueError: if ``dst_path`` contains invalid character
-                or does not start with ``'/'``
+            ValueError: if ``dst_path`` does not start with ``'/'`` or
+                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``version`` is empty or
+                does not match ``'[A-Za-z0-9._-]+'``
 
         Examples:
             >>> backend.exists('/sub/f.ext', '3.0.0')
@@ -629,8 +641,10 @@ class Backend:
         Raises:
             BackendError: if an error is raised on the backend,
                 e.g. ``path`` does not exist
-            ValueError: if ``path`` contains invalid character
-                or does not start with ``'/'``
+            ValueError: if ``path`` does not start with ``'/'`` or
+                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``version`` is empty or
+                does not match ``'[A-Za-z0-9._-]+'``
 
         Examples:
             >>> backend.exists('/f.ext', '1.0.0')
@@ -667,8 +681,8 @@ class Backend:
             tuple containing (root, basename)
 
         Raises:
-            ValueError: if ``path`` contains invalid character
-                or does not start with ``'/'``
+            ValueError: if ``path`` does not start with ``'/'`` or
+                does not match ``'[A-Za-z0-9/._-]+'``
 
         Examples:
             >>> backend.split('/')
@@ -709,8 +723,8 @@ class Backend:
             BackendError: if ``suppress_backend_errors`` is ``False``
                 and an error is raised on the backend,
                 e.g. ``path`` does not exist
-            ValueError: if ``path`` contains invalid character
-                or does not start with ``'/'``
+            ValueError: if ``path`` does not start with ``'/'`` or
+                does not match ``'[A-Za-z0-9/._-]+'``
 
         Examples:
             >>> backend.versions('/f.ext')

--- a/audbackend/core/utils.py
+++ b/audbackend/core/utils.py
@@ -43,7 +43,7 @@ def check_path(path: str) -> str:
     if path and BACKEND_ALLOWED_CHARS_COMPILED.fullmatch(path) is None:
         raise ValueError(
             f"Invalid backend path '{path}', "
-            f"allowed characters are {BACKEND_ALLOWED_CHARS[:-1]}."
+            f"does not match '{BACKEND_ALLOWED_CHARS}'."
         )
 
     # Remove immediately consecutive seps
@@ -66,7 +66,7 @@ def check_version(version: str) -> str:
     if VERSION_ALLOWED_CHARS_COMPILED.fullmatch(version) is None:
         raise ValueError(
             f"Invalid version '{version}', "
-            f"allowed characters are {VERSION_ALLOWED_CHARS[:-1]}."
+            f"does not match '{VERSION_ALLOWED_CHARS}'."
         )
 
     return version

--- a/audbackend/core/utils.py
+++ b/audbackend/core/utils.py
@@ -9,6 +9,11 @@ from audbackend.core.errors import BackendError
 BACKEND_ALLOWED_CHARS = '[A-Za-z0-9/._-]+'
 BACKEND_ALLOWED_CHARS_COMPILED = re.compile(BACKEND_ALLOWED_CHARS)
 
+BACKEND_SEPARATOR = '/'
+
+VERSION_ALLOWED_CHARS = BACKEND_ALLOWED_CHARS.replace(BACKEND_SEPARATOR, '')
+VERSION_ALLOWED_CHARS_COMPILED = re.compile(VERSION_ALLOWED_CHARS)
+
 
 def call_function_on_backend(
         function: typing.Callable,
@@ -26,30 +31,45 @@ def call_function_on_backend(
             raise BackendError(ex)
 
 
-def check_path(path, sep) -> str:
+def check_path(path: str) -> str:
     r"""Check path."""
 
     # Assert path starts with sep and does not contain invalid characters.
-    if not path.startswith(sep):
+    if not path.startswith(BACKEND_SEPARATOR):
         raise ValueError(
             f"Invalid backend path '{path}', "
-            f"must start with '{sep}'."
+            f"must start with '{BACKEND_SEPARATOR}'."
         )
     if path and BACKEND_ALLOWED_CHARS_COMPILED.fullmatch(path) is None:
         raise ValueError(
             f"Invalid backend path '{path}', "
-            f"allowed characters are '{BACKEND_ALLOWED_CHARS}'."
+            f"allowed characters are {BACKEND_ALLOWED_CHARS[:-1]}."
         )
 
     # Remove immediately consecutive seps
-    is_sub_path = path.endswith(sep)
-    paths = path.split(sep)
+    is_sub_path = path.endswith(BACKEND_SEPARATOR)
+    paths = path.split(BACKEND_SEPARATOR)
     paths = [path for path in paths if path]
-    path = sep + sep.join(paths)
-    if is_sub_path and not path.endswith(sep):
-        path += sep
+    path = BACKEND_SEPARATOR + BACKEND_SEPARATOR.join(paths)
+    if is_sub_path and not path.endswith(BACKEND_SEPARATOR):
+        path += BACKEND_SEPARATOR
 
     return path
+
+
+def check_version(version: str) -> str:
+    r"""Check version."""
+
+    # Assert version is not empty and does not contain invalid characters.
+    if not version:
+        raise ValueError('Version must not be empty.')
+    if VERSION_ALLOWED_CHARS_COMPILED.fullmatch(version) is None:
+        raise ValueError(
+            f"Invalid version '{version}', "
+            f"allowed characters are {VERSION_ALLOWED_CHARS[:-1]}."
+        )
+
+    return version
 
 
 def raise_file_exists_error(path: str):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -181,7 +181,7 @@ def test_errors(tmpdir, backend):
     file_invalid_char = '/invalid/char.txt?'
     error_invalid_char = re.escape(
         f"Invalid backend path '{file_invalid_char}', "
-        f"allowed characters are [A-Za-z0-9/._-]."
+        f"does not match '[A-Za-z0-9/._-]+'."
     )
     error_backend = (
         'An exception was raised by the backend, '
@@ -198,7 +198,7 @@ def test_errors(tmpdir, backend):
     invalid_version = '1.0.?'
     error_invalid_version = re.escape(
         f"Invalid version '{invalid_version}', "
-        f"allowed characters are [A-Za-z0-9._-]."
+        f"does not match '[A-Za-z0-9._-]+'."
     )
 
     # --- checksum ---

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -160,10 +160,10 @@ def test_errors(tmpdir, backend):
     # Ensure we have one file and one archive published on the backend
     archive = '/archive.zip'
     local_file = 'file.txt'
+    local_path = audeer.touch(audeer.path(tmpdir, local_file))
     remote_file = f'/{local_file}'
     version = '1.0.0'
-    src_path = audeer.touch(audeer.path(tmpdir, local_file))
-    backend.put_file(src_path, remote_file, version)
+    backend.put_file(local_path, remote_file, version)
     backend.put_archive(tmpdir, archive, version, files=[local_file])
 
     # Create local read-only file and folder
@@ -172,8 +172,7 @@ def test_errors(tmpdir, backend):
     folder_read_only = audeer.mkdir(audeer.path(tmpdir, 'read-only-folder'))
     os.chmod(folder_read_only, stat.S_IRUSR)
 
-    # File names and error messages
-    # for common errors
+    # Invalid file names / versions and error messages
     file_invalid_path = 'invalid/path.txt'
     error_invalid_path = re.escape(
         f"Invalid backend path '{file_invalid_path}', "
@@ -182,7 +181,7 @@ def test_errors(tmpdir, backend):
     file_invalid_char = '/invalid/char.txt?'
     error_invalid_char = re.escape(
         f"Invalid backend path '{file_invalid_char}', "
-        f"allowed characters are '[A-Za-z0-9/._-]+'."
+        f"allowed characters are [A-Za-z0-9/._-]."
     )
     error_backend = (
         'An exception was raised by the backend, '
@@ -194,6 +193,13 @@ def test_errors(tmpdir, backend):
     error_read_only_file = (
         f"Permission denied: '{file_read_only}'"
     )
+    empty_version = ''
+    error_empty_version = 'Version must not be empty.'
+    invalid_version = '1.0.?'
+    error_invalid_version = re.escape(
+        f"Invalid version '{invalid_version}', "
+        f"allowed characters are [A-Za-z0-9._-]."
+    )
 
     # --- checksum ---
     # `path` missing
@@ -202,6 +208,11 @@ def test_errors(tmpdir, backend):
     # `path` contains invalid character
     with pytest.raises(ValueError, match=error_invalid_char):
         backend.checksum(file_invalid_char, version)
+    # invalid version
+    with pytest.raises(ValueError, match=error_empty_version):
+        backend.checksum(remote_file, empty_version)
+    with pytest.raises(ValueError, match=error_invalid_version):
+        backend.checksum(remote_file, invalid_version)
 
     # --- exists ---
     # `path` without leading '/'
@@ -210,6 +221,11 @@ def test_errors(tmpdir, backend):
     # `path` contains invalid character
     with pytest.raises(ValueError, match=error_invalid_char):
         backend.exists(file_invalid_char, version)
+    # invalid version
+    with pytest.raises(ValueError, match=error_empty_version):
+        backend.exists(remote_file, empty_version)
+    with pytest.raises(ValueError, match=error_invalid_version):
+        backend.exists(remote_file, invalid_version)
 
     # --- get_archive ---
     # `src_path` missing
@@ -221,6 +237,11 @@ def test_errors(tmpdir, backend):
     # `src_path` contains invalid character
     with pytest.raises(ValueError, match=error_invalid_char):
         backend.get_archive(file_invalid_char, tmpdir, version)
+    # invalid version
+    with pytest.raises(ValueError, match=error_empty_version):
+        backend.get_archive(archive, tmpdir, empty_version)
+    with pytest.raises(ValueError, match=error_invalid_version):
+        backend.get_archive(archive, tmpdir, invalid_version)
     # `tmp_root` does not exist
     if platform.system() == 'Windows':
         error_msg = (
@@ -264,6 +285,11 @@ def test_errors(tmpdir, backend):
     # `src_path` contains invalid character
     with pytest.raises(ValueError, match=error_invalid_char):
         backend.get_file(file_invalid_char, tmpdir, version)
+    # invalid version
+    with pytest.raises(ValueError, match=error_empty_version):
+        backend.get_file(remote_file, local_file, empty_version)
+    with pytest.raises(ValueError, match=error_invalid_version):
+        backend.get_file(remote_file, local_file, invalid_version)
     # no write permissions to `dst_path`
     if not platform.system() == 'Windows':
         # Currently we don't know how to provoke permission error on Windows
@@ -333,6 +359,11 @@ def test_errors(tmpdir, backend):
             version,
             files=local_file,
         )
+    # invalid version
+    with pytest.raises(ValueError, match=error_empty_version):
+        backend.put_archive(tmpdir, archive, empty_version)
+    with pytest.raises(ValueError, match=error_invalid_version):
+        backend.put_archive(tmpdir, archive, invalid_version)
     # extension of `dst_path` is not supported
     error_msg = 'You can only create a ZIP or TAR.GZ archive, not ...'
     with pytest.raises(RuntimeError, match=error_msg):
@@ -349,10 +380,15 @@ def test_errors(tmpdir, backend):
         )
     # `dst_path` without leading '/'
     with pytest.raises(ValueError, match=error_invalid_path):
-        backend.put_file(src_path, file_invalid_path, version)
+        backend.put_file(local_path, file_invalid_path, version)
     # `dst_path` contains invalid character
     with pytest.raises(ValueError, match=error_invalid_char):
-        backend.put_file(src_path, file_invalid_char, version)
+        backend.put_file(local_path, file_invalid_char, version)
+    # invalid version
+    with pytest.raises(ValueError, match=error_empty_version):
+        backend.put_file(local_path, remote_file, empty_version)
+    with pytest.raises(ValueError, match=error_invalid_version):
+        backend.put_file(local_path, remote_file, invalid_version)
 
     # --- remove_file ---
     # `path` does not exists
@@ -364,6 +400,11 @@ def test_errors(tmpdir, backend):
     # `path` contains invalid character
     with pytest.raises(ValueError, match=error_invalid_char):
         backend.remove_file(file_invalid_char, version)
+    # invalid version
+    with pytest.raises(ValueError, match=error_empty_version):
+        backend.remove_file(remote_file, empty_version)
+    with pytest.raises(ValueError, match=error_invalid_version):
+        backend.remove_file(remote_file, invalid_version)
 
     # --- split ---
     # `path` without leading '/'


### PR DESCRIPTION
Closes #https://github.com/audeering/audbackend/issues/101

* Checks that version matches `[A-Za-z0-9._-]+`
* Hard codes backend separator (`/`) in `utils.py` (otherwise we cannot compile the regex expression)
* More verbose error message

## Example

![image](https://user-images.githubusercontent.com/10383417/235757775-e1cb51d4-1f97-498a-b7ba-8c978418378d.png)
