### PR TITLE
Depend on dohq-artifactory >=0.9.0

### DIFF
--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -72,7 +72,7 @@ def _deploy(
         dst_path.parent.mkdir()
 
     with open(src_path, 'rb') as fd:
-        dst_path.deploy(fd, md5=checksum)
+        dst_path.deploy(fd, md5=checksum, quote_parameters=True)
 
     if verbose:  # pragma: no cover
         # Clear progress line

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,10 +36,10 @@ dynamic = ['version']
 
 [project.optional-dependencies]
 artifactory = [
-    'dohq-artifactory >=0.8.1',
+    'dohq-artifactory >=0.9.0',
 ]
 all = [
-    'dohq-artifactory >=0.8.1',
+    'dohq-artifactory >=0.9.0',
 ]
 
 


### PR DESCRIPTION
This fixes a warning shown for the new quote_parameter added in version 0.9.0 of artifactory, see https://github.com/devopshq/artifactory/issues/408.