### PR TITLE
Artifactory: support old file structure

### DIFF
--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -304,7 +304,12 @@ class Artifactory(Backend):
             )
             if not path.exists():
                 utils.raise_file_not_found_error(str(path))
-            paths = [str(x) for x in path.glob("**/*") if x.is_file()]
+            path = str(path)
+
+            # listing all path on repository
+            # is faster than path.glob('**/*')
+            paths = [str(x) for x in self._repo]
+            paths = [x for x in paths if x.startswith(path)]
 
         else:  # find versions of path
 

--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -159,7 +159,7 @@ class Artifactory(Backend):
 
         # to support legacy file structure
         # see _use_legacy_file_structure()
-        self._legacy_extensions = None
+        self._legacy_extensions = []
         self._legacy_file_structure = False
 
     def _access(

--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -447,7 +447,7 @@ class Artifactory(Backend):
         By default,
         the extension
         ``<ext>``
-        is set the string after the last dot.
+        is set to the string after the last dot.
         I.e.,
         the backend path
         ``'.../file.tar.gz'``

--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -383,7 +383,7 @@ class Artifactory(Backend):
 
         <root>/<name>
         ->
-         <host>/<repository>/<root>/<version>/<name>
+        <host>/<repository>/<root>/<version>/<name>
 
         or legacy:
 

--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -155,13 +155,14 @@ class Artifactory(Backend):
         self._repo = path.find_repository_local(self.repository)
 
         self.extensions = []
-        r"""List with custom extensions.
-        
+        r"""Custom extensions.
+
         By default,
         the string after the last dot
         will be used as extension.
-        To recognize custom extensions including dots,
-        they must be added to this list.
+        To recognize extensions that include dots
+        (e.g. 'tar.gz'),
+        add them to this list.
 
         """
 
@@ -304,9 +305,6 @@ class Artifactory(Backend):
             paths = [str(self._path(path, v))
                      for v in vs if self._exists(path, v)]
 
-            if not paths:
-                utils.raise_file_not_found_error(path)
-
         # <host>/<repository>/<root>/<base>/<version>/<base>-<version>.<ext>
         # ->
         # (/<root>/<base>.<ext>, <version>)
@@ -401,6 +399,15 @@ class Artifactory(Backend):
             ext = audeer.file_extension(name)
 
         base = audeer.replace_file_extension(name, '', ext=ext)
+
+        if not base:
+            raise RuntimeError(
+                f"Cannot derive a valid basename from "
+                f"'{name}' "
+                f"when extension is set to "
+                f"'{ext}'."
+            )
+
         if ext:
             ext = f'.{ext}'
 

--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -391,22 +391,16 @@ class Artifactory(Backend):
 
         ext = None
         for custom_ext in self.extensions:
-            # check for custom extension ...
-            if name.endswith(f'.{custom_ext}'):
+            # check for custom extension
+            # ensure basename is not empty
+            if name[1:].endswith(f'.{custom_ext}'):
                 ext = custom_ext
         if ext is None:
-            # ... otherwise use last string after dot
+            # if no custom extension is found
+            # use last string after dot
             ext = audeer.file_extension(name)
 
         base = audeer.replace_file_extension(name, '', ext=ext)
-
-        if not base:
-            raise RuntimeError(
-                f"Cannot derive a valid basename from "
-                f"'{name}' "
-                f"when extension is set to "
-                f"'{ext}'."
-            )
 
         if ext:
             ext = f'.{ext}'

--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -305,6 +305,9 @@ class Artifactory(Backend):
             paths = [str(self._path(path, v))
                      for v in vs if self._exists(path, v)]
 
+            if not paths:
+                utils.raise_file_not_found_error(path)
+
         # <host>/<repository>/<root>/<base>/<version>/<base>-<version>.<ext>
         # ->
         # (/<root>/<base>.<ext>, <version>)

--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -307,12 +307,8 @@ class Artifactory(Backend):
             )
             if not path.exists():
                 utils.raise_file_not_found_error(str(path))
-            path = str(path)
 
-            # listing all path on repository
-            # is faster than path.glob('**/*')
-            paths = [str(x) for x in self._repo]
-            paths = [x for x in paths if x.startswith(path)]
+            paths = [str(x) for x in path.glob("**/*") if x.is_file()]
 
         else:  # find versions of path
 

--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -154,6 +154,17 @@ class Artifactory(Backend):
         )
         self._repo = path.find_repository_local(self.repository)
 
+        self.extensions = []
+        r"""List of extensions.
+        
+        By default,
+        the string after the last dot
+        will be used as extension.
+        To recognize extensions with dots,
+        add them to this list.
+
+        """
+
     def _access(
             self,
     ):
@@ -332,14 +343,15 @@ class Artifactory(Backend):
     ) -> artifactory.ArtifactoryPath:
         r"""Convert to backend path.
 
-        <root>/<name>
+        <root>/<name>.<ext>
         ->
-        <host>/<repository>/<root>/<version>/<name>
+        <host>/<repository>/<root>/<name>/<version>/<name>-<version>.<ext>
 
         """
         root, name = self.split(path)
         root = self._expand(root)
-        path = f'{root}/{version}/{name}'
+        path = f'{root}{version}/{name}'
+        print(path)
         path = _artifactory_path(
             path,
             self._username,

--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -32,9 +32,12 @@ def _authentication(host) -> typing.Tuple[str, str]:
         'ARTIFACTORY_CONFIG_FILE',
         artifactory.default_config_path,
     )
+    config_file = audeer.path(config_file)
 
-    if api_key is None or username is None:
-
+    if (
+            os.path.exists(config_file) and
+            (api_key is None or username is None)
+    ):
         config = artifactory.read_config(config_file)
         config_entry = artifactory.get_config_entry(config, host)
 

--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -157,12 +157,32 @@ class Artifactory(Backend):
         self.extensions = []
         r"""Custom extensions.
 
+        On Artifactory files are stored
+        under the following structure:
+        ``'.../<name-wo-ext>/<version>/<name-wo-ext>-<version>.<ext>'``.
         By default,
-        the string after the last dot
-        will be used as extension.
-        To recognize extensions that include dots
-        (e.g. 'tar.gz'),
-        add them to this list.
+        the extension
+        ``<ext>``
+        is set the string after the last dot.
+        I.e.,
+        the backend path
+        ``'.../file.tar.gz'``
+        will translate into
+        ``'.../file.tar/1.0.0/file.tar-1.0.0.gz'``.
+        However,
+        by defining custom extensions
+        it is possible to overwrite
+        the default behavior.
+        E.g.,
+        with
+        ``backend.extensions.append('tar.gz')``
+        it is ensured that
+        ``'tar.gz'``
+        will be recognized as an extension
+        and the backend path
+        ``'.../file.tar.gz'``
+        will then translate into
+        ``'.../file/1.0.0/file-1.0.0.tar.gz'``.
 
         """
 

--- a/tests/test_artifactory.py
+++ b/tests/test_artifactory.py
@@ -35,14 +35,18 @@ def hide_credentials():
 def test_authentication(tmpdir, hosts, hide_credentials):
 
     host = hosts['artifactory']
-
-    # create empty config file
-
     config_path = audeer.path(tmpdir, 'config.cfg')
-    os.environ['ARTIFACTORY_CONFIG_FILE'] = audeer.touch(config_path)
+    os.environ['ARTIFACTORY_CONFIG_FILE'] = config_path
 
-    # default credentials
+    # config file does not exist
 
+    backend = audbackend.Artifactory(host, 'repository')
+    assert backend._username == 'anonymous'
+    assert backend._api_key == ''
+
+    # config file is empty
+
+    audeer.touch(config_path)
     backend = audbackend.Artifactory(host, 'repository')
     assert backend._username == 'anonymous'
     assert backend._api_key == ''

--- a/tests/test_artifactory.py
+++ b/tests/test_artifactory.py
@@ -138,6 +138,7 @@ def test_errors(tmpdir, backend):
     'file, version, extensions, expected',
     [
         ('/file.tar.gz', '1.0.0', None, 'file.tar/1.0.0/file.tar-1.0.0.gz'),
+        ('/file.tar.gz', '1.0.0', [], 'file.tar/1.0.0/file.tar-1.0.0.gz'),
         ('/file.tar.gz', '1.0.0', ['tar.gz'], 'file/1.0.0/file-1.0.0.tar.gz'),
         ('/.tar.gz', '1.0.0', ['tar.gz'], '.tar/1.0.0/.tar-1.0.0.gz'),
         ('/tar.gz', '1.0.0', ['tar.gz'], 'tar/1.0.0/tar-1.0.0.gz'),

--- a/tests/test_artifactory.py
+++ b/tests/test_artifactory.py
@@ -135,16 +135,14 @@ def test_errors(tmpdir, backend):
     [
         ('/file.tar.gz', '1.0.0', None, 'file.tar/1.0.0/file.tar-1.0.0.gz'),
         ('/file.tar.gz', '1.0.0', 'tar.gz', 'file/1.0.0/file-1.0.0.tar.gz'),
+        ('/.tar.gz', '1.0.0', 'tar.gz', '.tar/1.0.0/.tar-1.0.0.gz'),
+        ('/tar.gz', '1.0.0', 'tar.gz', 'tar/1.0.0/tar-1.0.0.gz'),
         ('/.tar.gz', '1.0.0', None, '.tar/1.0.0/.tar-1.0.0.gz'),
         ('/.tar', '1.0.0', None, '.tar/1.0.0/.tar-1.0.0'),
         ('/tar', '1.0.0', None, 'tar/1.0.0/tar-1.0.0'),
-        pytest.param(  # empty basename
-            '/.tar.gz', '1.0.0', 'tar.gz', None,
-            marks=pytest.mark.xfail(raises=audbackend.BackendError),
-        ),
     ]
 )
-def test_extension(tmpdir, backend, file, extension, version, expected):
+def test_extension(tmpdir, backend, file, version, extension, expected):
 
     if extension is not None:
         backend.extensions.append(extension)

--- a/tests/test_artifactory.py
+++ b/tests/test_artifactory.py
@@ -131,21 +131,21 @@ def test_errors(tmpdir, backend):
     indirect=True,
 )
 @pytest.mark.parametrize(
-    'file, version, extension, expected',
+    'file, version, extensions, expected',
     [
         ('/file.tar.gz', '1.0.0', None, 'file.tar/1.0.0/file.tar-1.0.0.gz'),
-        ('/file.tar.gz', '1.0.0', 'tar.gz', 'file/1.0.0/file-1.0.0.tar.gz'),
-        ('/.tar.gz', '1.0.0', 'tar.gz', '.tar/1.0.0/.tar-1.0.0.gz'),
-        ('/tar.gz', '1.0.0', 'tar.gz', 'tar/1.0.0/tar-1.0.0.gz'),
+        ('/file.tar.gz', '1.0.0', ['tar.gz'], 'file/1.0.0/file-1.0.0.tar.gz'),
+        ('/.tar.gz', '1.0.0', ['tar.gz'], '.tar/1.0.0/.tar-1.0.0.gz'),
+        ('/tar.gz', '1.0.0', ['tar.gz'], 'tar/1.0.0/tar-1.0.0.gz'),
         ('/.tar.gz', '1.0.0', None, '.tar/1.0.0/.tar-1.0.0.gz'),
         ('/.tar', '1.0.0', None, '.tar/1.0.0/.tar-1.0.0'),
         ('/tar', '1.0.0', None, 'tar/1.0.0/tar-1.0.0'),
     ]
 )
-def test_extension(tmpdir, backend, file, version, extension, expected):
+def test_legacy_file_structure(tmpdir, backend, file, version, extensions,
+                               expected):
 
-    if extension is not None:
-        backend.extensions.append(extension)
+    backend._use_legacy_file_structure(extensions=extensions)
 
     src_path = audeer.touch(audeer.path(tmpdir, 'tmp'))
     backend.put_file(src_path, file, version)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -335,9 +335,11 @@ def test_errors(tmpdir, backend):
         backend.latest_version(file_invalid_char)
 
     # --- ls ---
-    # `path` missing
+    # `path` does not exist
     with pytest.raises(audbackend.BackendError, match=error_backend):
         backend.ls('/missing/')
+    with pytest.raises(audbackend.BackendError, match=error_backend):
+        backend.ls('/missing.txt')
     # joined path without leading '/'
     with pytest.raises(ValueError, match=error_invalid_path):
         backend.ls(file_invalid_path)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -340,6 +340,12 @@ def test_errors(tmpdir, backend):
         backend.ls('/missing/')
     with pytest.raises(audbackend.BackendError, match=error_backend):
         backend.ls('/missing.txt')
+    remote_file_with_wrong_ext = audeer.replace_file_extension(
+        remote_file,
+        'missing',
+    )
+    with pytest.raises(audbackend.BackendError, match=error_backend):
+        backend.ls(remote_file_with_wrong_ext)
     # joined path without leading '/'
     with pytest.raises(ValueError, match=error_invalid_path):
         backend.ls(file_invalid_path)


### PR DESCRIPTION
Closes #76 #129 

With this PR we add support for storing files on Artifactory using the old structure, i.e.:

`<host>/<repository>/<folder>/<name-wo-ext>/<version>/<name-wo-ext>-<version>.<ext>`

In packages where we want to stick with the old structure we can then do:

```python
backend = audbackend.access(...)
if isinstance(backend, audbackend.Artifactory):
    backend._use_legacy_file_structure(extensions=...)
```

Other changes:

* Checks if config file exists before trying to read credentials from it