### PR TITLE
Copy file on backend

### DIFF
--- a/audbackend/core/backend/artifactory.py
+++ b/audbackend/core/backend/artifactory.py
@@ -184,6 +184,25 @@ class Artifactory(Base):
         path = path.replace('/', self.sep)
         return path
 
+    def _copy_file(
+            self,
+            src_path: str,
+            dst_path: str,
+            verbose: bool,
+    ):
+        r"""Copy file on backend.
+
+        A default implementation is provided,
+        which temporarily gets the file from the backend
+        and afterward puts it to the new location.
+        It is recommended to overwrite the function
+        if backend supports a native way to copy files.
+
+        """
+        src_path = self._path(src_path)
+        dst_path = self._path(dst_path)
+        src_path.copy(dst_path)
+
     def _create(
             self,
     ):

--- a/audbackend/core/backend/artifactory.py
+++ b/audbackend/core/backend/artifactory.py
@@ -190,17 +190,11 @@ class Artifactory(Base):
             dst_path: str,
             verbose: bool,
     ):
-        r"""Copy file on backend.
-
-        A default implementation is provided,
-        which temporarily gets the file from the backend
-        and afterward puts it to the new location.
-        It is recommended to overwrite the function
-        if backend supports a native way to copy files.
-
-        """
+        r"""Copy file on backend."""
         src_path = self._path(src_path)
         dst_path = self._path(dst_path)
+        if not dst_path.parent.exists():
+            dst_path.parent.mkdir()
         src_path.copy(dst_path)
 
     def _create(

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -76,7 +76,7 @@ class Base:
             src_path: str,
             dst_path: str,
             verbose: bool,
-    ):
+    ):  # pragma: no Windows cover
         r"""Copy file on backend.
 
         A default implementation is provided,

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -125,7 +125,7 @@ class Base:
             src_path != dst_path
             and (
                 not self.exists(dst_path)
-                or self.checksum(src_path) != self.checksum(src_path)
+                or self.checksum(src_path) != self.checksum(dst_path)
             )
         ):
             utils.call_function_on_backend(

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -318,7 +318,7 @@ class Base:
         If ``dst_path`` exists
         with a different checksum,
         it is overwritten,
-        or otherwise,
+        Otherwise,
         the operation is silently skipped.
 
         To ensure the file is completely retrieved,

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -101,9 +101,9 @@ class Base:
         r"""Copy file on backend.
 
         If ``dst_path`` exists
-        with a different checksum,
-        it is overwritten,
-        or otherwise,
+        and has a different checksum,
+        it is overwritten.
+        Otherwise,
         the operation is silently skipped.
 
         Args:

--- a/audbackend/core/backend/filesystem.py
+++ b/audbackend/core/backend/filesystem.py
@@ -56,6 +56,15 @@ class FileSystem(Base):
         path = path.replace(os.path.sep, self.sep)
         return path
 
+    def _copy_file(
+            self,
+            src_path: str,
+            dst_path: str,
+            verbose: bool,
+    ):
+        r"""Copy file on backend."""
+        audeer.move(src_path, dst_path)
+
     def _create(
             self,
     ):

--- a/audbackend/core/backend/filesystem.py
+++ b/audbackend/core/backend/filesystem.py
@@ -63,7 +63,10 @@ class FileSystem(Base):
             verbose: bool,
     ):
         r"""Copy file on backend."""
