### PR TITLE
Support remote and virtual Artifactory repos

### DIFF
--- a/audbackend/core/artifactory.py
+++ b/audbackend/core/artifactory.py
@@ -152,7 +152,7 @@ class Artifactory(Backend):
             self._username,
             self._api_key,
         )
-        self._repo = path.find_repository_local(self.repository)
+        self._repo = path.find_repository(self.repository)
 
         # to support legacy file structure
         # see _use_legacy_file_structure()

--- a/tests/test_artifactory.py
+++ b/tests/test_artifactory.py
@@ -70,8 +70,10 @@ def test_authentication(tmpdir, hosts, hide_credentials):
         fp.write(f'username = {username}\n')
         fp.write(f'password = {api_key}\n')
 
-    with pytest.raises(dohq_artifactory.exception.ArtifactoryException):
-        audbackend.Artifactory(host, 'repository')
+    backend = audbackend.Artifactory(host, 'repository')
+    assert backend._username == username
+    assert backend._api_key == api_key
+    assert backend._repo is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_artifactory.py
+++ b/tests/test_artifactory.py
@@ -1,6 +1,5 @@
 import os
 
-import dohq_artifactory
 import pytest
 
 import audeer


### PR DESCRIPTION
Closes #186 

This add support for remote and virtual Artifactory repositories besides local ones,
by using the `find_repository()` method from the `artifactory` package, see

https://github.com/devopshq/artifactory/blob/c99d9109870e0b05e58d25c83f1458bb44bf54d6/artifactory.py#L2400-L2416

This leads to a different behavior of `audbackend.Artifactory()`. When instanciating the object it no longer raises an error if no repo could be found for the given path (or when no access rights were given for that repo). This behavior was anyway not documented. When using `audbackend.access()` it still raises an error when the username, password do not work.