### PR TITLE
CI: use Python 3.10 as default

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ '3.8' ]
+        python-version: [ '3.10' ]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.10'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,12 +13,12 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
-        python-version: [ '3.8' ]
+        python-version: [ '3.10' ]
         include:
           - os: ubuntu-latest
-            python-version: '3.9'
+            python-version: '3.8'
           - os: ubuntu-latest
-            python-version: '3.10'
+            python-version: '3.9'
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Use Python 3.10 as default version in `test.yml`, `doc.yml`, and `publish.yml` CI workflows.