-        audeer.move(src_path, dst_path)
+        src_path = self._expand(src_path)
+        dst_path = self._expand(dst_path)
+        audeer.mkdir(os.path.dirname(dst_path))
+        shutil.copy(src_path, dst_path)
 
     def _create(
             self,

--- a/audbackend/core/interface/unversioned.py
+++ b/audbackend/core/interface/unversioned.py
@@ -37,6 +37,35 @@ class Unversioned(Base):
         """
         return self.backend.checksum(path)
 
+    def copy_file(
+            self,
+            src_path: str,
+            dst_path: str,
+            *,
+            verbose: bool = False,
+    ):
+        r"""Copy file on backend.
+
+        If ``dst_path`` exists
+        with a different checksum,
+        it is overwritten,
+        or otherwise,
+        the operation is silently skipped.
+
+        Args:
+            src_path: source path to file on backend
+            dst_path: destination path to file on backend
+            verbose: show debug messages
+
+        Raises:
+            BackendError: if an error is raised on the backend
+            ValueError: if ``src_path`` or ``dst_path``
+                does not start with ``'/'`` or
+                does not match ``'[A-Za-z0-9/._-]+'``
+
+        """
+        self.backend.copy_file(src_path, dst_path, verbose=verbose)
+
     def date(
             self,
             path: str,

--- a/audbackend/core/interface/unversioned.py
+++ b/audbackend/core/interface/unversioned.py
@@ -47,9 +47,9 @@ class Unversioned(Base):
         r"""Copy file on backend.
 
         If ``dst_path`` exists
-        with a different checksum,
-        it is overwritten,
-        or otherwise,
+        and has a different checksum,
+        it is overwritten.
+        Otherwise,
         the operation is silently skipped.
 
         Args:

--- a/audbackend/core/interface/unversioned.py
+++ b/audbackend/core/interface/unversioned.py
@@ -63,6 +63,13 @@ class Unversioned(Base):
                 does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
 
+        Examples:
+            >>> unversioned.exists('/copy.ext')
+            False
+            >>> unversioned.copy_file('/f.ext', '/copy.ext')
+            >>> unversioned.exists('/copy.ext')
+            True
+
         """
         self.backend.copy_file(src_path, dst_path, verbose=verbose)
 

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -103,7 +103,11 @@ class Versioned(Base):
         for version in versions:
             src_path_with_version = self._path_with_version(src_path, version)
             dst_path_with_version = self._path_with_version(dst_path, version)
-            self.backend.copy_file(src_path_with_version, dst_path_with_version, verbose=verbose)
+            self.backend.copy_file(
+                src_path_with_version,
+                dst_path_with_version,
+                verbose=verbose,
+            )
 
     def date(
             self,

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -75,9 +75,9 @@ class Versioned(Base):
         will be copied.
 
         If ``dst_path`` exists
-        with a different checksum,
-        it is overwritten,
-        or otherwise,
+        and has a different checksum,
+        it is overwritten.
+        Otherwise,
         the operation is silently skipped.
 
         Args:

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -5,6 +5,7 @@ import typing
 import audeer
 
 from audbackend.core import utils
+from audbackend.core.backend.base import Base as Backend
 from audbackend.core.errors import BackendError
 from audbackend.core.interface.base import Base
 
@@ -19,7 +20,7 @@ class Versioned(Base):
 
     def __init__(
             self,
-            backend: Base,
+            backend: Backend,
     ):
         super().__init__(backend)
 
@@ -58,6 +59,51 @@ class Versioned(Base):
         """
         path_with_version = self._path_with_version(path, version)
         return self.backend.checksum(path_with_version)
+
+    def copy_file(
+            self,
+            src_path: str,
+            dst_path: str,
+            *,
+            version: str = None,
+            verbose: bool = False,
+    ):
+        r"""Copy file on backend.
+
+        If ``version`` is ``None``
+        all versions of ``src_path``
+        will be copied.
+
+        If ``dst_path`` exists
+        with a different checksum,
+        it is overwritten,
+        or otherwise,
+        the operation is silently skipped.
+
+        Args:
+            src_path: source path to file on backend
+            dst_path: destination path to file on backend
+            version: version string
+            verbose: show debug messages
+
+        Raises:
+            BackendError: if an error is raised on the backend
+            ValueError: if ``src_path`` or ``dst_path``
+                does not start with ``'/'`` or
+                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``version`` is empty or
+                does not match ``'[A-Za-z0-9._-]+'``
+
+        """
+        if version is None:
+            versions = self.versions(src_path)
+        else:
+            versions = [version]
+
+        for version in versions:
+            src_path_with_version = self._path_with_version(src_path, version)
+            dst_path_with_version = self._path_with_version(dst_path, version)
+            self.backend.copy_file(src_path_with_version, dst_path_with_version, verbose=verbose)
 
     def date(
             self,

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -86,6 +86,13 @@ class Versioned(Base):
             version: version string
             verbose: show debug messages
 
+        Examples:
+            >>> versioned.exists('/copy.ext', '1.0.0')
+            False
+            >>> versioned.copy_file('/f.ext', '/copy.ext', version='1.0.0')
+            >>> versioned.exists('/copy.ext', '1.0.0')
+            True
+
         Raises:
             BackendError: if an error is raised on the backend
             ValueError: if ``src_path`` or ``dst_path``

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -255,7 +255,7 @@ Or request it's latest version.
 
     interface.latest_version('/file.txt')
 
-When can copy a specific version of a file.
+We can copy a specific version of a file.
 
 .. jupyter-execute::
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -66,7 +66,6 @@ i.e. exactly one file exists for a backend path.
         interface=audbackend.interface.Unversioned,
     )
 
-
 Now we can upload our first file to the repository.
 Note,
 it is important to provide an absolute path
@@ -80,13 +79,11 @@ by starting it with ``/``.
     file = audeer.touch('file.txt')
     interface.put_file(file, '/file.txt')
 
-
 We check if the file exists in the repository.
 
 .. jupyter-execute::
 
     interface.exists('/file.txt')
-
 
 And access its meta information,
 like its checksum.
@@ -107,6 +104,13 @@ Or the owner who uploaded the file.
 
     interface.owner('/file.txt')
 
+We create a copy of the file
+and verify it exists.
+
+.. jupyter-execute::
+
+    interface.copy_file('/file.txt', '/copy/file.txt')
+    interface.exists('/copy/file.txt')
 
 We download the file
 and store it as ``local.txt``.
@@ -114,7 +118,6 @@ and store it as ``local.txt``.
 .. jupyter-execute::
 
     file = interface.get_file('/file.txt', 'local.txt')
-
 
 It is possible to upload
 one or more files
@@ -133,7 +136,6 @@ in the repository.
     audeer.touch(folder, 'file2.txt')
     interface.put_archive(folder, '/archives/folder.zip')
 
-
 When we download an archive
 it is automatically extracted,
 when using :meth:`audbackend.interface.Unversioned.get_archive`
@@ -143,7 +145,6 @@ instead of :meth:`audbackend.interface.Unversioned.get_file`.
 
     paths = interface.get_archive('/archives/folder.zip', 'downloaded_folder')
     paths
-
 
 We can list all files
 in the repository.
@@ -163,7 +164,6 @@ is returned.
 
     interface.ls('/archives/')
 
-
 We can remove files.
 
 .. jupyter-execute::
@@ -171,7 +171,6 @@ We can remove files.
     interface.remove_file('/file.txt')
     interface.remove_file('/archives/folder.zip')
     interface.ls('/')
-
 
 Or even delete the whole repository
 with all its content.
@@ -255,6 +254,20 @@ Or request it's latest version.
 .. jupyter-execute::
 
     interface.latest_version('/file.txt')
+
+When can copy a specific version of a file.
+
+.. jupyter-execute::
+
+    interface.copy_file('/file.txt', '/copy/file.txt', version='1.0.0')
+    interface.ls('/copy/')
+
+Or all versions.
+
+.. jupyter-execute::
+
+    interface.copy_file('/file.txt', '/copy/file.txt')
+    interface.ls('/copy/')
 
 When downloading a file,
 we can select the desired version.

--- a/tests/singlefolder.py
+++ b/tests/singlefolder.py
@@ -153,7 +153,7 @@ class SingleFolder(audbackend.backend.Base):
     ):
         with self.Map(self._path, self._lock) as m:
 
