### PR TITLE
TST: use name of authenticated user in owner fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,9 @@ def owner(request):
     r"""Return expected owner value."""
     name = request.param
     if name == 'artifactory':
-        owner = audbackend.core.artifactory._authentication('audeering.jfrog.io/artifactory')[0]
+        owner = audbackend.core.artifactory._authentication(
+            'audeering.jfrog.io/artifactory'
+        )[0]
     else:
         if os.name == 'nt':
             owner = 'Administrators'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ def owner(request):
     r"""Return expected owner value."""
     name = request.param
     if name == 'artifactory':
-        owner = 'audeering-unittest'
+        owner = audbackend.core.artifactory._authentication('audeering.jfrog.io/artifactory')[0]
     else:
         if os.name == 'nt':
             owner = 'Administrators'


### PR DESCRIPTION
Replaces hard-coded user name with name of authenticated user in owner fixture.