### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ jobs:
             python-version: '3.9'
           - os: ubuntu-latest
             python-version: '3.10'
+          - os: ubuntu-latest
+            python-version: '3.11'
 
     steps:
     - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,12 @@ classifiers = [
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
     'Topic :: Scientific/Engineering',
 ]
 dependencies = [
     'audeer >=1.20.0',
-    'dohq-artifactory >=0.8.1',
+    'dohq-artifactory >=0.9.1',
     'pywin32; sys_platform == "win32"'
 ]
 # Get version dynamically from git


### PR DESCRIPTION
With the release of `dohq-artifactory >=0.9.1` all the remaining issues with Python 3.11 should be fixed now (compare https://github.com/devopshq/artifactory/issues/404) and we should be able to support it here as well.