-            if dst_path not in m:
+            if dst_path not in m or checksum != m[dst_path][1]:
                 m[dst_path] = {}
                 p = audeer.path(self._root, audeer.uid()[:8])
                 m[dst_path] = (p, checksum)

--- a/tests/test_interface_unversioned.py
+++ b/tests/test_interface_unversioned.py
@@ -173,6 +173,7 @@ def test_copy(tmpdir, src_path, dst_path, interface):
     if dst_path != src_path:
         assert not interface.exists(dst_path)
     interface.copy_file(src_path, dst_path)
+    assert interface.exists(src_path)
     assert interface.exists(dst_path)
 
     # copy file again with different checksum

--- a/tests/test_interface_unversioned.py
+++ b/tests/test_interface_unversioned.py
@@ -256,6 +256,23 @@ def test_errors(tmpdir, interface):
     with pytest.raises(ValueError, match=error_invalid_char):
         interface.checksum(file_invalid_char)
 
+    # --- copy_file ---
+    # `src_path` missing
+    with pytest.raises(audbackend.BackendError, match=error_backend):
+        interface.copy_file('/missing.txt', '/file.txt')
+    # `src_path` without leading '/'
+    with pytest.raises(ValueError, match=error_invalid_path):
+        interface.copy_file(file_invalid_path, '/file.txt')
+    # `src_path` contains invalid character
+    with pytest.raises(ValueError, match=error_invalid_char):
+        interface.copy_file(file_invalid_char, '/file.txt')
+    # `dst_path` without leading '/'
+    with pytest.raises(ValueError, match=error_invalid_path):
+        interface.copy_file('/file.txt', file_invalid_path)
+    # `dst_path` contains invalid character
+    with pytest.raises(ValueError, match=error_invalid_char):
+        interface.copy_file('/file.txt', file_invalid_char)
+
     # --- exists ---
     # `path` without leading '/'
     with pytest.raises(ValueError, match=error_invalid_path):

