### PR TITLE
Base._ls(): may always return an empty list

### DIFF
--- a/audbackend/core/backend/artifactory.py
+++ b/audbackend/core/backend/artifactory.py
@@ -224,12 +224,7 @@ class Artifactory(Base):
             path: str,
     ) -> bool:
         r"""Check if file exists on backend."""
-        path = self._expand(path)
-        path = _artifactory_path(
-            path,
-            self._username,
-            self._api_key,
-        )
+        path = self._path(path)
         return path.exists()
 
     def _expand(
@@ -265,13 +260,8 @@ class Artifactory(Base):
     ) -> typing.List[str]:
         r"""List all files under sub-path."""
         path = self._path(path)
-        path = _artifactory_path(
-            path,
-            self._username,
-            self._api_key,
-        )
         if not path.exists():
-            utils.raise_file_not_found_error(str(path))
+            return []
 
         paths = [str(x) for x in path.glob("**/*") if x.is_file()]
         paths = [self._collapse(path) for path in paths]

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -348,11 +348,9 @@ class Base:
     ) -> typing.List[str]:  # pragma: no cover
         r"""List all files under sub-path.
 
-        If ``path`` is ``'/'`` and no files exist on the repository,
-        an empty list should be returned
-        Otherwise,
-        if ``path`` does not exist or no files are found under ``path``,
-        an error should be raised.
+        If ``path`` does not exist
+        or no files are found under ``path``
+        return an empty list.
 
         """
         raise NotImplementedError()
@@ -419,17 +417,19 @@ class Base:
             if self.exists(path):
                 paths = [path]
             else:
-                if not suppress_backend_errors:
-                    # since the backend does no longer raise an error
-                    # if the path does not exist
-                    # we have to do it
-                    try:
-                        raise utils.raise_file_not_found_error(path)
-                    except FileNotFoundError as ex:
-                        raise BackendError(ex)
                 paths = []
 
         if not paths:
+
+            if path != '/' and not suppress_backend_errors:
+                # since the backend does no longer raise an error
+                # if the path does not exist
+                # we have to do it
+                try:
+                    raise utils.raise_file_not_found_error(path)
+                except FileNotFoundError as ex:
+                    raise BackendError(ex)
+
             return []
 
         paths = sorted(paths)

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -421,9 +421,8 @@ class Base:
         if not paths:
 
             if path != '/' and not suppress_backend_errors:
-                # since the backend does no longer raise an error
                 # if the path does not exist
-                # we have to do it
+                # we raise an error
                 try:
                     raise utils.raise_file_not_found_error(path)
                 except FileNotFoundError as ex:

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -349,8 +349,7 @@ class Base:
         r"""List all files under sub-path.
 
         If ``path`` does not exist
-        or no files are found under ``path``
-        return an empty list.
+        an empty list can be returned.
 
         """
         raise NotImplementedError()

--- a/audbackend/core/backend/filesystem.py
+++ b/audbackend/core/backend/filesystem.py
@@ -124,7 +124,8 @@ class FileSystem(Base):
         r"""List all files under sub-path."""
         path = self._expand(path)
         if not os.path.exists(path):
-            utils.raise_file_not_found_error(path)
+            return []
+
         paths = audeer.list_file_names(
             path,
             recursive=True,

--- a/docs/developer-guide.rst
+++ b/docs/developer-guide.rst
@@ -544,14 +544,6 @@ we provide a listing method.
             ls = db.execute(query, [path]).fetchall()
             ls = [x[0] for x in ls]
 
-        if not ls and not path == '/':
-            # path has to exists if not root
-            raise FileNotFoundError(
-                errno.ENOENT,
-                os.strerror(errno.ENOENT),
-                path,
-            )
-
         return ls
 
 

--- a/tests/singlefolder.py
+++ b/tests/singlefolder.py
@@ -134,9 +134,6 @@ class SingleFolder(audbackend.backend.Base):
                 if p.startswith(path):
                     ls.append(p)
 
-            if not ls and not path == '/':
-                raise audbackend.core.utils.raise_file_not_found_error(path)
-
             return ls
 
     def _owner(


### PR DESCRIPTION
So far the docstring of `Base._ls()` was saying:

```
        If ``path`` is ``'/'`` and no files exist on the repository,
        an empty list should be returned
        Otherwise,
        if ``path`` does not exist or no files are found under ``path``,
        an error should be raised.
```

This might be overlooked by a developer, so here we simplify `_ls()` by not demanding to raise an error message or treat `/` as a special case. Instead it is sufficient to return an empty list, even in the case that the path does not exist. The docstring now says:

```
        If ``path`` does not exist
        an empty list can be returned.
```

To avoid a breaking change, raising a file-not-found-error is now handled by `Base`, in the same way we already do it for the case that `path` is not a sub-path.
