### PR TITLE
FileSystem: support old file structure

### DIFF
--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 import audeer
@@ -51,3 +53,35 @@ def test_get_file_interrupt(tmpdir, bad_file_system, backend):
     with pytest.raises(audbackend.BackendError):
         backend.get_file('/file', src_path, '1.0.0')
     assert audeer.md5(src_path) == checksum_local
+
+
+@pytest.mark.parametrize(
+    'backend',
+    ['file-system'],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    'file, version, extensions, expected',
+    [
+        ('/file.tar.gz', '1.0.0', None, 'file.tar/1.0.0/file.tar-1.0.0.gz'),
+        ('/file.tar.gz', '1.0.0', [], 'file.tar/1.0.0/file.tar-1.0.0.gz'),
+        ('/file.tar.gz', '1.0.0', ['tar.gz'], 'file/1.0.0/file-1.0.0.tar.gz'),
+        ('/.tar.gz', '1.0.0', ['tar.gz'], '.tar/1.0.0/.tar-1.0.0.gz'),
+        ('/tar.gz', '1.0.0', ['tar.gz'], 'tar/1.0.0/tar-1.0.0.gz'),
+        ('/.tar.gz', '1.0.0', None, '.tar/1.0.0/.tar-1.0.0.gz'),
+        ('/.tar', '1.0.0', None, '.tar/1.0.0/.tar-1.0.0'),
+        ('/tar', '1.0.0', None, 'tar/1.0.0/tar-1.0.0'),
+    ]
+)
+def test_legacy_file_structure(tmpdir, backend, file, version, extensions,
+                               expected):
+
+    backend._use_legacy_file_structure(extensions=extensions)
+
+    src_path = audeer.touch(audeer.path(tmpdir, 'tmp'))
+    backend.put_file(src_path, file, version)
+
+    path = os.path.join(backend._root, expected)
+    assert str(backend._path(file, version)) == path
+    assert backend.ls(file) == [(file, version)]
+    assert backend.ls() == [(file, version)]

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -76,6 +76,8 @@ def test_get_file_interrupt(tmpdir, bad_file_system, backend):
 def test_legacy_file_structure(tmpdir, backend, file, version, extensions,
                                expected):
 
+    expected = expected.replace('/', os.path.sep)
+
     backend._use_legacy_file_structure(extensions=extensions)
 
     src_path = audeer.touch(audeer.path(tmpdir, 'tmp'))


### PR DESCRIPTION
Closes https://github.com/audeering/audbackend/issues/136

Analogous to https://github.com/audeering/audbackend/pull/130 this adds `FileSystem._use_legacy_file_structure()` to support our legacy file systems on existing repositories.

### Example

Default:

```python
import tempfile
import audbackend
import audeer


with tempfile.TemporaryDirectory(dir='.') as host:

    backend = audbackend.create('file-system', host, 'repo')

    file = audeer.touch('file')
    backend.put_file(file, '/sub/file.txt', '1.0.0')
    backend.put_file(file, '/sub/file.tar.gz', '1.0.0')
    files = audeer.list_file_names(host, recursive=True, basenames=True)

print(files)
```
```
['repo/sub/1.0.0/file.tar.gz', 'repo/sub/1.0.0/file.txt']
```

Legacy:

```python
import tempfile
import audbackend
import audeer


with tempfile.TemporaryDirectory(dir='.') as host:

    backend = audbackend.create('file-system', host, 'repo')
    backend._use_legacy_file_structure(extensions=['tar.gz'])

    file = audeer.touch('file')
    backend.put_file(file, '/sub/file.txt', '1.0.0')
    backend.put_file(file, '/sub/file.tar.gz', '1.0.0')
    files = audeer.list_file_names(host, recursive=True, basenames=True)

print(files)
```
```
['repo/sub/file/1.0.0/file-1.0.0.tar.gz', 'repo/sub/file/1.0.0/file-1.0.0.txt']
```


