### PR TITLE
Move file on backend

### DIFF
--- a/audbackend/core/backend/artifactory.py
+++ b/audbackend/core/backend/artifactory.py
@@ -281,6 +281,19 @@ class Artifactory(Base):
 
         return paths
 
+    def _move_file(
+            self,
+            src_path: str,
+            dst_path: str,
+            verbose: bool,
+    ):
+        r"""Move file on backend."""
+        src_path = self._path(src_path)
+        dst_path = self._path(dst_path)
+        if not dst_path.parent.exists():
+            dst_path.parent.mkdir()
+        src_path.move(dst_path)
+
     def _owner(
             self,
             path: str,

--- a/audbackend/core/backend/filesystem.py
+++ b/audbackend/core/backend/filesystem.py
@@ -147,6 +147,18 @@ class FileSystem(Base):
 
         return paths
 
+    def _move_file(
+            self,
+            src_path: str,
+            dst_path: str,
+            verbose: bool,
+    ):
+        r"""Move file on backend."""
+        src_path = self._expand(src_path)
+        dst_path = self._expand(dst_path)
+        audeer.mkdir(os.path.dirname(dst_path))
+        audeer.move(src_path, dst_path)
+
     def _owner(
             self,
             path: str,

--- a/audbackend/core/interface/unversioned.py
+++ b/audbackend/core/interface/unversioned.py
@@ -301,6 +301,45 @@ class Unversioned(Base):
             suppress_backend_errors=suppress_backend_errors,
         )
 
+    def move_file(
+            self,
+            src_path: str,
+            dst_path: str,
+            *,
+            verbose: bool = False,
+    ):
+        r"""Move file on backend.
+
+        If ``dst_path`` exists
+        and has a different checksum,
+        it is overwritten.
+        Otherwise,
+        ``src_path``
+        is removed and the operation silently skipped.
+
+        Args:
+            src_path: source path to file on backend
+            dst_path: destination path to file on backend
+            verbose: show debug messages
+
+        Raises:
+            BackendError: if an error is raised on the backend
+            ValueError: if ``src_path`` or ``dst_path``
+                does not start with ``'/'`` or
+                does not match ``'[A-Za-z0-9/._-]+'``
+
+        Examples:
+            >>> unversioned.exists('/move.ext')
+            False
+            >>> unversioned.move_file('/f.ext', '/move.ext')
+            >>> unversioned.exists('/move.ext')
+            True
+            >>> unversioned.exists('/f.ext')
+            False
+
+        """
+        self.backend.move_file(src_path, dst_path, verbose=verbose)
+
     def owner(
             self,
             path: str,

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -483,6 +483,70 @@ class Versioned(Base):
 
         return paths_and_versions
 
+    def move_file(
+            self,
+            src_path: str,
+            dst_path: str,
+            *,
+            version: str = None,
+            verbose: bool = False,
+    ):
+        r"""Move file on backend.
+
+        If ``version`` is ``None``
+        all versions of ``src_path``
+        will be moved.
+
+        If ``dst_path`` exists
+        and has a different checksum,
+        it is overwritten.
+        Otherwise,
+        ``src_path``
+        is removed and the operation silently skipped.
+
+        Args:
+            src_path: source path to file on backend
+            dst_path: destination path to file on backend
+            verbose: show debug messages
+
+        Raises:
+            BackendError: if an error is raised on the backend
+            ValueError: if ``src_path`` or ``dst_path``
+                does not start with ``'/'`` or
+                does not match ``'[A-Za-z0-9/._-]+'``
+
+        Examples:
+            >>> versioned.exists('/move.ext', '1.0.0')
+            False
+            >>> versioned.move_file('/f.ext', '/move.ext', version='1.0.0')
+            >>> versioned.exists('/move.ext', '1.0.0')
+            True
+            >>> versioned.exists('/f.ext', '1.0.0')
+            False
+
+        Raises:
+            BackendError: if an error is raised on the backend
+            ValueError: if ``src_path`` or ``dst_path``
+                does not start with ``'/'`` or
+                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``version`` is empty or
+                does not match ``'[A-Za-z0-9._-]+'``
+
+        """
+        if version is None:
+            versions = self.versions(src_path)
+        else:
+            versions = [version]
+
+        for version in versions:
+            src_path_with_version = self._path_with_version(src_path, version)
+            dst_path_with_version = self._path_with_version(dst_path, version)
+            self.backend.move_file(
+                src_path_with_version,
+                dst_path_with_version,
+                verbose=verbose,
+            )
+
     def owner(
             self,
             path: str,

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -507,6 +507,7 @@ class Versioned(Base):
         Args:
             src_path: source path to file on backend
             dst_path: destination path to file on backend
+            version: version string
             verbose: show debug messages
 
         Raises:

--- a/docs/developer-guide.rst
+++ b/docs/developer-guide.rst
@@ -522,8 +522,7 @@ we provide a more efficient implementation.
 
 
 Implementing a move function is also optional,
-but we for efficiency reasons we provide one,
-too.
+but it is more efficient if we provide one.
 
 .. jupyter-execute::
 

--- a/docs/developer-guide.rst
+++ b/docs/developer-guide.rst
@@ -521,6 +521,31 @@ we provide a more efficient implementation.
     interface.exists('/copy/file.txt', '1.0.0')
 
 
+Implementing a move function is also optional,
+but we for efficiency reasons we provide one,
+too.
+
+.. jupyter-execute::
+
+    @add_method(SQLite)
+    def _move_file(
+            self,
+            src_path: str,
+            dst_path: str,
+            verbose: bool,
+    ):
+        with self._db as db:
+            query = f'''
+                UPDATE data
+                SET path="{dst_path}"
+                WHERE path="{src_path}"
+            '''
+            db.execute(query)
+
+    interface.move_file('/copy/file.txt', '/move/file.txt', version='1.0.0')
+    interface.exists('/move/file.txt', '1.0.0')
+
+
 Finally,
 we implement a method
 to fetch a file

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -112,6 +112,13 @@ and verify it exists.
     interface.copy_file('/file.txt', '/copy/file.txt')
     interface.exists('/copy/file.txt')
 
+We move it to a new location.
+
+.. jupyter-execute::
+
+    interface.move_file('/copy/file.txt', '/move/file.txt')
+    interface.exists('/copy/file.txt'), interface.exists('/move/file.txt')
+
 We download the file
 and store it as ``local.txt``.
 
@@ -268,6 +275,13 @@ Or all versions.
 
     interface.copy_file('/file.txt', '/copy/file.txt')
     interface.ls('/copy/')
+
+We move them to a new location.
+
+.. jupyter-execute::
+
+    interface.move_file('/copy/file.txt', '/move/file.txt')
+    interface.ls('/move/')
 
 When downloading a file,
 we can select the desired version.

--- a/tests/test_interface_unversioned.py
+++ b/tests/test_interface_unversioned.py
@@ -378,6 +378,23 @@ def test_errors(tmpdir, interface):
     with pytest.raises(ValueError, match=error_invalid_char):
         interface.ls(file_invalid_char)
 
+    # --- move_file ---
+    # `src_path` missing
+    with pytest.raises(audbackend.BackendError, match=error_backend):
+        interface.move_file('/missing.txt', '/file.txt')
+    # `src_path` without leading '/'
+    with pytest.raises(ValueError, match=error_invalid_path):
+        interface.move_file(file_invalid_path, '/file.txt')
+    # `src_path` contains invalid character
+    with pytest.raises(ValueError, match=error_invalid_char):
+        interface.move_file(file_invalid_char, '/file.txt')
+    # `dst_path` without leading '/'
+    with pytest.raises(ValueError, match=error_invalid_path):
+        interface.move_file('/file.txt', file_invalid_path)
+    # `dst_path` contains invalid character
+    with pytest.raises(ValueError, match=error_invalid_char):
+        interface.move_file('/file.txt', file_invalid_char)
+
     # --- put_archive ---
     # `src_root` missing
     error_msg = 'No such file or directory: ...'

--- a/tests/test_interface_unversioned.py
+++ b/tests/test_interface_unversioned.py
@@ -576,3 +576,63 @@ def test_ls(tmpdir, interface):
             path,
             pattern=pattern,
         ) == sorted(expected)
+
+
+@pytest.mark.parametrize(
+    'src_path, dst_path',
+    [
+        (
+            '/file.ext',
+            '/file.ext',
+        ),
+        (
+            '/file.ext',
+            '/dir/to/file.ext',
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    'interface',
+    pytest.UNVERSIONED,
+    indirect=True,
+)
+def test_move(tmpdir, src_path, dst_path, interface):
+
+    local_path = audeer.path(tmpdir, '~')
+    audeer.touch(local_path)
+
+    # move file
+
+    interface.put_file(local_path, src_path)
+
+    if dst_path != src_path:
+        assert not interface.exists(dst_path)
+    interface.move_file(src_path, dst_path)
+    if dst_path != src_path:
+        assert not interface.exists(src_path)
+    assert interface.exists(dst_path)
+
+    # move file again with same checksum
+
+    interface.put_file(local_path, src_path)
+
+    interface.move_file(src_path, dst_path)
+    if dst_path != src_path:
+        assert not interface.exists(src_path)
+    assert interface.exists(dst_path)
+
+    # move file again with different checksum
+
+    with open(local_path, 'w') as fp:
+        fp.write('different checksum')
+
+    interface.put_file(local_path, src_path)
+
+    if dst_path != src_path:
+        assert audeer.md5(local_path) != interface.checksum(dst_path)
+    interface.move_file(src_path, dst_path)
+    assert audeer.md5(local_path) == interface.checksum(dst_path)
+
+    # clean up
+
+    interface.remove_file(dst_path)

--- a/tests/test_interface_versioned.py
+++ b/tests/test_interface_versioned.py
@@ -454,6 +454,26 @@ def test_errors(tmpdir, interface):
     with pytest.raises(ValueError, match=error_invalid_char):
         interface.ls(file_invalid_char)
 
+    # --- copy_file ---
+    # `src_path` missing
+    with pytest.raises(audbackend.BackendError, match=error_backend):
+        interface.move_file('/missing.txt', '/file.txt')
+    # `src_path` without leading '/'
+    with pytest.raises(ValueError, match=error_invalid_path):
+        interface.move_file(file_invalid_path, '/file.txt')
+    # `src_path` contains invalid character
+    with pytest.raises(ValueError, match=error_invalid_char):
+        interface.move_file(file_invalid_char, '/file.txt')
+    # `dst_path` without leading '/'
+    with pytest.raises(ValueError, match=error_invalid_path):
+        interface.move_file('/file.txt', file_invalid_path)
+    # `dst_path` contains invalid character
+    with pytest.raises(ValueError, match=error_invalid_char):
+        interface.move_file('/file.txt', file_invalid_char)
+    # invalid version
+    with pytest.raises(ValueError, match=error_empty_version):
+        interface.move_file(remote_file, '/file.txt', version=empty_version)
+
     # --- put_archive ---
     # `src_root` missing
     error_msg = 'No such file or directory: ...'

--- a/tests/test_interface_versioned.py
+++ b/tests/test_interface_versioned.py
@@ -719,6 +719,88 @@ def test_ls(tmpdir, interface):
 
 
 @pytest.mark.parametrize(
+    'src_path, src_versions, dst_path',
+    [
+        (
+            '/file.ext',
+            ['1.0.0', '2.0.0'],
+            '/file.ext',
+        ),
+        (
+            '/file.ext',
+            ['1.0.0', '2.0.0'],
+            '/dir/to/file.ext',
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    'version',
+    [None, '2.0.0'],
+)
+@pytest.mark.parametrize(
+    'interface',
+    pytest.VERSIONED,
+    indirect=True,
+)
+def test_move(tmpdir, src_path, src_versions, dst_path, version, interface):
+
+    if version is None:
+        dst_versions = src_versions
+    else:
+        dst_versions = [version]
+
+    local_path = audeer.path(tmpdir, '~')
+    audeer.touch(local_path)
+
+    # move file
+
+    for v in src_versions:
+        interface.put_file(local_path, src_path, v)
+
+    if dst_path != src_path:
+        for v in dst_versions:
+            assert not interface.exists(dst_path, v)
+    interface.move_file(src_path, dst_path, version=version)
+    if dst_path != src_path:
+        for v in dst_versions:
+            assert not interface.exists(src_path, v)
+    for v in dst_versions:
+        assert interface.exists(dst_path, v)
+
+    # move file again with same checksum
+
+    for v in src_versions:
+        interface.put_file(local_path, src_path, v)
+
+    interface.move_file(src_path, dst_path, version=version)
+    if dst_path != src_path:
+        for v in dst_versions:
+            assert not interface.exists(src_path, v)
+    for v in dst_versions:
+        assert interface.exists(dst_path, v)
+
+    # move file again with different checksum
+
+    with open(local_path, 'w') as fp:
+        fp.write('different checksum')
+
+    for v in src_versions:
+        interface.put_file(local_path, src_path, v)
+
+    if dst_path != src_path:
+        for v in dst_versions:
+            assert audeer.md5(local_path) != interface.checksum(dst_path, v)
+    interface.move_file(src_path, dst_path, version=version)
+    for v in dst_versions:
+        assert audeer.md5(local_path) == interface.checksum(dst_path, v)
+
+    # clean up
+
+    for v in dst_versions:
+        interface.remove_file(dst_path, v)
+
+
+@pytest.mark.parametrize(
     'dst_path',
     [
         '/file.ext',


### PR DESCRIPTION
Closes #177 

We introduce `backend.Base.move_file()`, which moves a file on the backend to a new location. Similar to #181 a default implementation is provided, which can be overwritten when a backend provides a native way to move files.

### backend.Base

![image](https://github.com/audeering/audbackend/assets/10383417/9071816c-0612-4c41-8fd6-250ed549b1ac)

### backend.Artifactory

![image](https://github.com/audeering/audbackend/assets/10383417/6e28a7f3-749d-4968-b277-190a89b69652)

### backend.FileSystem

![image](https://github.com/audeering/audbackend/assets/10383417/0893f2e6-4605-45f7-aaa7-7af3ea55c617)

### interface.Unversioned

![image](https://github.com/audeering/audbackend/assets/10383417/8410550b-aa12-48d1-bdc3-3ab5ac2576e2)

### interface.Versioned

![image](https://github.com/audeering/audbackend/assets/10383417/ea28486b-60ed-4ee2-9e84-86d84be195e6)

### Usage

![image](https://github.com/audeering/audbackend/assets/10383417/eac28934-50d3-4e95-9a0c-93e76b4b0c36)

...

![image](https://github.com/audeering/audbackend/assets/10383417/4f8fca83-0458-4b7a-aa68-10d6cc20e569)

### Development

![image](https://github.com/audeering/audbackend/assets/10383417/d97cdfd0-043f-45eb-aba5-0189f15a58d7)