--- a/tests/test_interface_versioned.py
+++ b/tests/test_interface_versioned.py
@@ -193,6 +193,8 @@ def test_copy(tmpdir, src_path, src_versions, dst_path, version, interface):
         for v in dst_versions:
             assert not interface.exists(dst_path, v)
     interface.copy_file(src_path, dst_path, version=version)
+    for v in src_versions:
+        assert interface.exists(src_path, v)
     for v in dst_versions:
         assert interface.exists(dst_path, v)
 

--- a/tests/test_interface_versioned.py
+++ b/tests/test_interface_versioned.py
@@ -214,6 +214,7 @@ def test_copy(tmpdir, src_path, src_versions, dst_path, version, interface):
         assert audeer.md5(local_path) == interface.checksum(dst_path, v)
 
     # clean up
+
     for v in src_versions:
         interface.remove_file(src_path, v)
     if dst_path != src_path:
@@ -293,6 +294,26 @@ def test_errors(tmpdir, interface):
         interface.checksum(remote_file, empty_version)
     with pytest.raises(ValueError, match=error_invalid_version):
         interface.checksum(remote_file, invalid_version)
+
+    # --- copy_file ---
+    # `src_path` missing
+    with pytest.raises(audbackend.BackendError, match=error_backend):
+        interface.copy_file('/missing.txt', '/file.txt')
+    # `src_path` without leading '/'
+    with pytest.raises(ValueError, match=error_invalid_path):
+        interface.copy_file(file_invalid_path, '/file.txt')
+    # `src_path` contains invalid character
+    with pytest.raises(ValueError, match=error_invalid_char):
+        interface.copy_file(file_invalid_char, '/file.txt')
+    # `dst_path` without leading '/'
+    with pytest.raises(ValueError, match=error_invalid_path):
+        interface.copy_file('/file.txt', file_invalid_path)
+    # `dst_path` contains invalid character
+    with pytest.raises(ValueError, match=error_invalid_char):
+        interface.copy_file('/file.txt', file_invalid_char)
+    # invalid version
+    with pytest.raises(ValueError, match=error_empty_version):
+        interface.copy_file(remote_file, '/file.txt', version=empty_version)
 
     # --- exists ---
     # `path` without leading '/'

