### PR TITLE
put_archive(): raise NotADirectoryError

### DIFF
--- a/audbackend/core/backend.py
+++ b/audbackend/core/backend.py
@@ -519,6 +519,7 @@ class Backend:
             FileNotFoundError: if ``src_root``,
                 ``tmp_root``,
                 or one or more ``files`` do not exist
+            NotADirectoryError: if ``src_root`` is not a folder
             RuntimeError: if ``dst_path`` does not end with
                 ``zip`` or ``tar.gz``
                 or a file in ``files`` is not below ``root``

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -271,12 +271,12 @@ def test_errors(tmpdir, backend):
     )
     with pytest.raises(RuntimeError, match=error_msg):
         backend.get_archive('/malformed.zip', tmpdir, version)
-    # no write permissions to `dst_path`
+    # no write permissions to `dst_root`
     if not platform.system() == 'Windows':
         # Currently we don't know how to provoke permission error on Windows
         with pytest.raises(PermissionError, match=error_read_only_folder):
             backend.get_archive(archive, folder_read_only, version)
-    # `dst_path` is not a directory
+    # `dst_root` is not a directory
     with pytest.raises(NotADirectoryError, match=error_not_a_folder):
         backend.get_archive(archive, local_path, version)
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -201,7 +201,7 @@ def test_errors(tmpdir, backend):
         f"Invalid version '{invalid_version}', "
         f"does not match '[A-Za-z0-9._-]+'."
     )
-    error_not_a_folder = f"Not a directory: '{local_path}'"
+    error_not_a_folder = re.escape(f"Not a directory: '{local_path}'")
 
     # --- checksum ---
     # `path` missing

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -201,7 +201,10 @@ def test_errors(tmpdir, backend):
         f"Invalid version '{invalid_version}', "
         f"does not match '[A-Za-z0-9._-]+'."
     )
-    error_not_a_folder = re.escape(f"Not a directory: '{local_path}'")
+    if platform.system() == 'Windows':
+        error_not_a_folder = f"Not a directory: "
+    else:
+        error_not_a_folder = f"Not a directory: '{local_path}'"
 
     # --- checksum ---
     # `path` missing

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -202,6 +202,10 @@ def test_errors(tmpdir, backend):
         f"does not match '[A-Za-z0-9._-]+'."
     )
     if platform.system() == 'Windows':
+        error_is_a_folder = "Is a directory: "
+    else:
+        error_is_a_folder = f"Is a directory: '{local_folder}'"
+    if platform.system() == 'Windows':
         error_not_a_folder = "Not a directory: "
     else:
         error_not_a_folder = f"Not a directory: '{local_path}'"

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -202,7 +202,7 @@ def test_errors(tmpdir, backend):
         f"does not match '[A-Za-z0-9._-]+'."
     )
     if platform.system() == 'Windows':
-        error_not_a_folder = f"Not a directory: "
+        error_not_a_folder = "Not a directory: "
     else:
         error_not_a_folder = f"Not a directory: '{local_path}'"
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -201,10 +201,7 @@ def test_errors(tmpdir, backend):
         f"Invalid version '{invalid_version}', "
         f"does not match '[A-Za-z0-9._-]+'."
     )
-    if platform.system() == 'Windows':
-        error_is_a_folder = "Is a directory: "
-    else:
-        error_is_a_folder = f"Is a directory: '{local_folder}'"
+    error_not_a_folder = f"Not a directory: '{local_path}'"
 
     # --- checksum ---
     # `path` missing
@@ -279,6 +276,9 @@ def test_errors(tmpdir, backend):
         # Currently we don't know how to provoke permission error on Windows
         with pytest.raises(PermissionError, match=error_read_only_folder):
             backend.get_archive(archive, folder_read_only, version)
+    # `dst_path` is not a directory
+    with pytest.raises(NotADirectoryError, match=error_not_a_folder):
+        backend.get_archive(archive, local_path, version)
 
     # --- get_file ---
     # `src_path` missing
@@ -347,6 +347,9 @@ def test_errors(tmpdir, backend):
             version,
             files=local_file,
         )
+    # `src_root` is not a directory
+    with pytest.raises(NotADirectoryError, match=error_not_a_folder):
+        backend.put_archive(local_path, archive, version)
     # `files` missing
     error_msg = 'No such file or directory: ...'
     with pytest.raises(FileNotFoundError, match=error_msg):


### PR DESCRIPTION
Insert missing `NotADirectoryError` in raises section of `Backend.put_archive()` and adds a test for it. Also adds the same test for `Backend.get_archive()`.

![image](https://user-images.githubusercontent.com/10383417/235864336-4fbedbbf-b731-448b-8e78-bd329a073c62.png)
