### PR TITLE
DOC: discuss legacy backends

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,6 +6,7 @@
 
     install
     usage
+    legacy
 
 .. Warning: then usage of genindex is a hack to get a TOC entry, see
 .. https://stackoverflow.com/a/42310803. This might break the usage of sphinx if

--- a/docs/legacy.rst
+++ b/docs/legacy.rst
@@ -1,0 +1,82 @@
+.. set temporal working directory
+.. jupyter-execute::
+    :hide-code:
+
+    import os
+    import audeer
+
+    _cwd_root = os.getcwd()
+    _tmp_root = audeer.mkdir(os.path.join('docs', 'tmp'))
+    os.chdir(_tmp_root)
+
+
+.. _legacy-backends:
+
+Legacy backends
+===============
+
+The file structure on the backend
+has changed for
+:class:`audbackend.FileSystem`
+and :class:`audbackend.Artifactory`
+in version 1.0.0
+of :mod:`audbackend`.
+
+Before a file ``/sub/file.txt``
+for version ``1.0.0``
+was stored under
+
+.. code-block::
+
+    /sub/file/1.0.0/file-1.0.0.txt
+
+and is now stored under
+
+.. code-block::
+
+    /sub/1.0.0/file.txt
+
+If you need to continue
+with the old file structure
+in your application,
+you can configure :mod:`audbackend` accordingly
+by calling the hidden method
+``_use_legacy_file_structure()``
+after instantiating the backend.
+If you have to store files
+that contain a dot
+in its file extension,
+you have to list those extensions explicitly.
+
+.. jupyter-execute::
+
+    import audbackend
+
+    backend = audbackend.create('file-system', './host', 'repo')
+    extensions = ['tar.gz']
+    backend._use_legacy_file_structure(extensions=extensions)
+
+Afterwards we upload an TAR.GZ archive
+and check that it is stored as expected.
+
+.. jupyter-execute::
+
+    import audeer
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        src_path = os.path.join(tmp, 'file.txt')
+        with open(src_path, 'w') as fp:
+            fp.write('Hello world')
+        backend.put_archive(tmp, '/file.tar.gz', '1.0.0')
+
+    audeer.list_file_names('./host', recursive=True, basenames=True)
+
+
+.. reset working directory and clean up
+.. jupyter-execute::
+    :hide-code:
+
+    import shutil
+    os.chdir(_cwd_root)
+    shutil.rmtree(_tmp_root)

--- a/docs/legacy.rst
+++ b/docs/legacy.rst
@@ -37,13 +37,14 @@ Now it is stored under
 
     /sub/1.0.0/file.txt
 
-If you need to continue
-with the old file structure
-in your application,
-you can configure :mod:`audbackend` accordingly
-by calling the hidden method
+To force the old file structure
+call the hidden method
 ``_use_legacy_file_structure()``
 after instantiating the backend.
+We recommend this 
+for existing repositories
+that store files
+under the old structure.
 If you have to store files
 that contain a dot
 in its file extension,

--- a/docs/legacy.rst
+++ b/docs/legacy.rst
@@ -23,7 +23,7 @@ in version 1.0.0
 of :mod:`audbackend`.
 
 Before a file ``/sub/file.txt``
-for version ``1.0.0``
+with version ``1.0.0``
 was stored under
 
 .. code-block::
@@ -65,9 +65,7 @@ and check that it is stored as expected.
     import tempfile
 
     with tempfile.TemporaryDirectory() as tmp:
-        src_path = os.path.join(tmp, 'file.txt')
-        with open(src_path, 'w') as fp:
-            fp.write('Hello world')
+        audeer.touch(audeer.path(tmp, 'file.txt'))
         backend.put_archive(tmp, '/file.tar.gz', '1.0.0')
 
     audeer.list_file_names('./host', recursive=True, basenames=True)

--- a/docs/legacy.rst
+++ b/docs/legacy.rst
@@ -31,7 +31,7 @@ was stored under
 
     /sub/file/1.0.0/file-1.0.0.txt
 
-and is now stored under
+Now it is stored under
 
 .. code-block::
 

--- a/docs/legacy.rst
+++ b/docs/legacy.rst
@@ -22,7 +22,8 @@ and :class:`audbackend.Artifactory`
 in version 1.0.0
 of :mod:`audbackend`.
 
-Before a file ``/sub/file.txt``
+Before,
+a file ``/sub/file.txt``
 with version ``1.0.0``
 was stored under
 


### PR DESCRIPTION
Closes #131 

This adds a new entry to the documentation how to continue using the old file structure on file-system and artifactory backends.

![image](https://github.com/audeering/audbackend/assets/173624/24e8edca-6231-4b31-b51b-7b186f0f1812)

![image](https://github.com/audeering/audbackend/assets/173624/01be51b2-772d-4486-b83d-0b2ba8c4893e)