--- a/tests/test_interface_versioned.py
+++ b/tests/test_interface_versioned.py
@@ -152,6 +152,76 @@ def test_archive(tmpdir, tree, archive, files, tmp_root, interface, expected):
 
 
 @pytest.mark.parametrize(
+    'src_path, src_versions, dst_path',
+    [
+        (
+            '/file.ext',
+            ['1.0.0', '2.0.0'],
+            '/file.ext',
+        ),
+        (
+            '/file.ext',
+            ['1.0.0', '2.0.0'],
+            '/dir/to/file.ext',
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    'version',
+    [None, '2.0.0'],
+)
+@pytest.mark.parametrize(
+    'interface',
+    pytest.VERSIONED,
+    indirect=True,
+)
+def test_copy(tmpdir, src_path, src_versions, dst_path, version, interface):
+
+    if version is None:
+        dst_versions = src_versions
+    else:
+        dst_versions = [version]
+
+    local_path = audeer.path(tmpdir, '~')
+    audeer.touch(local_path)
+    for v in src_versions:
+        interface.put_file(local_path, src_path, v)
+
+    # copy file
+
+    if dst_path != src_path:
+        for v in dst_versions:
+            assert not interface.exists(dst_path, v)
+    interface.copy_file(src_path, dst_path, version=version)
+    for v in dst_versions:
+        assert interface.exists(dst_path, v)
+
+    # copy file again with different checksum
+
+    with open(local_path, 'w') as fp:
+        fp.write('different checksum')
+
+    for v in src_versions:
+        assert audeer.md5(local_path) != interface.checksum(src_path, v)
+        interface.put_file(local_path, src_path, v)
+        assert audeer.md5(local_path) == interface.checksum(src_path, v)
+
+    if dst_path != src_path:
+        for v in dst_versions:
+            assert audeer.md5(local_path) != interface.checksum(dst_path, v)
+    interface.copy_file(src_path, dst_path, version=version)
+    for v in dst_versions:
+        assert audeer.md5(local_path) == interface.checksum(dst_path, v)
+
+    # clean up
+    for v in src_versions:
+        interface.remove_file(src_path, v)
+    if dst_path != src_path:
+        for v in dst_versions:
+            interface.remove_file(dst_path, v)
+
+
+@pytest.mark.parametrize(
     'interface',
     pytest.VERSIONED,
     indirect=True,


### PR DESCRIPTION
Relates to #177 

Adds `backend.Base.copy_file()` to copy a file on the backend. A default implementation is provided, which downloads the files to a temporary directory and afterward uploads it to the new location. The behavior can be overwritten by implementing a custom `_copy_file()` method. In case of a versioned interface, all versions of file are copied unless a specific version is selected.

## Documentation

### API

#### backend.Base / backend.Artifactory / backend.FileSystem

![image](https://github.com/audeering/audbackend/assets/10383417/28b5ff6a-b5bc-401f-b855-68d272576b80)

#### interface.Unversioned

![image](https://github.com/audeering/audbackend/assets/10383417/82e55349-fea6-46ce-bb7f-cd3b9b49b83d)

#### interface.Versioned

![image](https://github.com/audeering/audbackend/assets/10383417/98f21b67-c8eb-4207-a39e-1820f31ed3f8)

### Usage

![image](https://github.com/audeering/audbackend/assets/10383417/03853d1a-975e-46b5-81ec-bd5959007e4e)

...

![image](https://github.com/audeering/audbackend/assets/10383417/8e77c4a6-d605-41e1-8407-fe5a809a484a)

### Developer

![image](https://github.com/audeering/audbackend/assets/10383417/1907fac9-2de6-442b-95d6-a1390a8c7cdb)

