### PR TITLE
CI: add ipykernel to requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+ipykernel
 jupyter-sphinx
 sphinx
 sphinx-audeering-theme >=1.2.1


### PR DESCRIPTION
The Python kernel seems to be no longer a requirement when installing `jupyter-sphinx`, so we have to add it manually to the dependencies.