### PR TITLE
Make backend dependencies optional

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -9,3 +9,17 @@ To install :mod:`audbackend` run:
     $ # virtualenv --python=python3 ${HOME}/.envs/audbackend
     $ # source ${HOME}/.envs/audbackend/bin/activate
     $ pip install audbackend
+
+Per default,
+only the file-system backend will be installed.
+To install all backends run:
+
+.. code-block:: bash
+
+    $ pip install audbackend[all]
+
+or select single backends, e.g.
+
+.. code-block:: bash
+
+    $ pip install audbackend[artifactory]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,12 +28,20 @@ classifiers = [
 ]
 dependencies = [
     'audeer >=1.20.0',
-    'dohq-artifactory >=0.8.1',
     'pywin32; sys_platform == "win32"'
 ]
 # Get version dynamically from git
 # (needs setuptools_scm tools config below)
 dynamic = ['version']
+
+[project.optional-dependencies]
+artifactory = [
+    'dohq-artifactory >=0.8.1',
+]
+all = [
+    'dohq-artifactory >=0.8.1',
+]
+
 
 [project.urls]
 repository = 'https://github.com/audeering/audbackend/'


### PR DESCRIPTION
Closes #135 

This makes dependencies for backends optional
and install only the file-system backend as default.

The question is if we also need to add some error handling in the code,
e.g. raise a custom error when a user tries to use the artifactory backend,
even thought it is not installed?

![image](https://github.com/audeering/audbackend/assets/173624/43150d01-e7dc-44f9-a30a-376b7a525fc1)
