### PR TITLE
Introduce optional validation step

### DIFF
--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -41,6 +41,7 @@ class Base:
 
     def _assert_equal_checksum(
             self,
+            *,
             path: str,
             path_is_local: bool,
             path_ref: str,
@@ -192,10 +193,10 @@ class Base:
 
             if validate:
                 self._assert_equal_checksum(
-                    dst_path,
-                    False,
-                    src_path,
-                    False,
+                    path=dst_path,
+                    path_is_local=False,
+                    path_ref=src_path,
+                    path_ref_is_local=False,
                 )
 
     def _create(
@@ -460,10 +461,10 @@ class Base:
 
             if validate:
                 self._assert_equal_checksum(
-                    dst_path,
-                    True,
-                    src_path,
-                    False,
+                    path=dst_path,
+                    path_is_local=True,
+                    path_ref=src_path,
+                    path_ref_is_local=False,
                 )
 
         return dst_path
@@ -876,10 +877,10 @@ class Base:
 
             if validate:
                 self._assert_equal_checksum(
-                    dst_path,
-                    False,
-                    src_path,
-                    True,
+                    path=dst_path,
+                    path_is_local=False,
+                    path_ref=src_path,
+                    path_ref_is_local=True,
                 )
 
     def _remove_file(

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -67,7 +67,7 @@ class Base:
                 location = 'backend'
 
             raise InterruptedError(
-                f"Execution was interrupted because "
+                f"Execution is interrupted because "
                 f"{path} "
                 f"has checksum "
                 f"'{checksum}' "
@@ -151,17 +151,17 @@ class Base:
         have the same checksum.
         If it fails,
         ``dst_path`` is removed and
-        an :class:`InterruptedError` is raised
+        an :class:`InterruptedError` is raised.
 
         Args:
             src_path: source path to file on backend
             dst_path: destination path to file on backend
-            validate: validate file was successfully copied
+            validate: verify file was successfully copied
             verbose: show debug messages
 
         Raises:
             BackendError: if an error is raised on the backend
-            InterruptedError: if validation check fails
+            InterruptedError: if validation fails
             ValueError: if ``src_path`` or ``dst_path``
                 does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
@@ -296,6 +296,7 @@ class Base:
             dst_root: str,
             *,
             tmp_root: str = None,
+            validate: bool = False,
             verbose: bool = False,
     ) -> typing.List[str]:
         r"""Get archive from backend and extract.
@@ -306,11 +307,21 @@ class Base:
         If ``dst_root`` does not exist,
         it is created.
 
+        If ``validate`` is set to ``True``,
+        a final check is performed to assert that
+        ``src_path`` and the retrieved archive
+        have the same checksum.
+        If it fails,
+        the retrieved archive is removed and
+        an :class:`InterruptedError` is raised.
+
         Args:
             src_path: path to archive on backend
             dst_root: local destination directory
             tmp_root: directory under which archive is temporarily extracted.
                 Defaults to temporary directory of system
+            validate: verify archive was successfully
+                retrieved from the backend
             verbose: show debug messages
 
         Returns:
@@ -320,6 +331,7 @@ class Base:
             BackendError: if an error is raised on the backend,
                 e.g. ``src_path`` does not exist
             FileNotFoundError: if ``tmp_root`` does not exist
+            InterruptedError: if validation fails
             NotADirectoryError: if ``dst_root`` is not a directory
             PermissionError: if the user lacks write permissions
                 for ``dst_path``
@@ -341,6 +353,7 @@ class Base:
             self.get_file(
                 src_path,
                 local_archive,
+                validate=validate,
                 verbose=verbose,
             )
 
@@ -385,12 +398,12 @@ class Base:
         have the same checksum.
         If it fails,
         ``dst_path`` is removed and
-        an :class:`InterruptedError` is raised
+        an :class:`InterruptedError` is raised.
 
         Args:
             src_path: path to file on backend
             dst_path: destination path to local file
-            validate: validate file was successfully
+            validate: verify file was successfully
                 retrieved from the backend
             verbose: show debug messages
 
@@ -400,7 +413,7 @@ class Base:
         Raises:
             BackendError: if an error is raised on the backend,
                 e.g. ``src_path`` does not exist
-            InterruptedError: if validation check fails
+            InterruptedError: if validation fails
             IsADirectoryError: if ``dst_path`` points to an existing folder
             PermissionError: if the user lacks write permissions
                 for ``dst_path``
@@ -599,8 +612,8 @@ class Base:
             self,
             src_path: str,
             dst_path: str,
-            validate: bool = False,
             *,
+            validate: bool = False,
             verbose: bool = False,
     ):
         r"""Move file on backend.
@@ -621,18 +634,18 @@ class Base:
         an :class:`InterruptedError` is raised.
         In addition,
         ``src_path`` is restored from a temporary copy.
-        Keeping this copy will create
+        Note that keeping this copy creates
         additional costs on top of the checksums.
 
         Args:
             src_path: source path to file on backend
             dst_path: destination path to file on backend
-            validate: validate file was successfully moved
+            validate: verify file was successfully moved
             verbose: show debug messages
 
         Raises:
             BackendError: if an error is raised on the backend
-            InterruptedError: if validation check fails
+            InterruptedError: if validation fails
             ValueError: if ``src_path`` or ``dst_path``
                 does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
@@ -729,6 +742,7 @@ class Base:
             *,
             files: typing.Union[str, typing.Sequence[str]] = None,
             tmp_root: str = None,
+            validate: bool = False,
             verbose: bool = False,
     ):
         r"""Create archive and put on backend.
@@ -739,6 +753,14 @@ class Base:
         The operation is silently skipped,
         if an archive with the same checksum
         already exists on the backend.
+
+        If ``validate`` is set to ``True``,
+        a final check is performed to assert that
+        the local archive and ``dst_path``
+        have the same checksum.
+        If it fails,
+        ``dst_path`` is removed and
+        an :class:`InterruptedError` is raised.
 
         Args:
             src_root: local root directory where files are located.
@@ -751,6 +773,8 @@ class Base:
                 Must exist within ``src_root``
             tmp_root: directory under which archive is temporarily created.
                 Defaults to temporary directory of system
+            validate: verify archive was successfully
+                put on the backend
             verbose: show debug messages
 
         """
@@ -775,6 +799,7 @@ class Base:
             self.put_file(
                 archive,
                 dst_path,
+                validate=validate,
                 verbose=verbose,
             )
 
@@ -808,19 +833,19 @@ class Base:
         have the same checksum.
         If it fails,
         ``dst_path`` is removed and
-        an :class:`InterruptedError` is raised
+        an :class:`InterruptedError` is raised.
 
         Args:
             src_path: path to local file
             dst_path: path to file on backend
-            validate: validate file was successfully
+            validate: verify file was successfully
                 put on the backend
             verbose: show debug messages
 
         Raises:
             BackendError: if an error is raised on the backend
             FileNotFoundError: if ``src_path`` does not exist
-            InterruptedError: if validation check fails
+            InterruptedError: if validation fails
             IsADirectoryError: if ``src_path`` is a folder
             ValueError: if ``dst_path`` does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -620,8 +620,9 @@ class Base:
         ``dst_path`` is removed and
         an :class:`InterruptionError` is raised.
         In addition,
-        an attempt is made
-        to restore ``src_path`` from a local copy.
+        ``src_path`` is restored from a temporary copy.
+        Keeping this copy will create
+        additional costs on top of the checksums.
 
         Args:
             src_path: source path to file on backend

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -777,6 +777,16 @@ class Base:
                 put on the backend
             verbose: show debug messages
 
+        Raises:
+            BackendError: if an error is raised on the backend
+            FileNotFoundError: if ``src_root`` or ``tmp_root`` does not exist
+            InterruptedError: if validation fails
+            NotADirectoryError: if ``src_root`` is not a folder
+            RuntimeError: if extension of ``dst_path`` is not supported
+                or a file in ``files`` is not below ``src_root``
+            ValueError: if ``dst_path`` does not start with ``'/'`` or
+                does not match ``'[A-Za-z0-9/._-]+'``
+
         """
         dst_path = utils.check_path(dst_path)
         src_root = audeer.path(src_root)

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -151,7 +151,7 @@ class Base:
         have the same checksum.
         If it fails,
         ``dst_path`` is removed and
-        an :class:`InterruptionError` is raised
+        an :class:`InterruptedError` is raised
 
         Args:
             src_path: source path to file on backend
@@ -161,7 +161,7 @@ class Base:
 
         Raises:
             BackendError: if an error is raised on the backend
-            InterruptionError: if validation check fails
+            InterruptedError: if validation check fails
             ValueError: if ``src_path`` or ``dst_path``
                 does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
@@ -385,7 +385,7 @@ class Base:
         have the same checksum.
         If it fails,
         ``dst_path`` is removed and
-        an :class:`InterruptionError` is raised
+        an :class:`InterruptedError` is raised
 
         Args:
             src_path: path to file on backend
@@ -400,7 +400,7 @@ class Base:
         Raises:
             BackendError: if an error is raised on the backend,
                 e.g. ``src_path`` does not exist
-            InterruptionError: if validation check fails
+            InterruptedError: if validation check fails
             IsADirectoryError: if ``dst_path`` points to an existing folder
             PermissionError: if the user lacks write permissions
                 for ``dst_path``
@@ -618,7 +618,7 @@ class Base:
         have the same checksum.
         If it fails,
         ``dst_path`` is removed and
-        an :class:`InterruptionError` is raised.
+        an :class:`InterruptedError` is raised.
         In addition,
         ``src_path`` is restored from a temporary copy.
         Keeping this copy will create
@@ -632,7 +632,7 @@ class Base:
 
         Raises:
             BackendError: if an error is raised on the backend
-            InterruptionError: if validation check fails
+            InterruptedError: if validation check fails
             ValueError: if ``src_path`` or ``dst_path``
                 does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
@@ -808,7 +808,7 @@ class Base:
         have the same checksum.
         If it fails,
         ``dst_path`` is removed and
-        an :class:`InterruptionError` is raised
+        an :class:`InterruptedError` is raised
 
         Args:
             src_path: path to local file
@@ -820,7 +820,7 @@ class Base:
         Raises:
             BackendError: if an error is raised on the backend
             FileNotFoundError: if ``src_path`` does not exist
-            InterruptionError: if validation check fails
+            InterruptedError: if validation check fails
             IsADirectoryError: if ``src_path`` is a folder
             ValueError: if ``dst_path`` does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -39,6 +39,44 @@ class Base:
         """
         raise NotImplementedError()
 
+    def _assert_equal_checksum(
+            self,
+            path: str,
+            path_is_local: bool,
+            path_ref: str,
+            path_ref_is_local: bool,
+    ):
+
+        if path_is_local:
+            checksum = audeer.md5(path)
+        else:
+            checksum = self.checksum(path)
+
+        if path_ref_is_local:
+            checksum_ref = audeer.md5(path_ref)
+        else:
+            checksum_ref = self.checksum(path_ref)
+
+        if checksum != checksum_ref:
+
+            if path_is_local:
+                os.remove(path)
+                location = 'local file system'
+            else:
+                self.remove_file(path)
+                location = 'backend'
+
+            raise InterruptedError(
+                f"Execution was interrupted because "
+                f"{path} "
+                f"has checksum "
+                f"'{checksum}' "
+                "when the expected checksum is "
+                f"'{checksum_ref}'. "
+                f"The file has been removed from the "
+                f"{location}."
+            )
+
     def _checksum(
             self,
             path: str,
@@ -96,6 +134,7 @@ class Base:
             src_path: str,
             dst_path: str,
             *,
+            validate: bool = False,
             verbose: bool = False,
     ):
         r"""Copy file on backend.
@@ -106,13 +145,23 @@ class Base:
         Otherwise,
         the operation is silently skipped.
 
+        If ``validate`` is set to ``True``,
+        a final check is performed to assert that
+        ``src_path`` and ``dst_path``
+        have the same checksum.
+        If it fails,
+        ``dst_path`` is removed and
+        an :class:`InterruptionError` is raised
+
         Args:
             src_path: source path to file on backend
             dst_path: destination path to file on backend
+            validate: validate file was successfully copied
             verbose: show debug messages
 
         Raises:
             BackendError: if an error is raised on the backend
+            InterruptionError: if validation check fails
             ValueError: if ``src_path`` or ``dst_path``
                 does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
@@ -134,6 +183,14 @@ class Base:
                 dst_path,
                 verbose,
             )
+
+            if validate:
+                self._assert_equal_checksum(
+                    dst_path,
+                    False,
+                    src_path,
+                    False,
+                )
 
     def _create(
             self,
@@ -307,6 +364,7 @@ class Base:
             src_path: str,
             dst_path: str,
             *,
+            validate: bool = False,
             verbose: bool = False,
     ) -> str:
         r"""Get file from backend.
@@ -321,13 +379,19 @@ class Base:
         Otherwise,
         the operation is silently skipped.
 
-        To ensure the file is completely retrieved,
-        it is first stored in a temporary directory
-        and afterward moved to ``dst_path``.
+        If ``validate`` is set to ``True``,
+        a final check is performed to assert that
+        ``src_path`` and ``dst_path``
+        have the same checksum.
+        If it fails,
+        ``dst_path`` is removed and
+        an :class:`InterruptionError` is raised
 
         Args:
             src_path: path to file on backend
             dst_path: destination path to local file
+            validate: validate file was successfully
+                retrieved from the backend
             verbose: show debug messages
 
         Returns:
@@ -336,6 +400,7 @@ class Base:
         Raises:
             BackendError: if an error is raised on the backend,
                 e.g. ``src_path`` does not exist
+            InterruptionError: if validation check fails
             IsADirectoryError: if ``dst_path`` points to an existing folder
             PermissionError: if the user lacks write permissions
                 for ``dst_path``
@@ -373,6 +438,14 @@ class Base:
                     verbose,
                 )
                 audeer.move_file(tmp_path, dst_path)
+
+            if validate:
+                self._assert_equal_checksum(
+                    dst_path,
+                    True,
+                    src_path,
+                    False,
+                )
 
         return dst_path
 
@@ -526,6 +599,7 @@ class Base:
             self,
             src_path: str,
             dst_path: str,
+            validate: bool = False,
             *,
             verbose: bool = False,
     ):
@@ -538,13 +612,26 @@ class Base:
         ``src_path``
         is removed and the operation silently skipped.
 
+        If ``validate`` is set to ``True``,
+        a final check is performed to assert that
+        ``src_path`` and ``dst_path``
+        have the same checksum.
+        If it fails,
+        ``dst_path`` is removed and
+        an :class:`InterruptionError` is raised.
+        In addition,
+        an attempt is made
+        to restore ``src_path`` from a local copy.
+
         Args:
             src_path: source path to file on backend
             dst_path: destination path to file on backend
+            validate: validate file was successfully moved
             verbose: show debug messages
 
         Raises:
             BackendError: if an error is raised on the backend
+            InterruptionError: if validation check fails
             ValueError: if ``src_path`` or ``dst_path``
                 does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
@@ -560,12 +647,37 @@ class Base:
             not self.exists(dst_path)
             or self.checksum(src_path) != self.checksum(dst_path)
         ):
-            utils.call_function_on_backend(
-                self._move_file,
-                src_path,
-                dst_path,
-                verbose,
-            )
+            if validate:
+                with tempfile.TemporaryDirectory() as tmp:
+
+                    tmp_path = audeer.path(tmp, '~')
+                    self.get_file(src_path, tmp_path, validate=True)
+
+                    utils.call_function_on_backend(
+                        self._move_file,
+                        src_path,
+                        dst_path,
+                        verbose,
+                    )
+
+                    try:
+                        self._assert_equal_checksum(
+                            dst_path,
+                            False,
+                            tmp_path,
+                            True,
+                        )
+                    except InterruptedError as ex:
+                        self.put_file(tmp_path, src_path, validate=True)
+                        raise ex
+
+            else:
+                utils.call_function_on_backend(
+                    self._move_file,
+                    src_path,
+                    dst_path,
+                    verbose,
+                )
         else:
             self.remove_file(src_path)
 
@@ -680,6 +792,7 @@ class Base:
             src_path: str,
             dst_path: str,
             *,
+            validate: bool = False,
             verbose: bool = False,
     ):
         r"""Put file on backend.
@@ -688,14 +801,25 @@ class Base:
         if a file with the same checksum
         already exists on the backend.
 
+        If ``validate`` is set to ``True``,
+        a final check is performed to assert that
+        ``src_path`` and ``dst_path``
+        have the same checksum.
+        If it fails,
+        ``dst_path`` is removed and
+        an :class:`InterruptionError` is raised
+
         Args:
             src_path: path to local file
             dst_path: path to file on backend
+            validate: validate file was successfully
+                put on the backend
             verbose: show debug messages
 
         Raises:
             BackendError: if an error is raised on the backend
             FileNotFoundError: if ``src_path`` does not exist
+            InterruptionError: if validation check fails
             IsADirectoryError: if ``src_path`` is a folder
             ValueError: if ``dst_path`` does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
@@ -721,6 +845,14 @@ class Base:
                 checksum,
                 verbose,
             )
+
+            if validate:
+                self._assert_equal_checksum(
+                    dst_path,
+                    False,
+                    src_path,
+                    True,
+                )
 
     def _remove_file(
             self,

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -779,11 +779,14 @@ class Base:
 
         Raises:
             BackendError: if an error is raised on the backend
-            FileNotFoundError: if ``src_root`` or ``tmp_root`` does not exist
+            FileNotFoundError: if ``src_root``,
+                ``tmp_root``,
+                or one or more ``files`` do not exist
             InterruptedError: if validation fails
             NotADirectoryError: if ``src_root`` is not a folder
-            RuntimeError: if extension of ``dst_path`` is not supported
-                or a file in ``files`` is not below ``src_root``
+            RuntimeError: if ``dst_path`` does not end with
+                ``zip`` or ``tar.gz``
+                or a file in ``files`` is not below ``root``
             ValueError: if ``dst_path`` does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
 

--- a/audbackend/core/interface/unversioned.py
+++ b/audbackend/core/interface/unversioned.py
@@ -42,6 +42,7 @@ class Unversioned(Base):
             src_path: str,
             dst_path: str,
             *,
+            validate: bool = False,
             verbose: bool = False,
     ):
         r"""Copy file on backend.
@@ -52,13 +53,23 @@ class Unversioned(Base):
         Otherwise,
         the operation is silently skipped.
 
+        If ``validate`` is set to ``True``,
+        a final check is performed to assert that
+        ``src_path`` and ``dst_path``
+        have the same checksum.
+        If it fails,
+        ``dst_path`` is removed and
+        an :class:`InterruptedError` is raised.
+
         Args:
             src_path: source path to file on backend
             dst_path: destination path to file on backend
+            validate: verify file was successfully copied
             verbose: show debug messages
 
         Raises:
             BackendError: if an error is raised on the backend
+            InterruptedError: if validation fails
             ValueError: if ``src_path`` or ``dst_path``
                 does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
@@ -71,7 +82,12 @@ class Unversioned(Base):
             True
 
         """
-        self.backend.copy_file(src_path, dst_path, verbose=verbose)
+        self.backend.copy_file(
+            src_path,
+            dst_path,
+            validate=validate,
+            verbose=verbose,
+        )
 
     def date(
             self,
@@ -143,6 +159,7 @@ class Unversioned(Base):
             dst_root: str,
             *,
             tmp_root: str = None,
+            validate: bool = False,
             verbose: bool = False,
     ) -> typing.List[str]:
         r"""Get archive from backend and extract.
@@ -153,11 +170,21 @@ class Unversioned(Base):
         If ``dst_root`` does not exist,
         it is created.
 
+        If ``validate`` is set to ``True``,
+        a final check is performed to assert that
+        ``src_path`` and the retrieved archive
+        have the same checksum.
+        If it fails,
+        the retrieved archive is removed and
+        an :class:`InterruptedError` is raised.
+
         Args:
             src_path: path to archive on backend
             dst_root: local destination directory
             tmp_root: directory under which archive is temporarily extracted.
                 Defaults to temporary directory of system
+            validate: verify archive was successfully
+                retrieved from the backend
             verbose: show debug messages
 
         Returns:
@@ -167,6 +194,7 @@ class Unversioned(Base):
             BackendError: if an error is raised on the backend,
                 e.g. ``src_path`` does not exist
             FileNotFoundError: if ``tmp_root`` does not exist
+            InterruptedError: if validation fails
             NotADirectoryError: if ``dst_root`` is not a directory
             PermissionError: if the user lacks write permissions
                 for ``dst_path``
@@ -184,6 +212,7 @@ class Unversioned(Base):
             src_path,
             dst_root,
             tmp_root=tmp_root,
+            validate=validate,
             verbose=verbose,
         )
 
@@ -192,6 +221,7 @@ class Unversioned(Base):
             src_path: str,
             dst_path: str,
             *,
+            validate: bool = False,
             verbose: bool = False,
     ) -> str:
         r"""Get file from backend.
@@ -203,16 +233,22 @@ class Unversioned(Base):
         If ``dst_path`` exists
         with a different checksum,
         it is overwritten,
-        or otherwise,
+        Otherwise,
         the operation is silently skipped.
 
-        To ensure the file is completely retrieved,
-        it is first stored in a temporary directory
-        and afterwards moved to ``dst_path``.
+        If ``validate`` is set to ``True``,
+        a final check is performed to assert that
+        ``src_path`` and ``dst_path``
+        have the same checksum.
+        If it fails,
+        ``dst_path`` is removed and
+        an :class:`InterruptedError` is raised.
 
         Args:
             src_path: path to file on backend
             dst_path: destination path to local file
+            validate: verify file was successfully
+                retrieved from the backend
             verbose: show debug messages
 
         Returns:
@@ -221,6 +257,7 @@ class Unversioned(Base):
         Raises:
             BackendError: if an error is raised on the backend,
                 e.g. ``src_path`` does not exist
+            InterruptedError: if validation fails
             IsADirectoryError: if ``dst_path`` points to an existing folder
             PermissionError: if the user lacks write permissions
                 for ``dst_path``
@@ -235,7 +272,12 @@ class Unversioned(Base):
             True
 
         """
-        return self.backend.get_file(src_path, dst_path, verbose=verbose)
+        return self.backend.get_file(
+            src_path,
+            dst_path,
+            validate=validate,
+            verbose=verbose,
+        )
 
     def ls(
             self,
@@ -306,6 +348,7 @@ class Unversioned(Base):
             src_path: str,
             dst_path: str,
             *,
+            validate: bool = False,
             verbose: bool = False,
     ):
         r"""Move file on backend.
@@ -317,13 +360,27 @@ class Unversioned(Base):
         ``src_path``
         is removed and the operation silently skipped.
 
+        If ``validate`` is set to ``True``,
+        a final check is performed to assert that
+        ``src_path`` and ``dst_path``
+        have the same checksum.
+        If it fails,
+        ``dst_path`` is removed and
+        an :class:`InterruptedError` is raised.
+        In addition,
+        ``src_path`` is restored from a temporary copy.
+        Note that keeping this copy creates
+        additional costs on top of the checksums.
+
         Args:
             src_path: source path to file on backend
             dst_path: destination path to file on backend
+            validate: verify file was successfully moved
             verbose: show debug messages
 
         Raises:
             BackendError: if an error is raised on the backend
+            InterruptedError: if validation fails
             ValueError: if ``src_path`` or ``dst_path``
                 does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
@@ -338,7 +395,12 @@ class Unversioned(Base):
             False
 
         """
-        self.backend.move_file(src_path, dst_path, verbose=verbose)
+        self.backend.move_file(
+            src_path,
+            dst_path,
+            validate=validate,
+            verbose=verbose,
+        )
 
     def owner(
             self,
@@ -376,6 +438,7 @@ class Unversioned(Base):
             *,
             files: typing.Union[str, typing.Sequence[str]] = None,
             tmp_root: str = None,
+            validate: bool = False,
             verbose: bool = False,
     ):
         r"""Create archive and put on backend.
@@ -386,6 +449,14 @@ class Unversioned(Base):
         The operation is silently skipped,
         if an archive with the same checksum
         already exists on the backend.
+
+        If ``validate`` is set to ``True``,
+        a final check is performed to assert that
+        the local archive and ``dst_path``
+        have the same checksum.
+        If it fails,
+        ``dst_path`` is removed and
+        an :class:`InterruptedError` is raised.
 
         Args:
             src_root: local root directory where files are located.
@@ -398,6 +469,8 @@ class Unversioned(Base):
                 Must exist within ``src_root``
             tmp_root: directory under which archive is temporarily created.
                 Defaults to temporary directory of system
+            validate: verify archive was successfully
+                put on the backend
             verbose: show debug messages
 
         Raises:
@@ -405,6 +478,7 @@ class Unversioned(Base):
             FileNotFoundError: if ``src_root``,
                 ``tmp_root``,
                 or one or more ``files`` do not exist
+            InterruptedError: if validation fails
             NotADirectoryError: if ``src_root`` is not a folder
             RuntimeError: if ``dst_path`` does not end with
                 ``zip`` or ``tar.gz``
@@ -425,6 +499,7 @@ class Unversioned(Base):
             dst_path,
             files=files,
             tmp_root=tmp_root,
+            validate=validate,
             verbose=verbose,
         )
 
@@ -433,6 +508,7 @@ class Unversioned(Base):
             src_path: str,
             dst_path: str,
             *,
+            validate: bool = False,
             verbose: bool = False,
     ):
         r"""Put file on backend.
@@ -441,17 +517,25 @@ class Unversioned(Base):
         if a file with the same checksum
         already exists on the backend.
 
+        If ``validate`` is set to ``True``,
+        a final check is performed to assert that
+        ``src_path`` and ``dst_path``
+        have the same checksum.
+        If it fails,
+        ``dst_path`` is removed and
+        an :class:`InterruptedError` is raised.
+
         Args:
             src_path: path to local file
             dst_path: path to file on backend
+            validate: verify file was successfully
+                put on the backend
             verbose: show debug messages
-
-        Returns:
-            file path on backend
 
         Raises:
             BackendError: if an error is raised on the backend
             FileNotFoundError: if ``src_path`` does not exist
+            InterruptedError: if validation fails
             IsADirectoryError: if ``src_path`` is a folder
             ValueError: if ``dst_path`` does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
@@ -464,7 +548,12 @@ class Unversioned(Base):
             True
 
         """
-        self.backend.put_file(src_path, dst_path, verbose=verbose)
+        self.backend.put_file(
+            src_path,
+            dst_path,
+            validate=validate,
+            verbose=verbose,
+        )
 
     def remove_file(
             self,

--- a/audbackend/core/interface/unversioned.py
+++ b/audbackend/core/interface/unversioned.py
@@ -367,10 +367,9 @@ class Unversioned(Base):
         If it fails,
         ``dst_path`` is removed and
         an :class:`InterruptedError` is raised.
-        In addition,
-        ``src_path`` is restored from a temporary copy.
-        Note that keeping this copy creates
-        additional costs on top of the checksums.
+        To ensure ``src_path`` still exists in this case
+        it is first copied and only removed
+        when the check has successfully passed.
 
         Args:
             src_path: source path to file on backend

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -332,6 +332,7 @@ class Versioned(Base):
         return self.backend.get_file(
             src_path_with_version,
             dst_path,
+            validate=validate,
             verbose=verbose,
         )
 
@@ -698,6 +699,7 @@ class Versioned(Base):
             dst_path_with_version,
             files=files,
             tmp_root=tmp_root,
+            validate=validate,
             verbose=verbose,
         )
 

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -546,10 +546,9 @@ class Versioned(Base):
         If it fails,
         ``dst_path`` is removed and
         an :class:`InterruptedError` is raised.
-        In addition,
-        ``src_path`` is restored from a temporary copy.
-        Note that keeping this copy creates
-        additional costs on top of the checksums.
+        To ensure ``src_path`` still exists in this case
+        it is first copied and only removed
+        when the check has successfully passed.
 
         Args:
             src_path: source path to file on backend

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -66,6 +66,7 @@ class Versioned(Base):
             dst_path: str,
             *,
             version: str = None,
+            validate: bool = False,
             verbose: bool = False,
     ):
         r"""Copy file on backend.
@@ -80,9 +81,18 @@ class Versioned(Base):
         Otherwise,
         the operation is silently skipped.
 
+        If ``validate`` is set to ``True``,
+        a final check is performed to assert that
+        ``src_path`` and ``dst_path``
+        have the same checksum.
+        If it fails,
+        ``dst_path`` is removed and
+        an :class:`InterruptedError` is raised.
+
         Args:
             src_path: source path to file on backend
             dst_path: destination path to file on backend
+            validate: verify file was successfully copied
             version: version string
             verbose: show debug messages
 
@@ -95,6 +105,7 @@ class Versioned(Base):
 
         Raises:
             BackendError: if an error is raised on the backend
+            InterruptedError: if validation fails
             ValueError: if ``src_path`` or ``dst_path``
                 does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
@@ -113,6 +124,7 @@ class Versioned(Base):
             self.backend.copy_file(
                 src_path_with_version,
                 dst_path_with_version,
+                validate=validate,
                 verbose=verbose,
             )
 
@@ -195,6 +207,7 @@ class Versioned(Base):
             version: str,
             *,
             tmp_root: str = None,
+            validate: bool = False,
             verbose: bool = False,
     ) -> typing.List[str]:
         r"""Get archive from backend and extract.
@@ -205,12 +218,22 @@ class Versioned(Base):
         If ``dst_root`` does not exist,
         it is created.
 
+        If ``validate`` is set to ``True``,
+        a final check is performed to assert that
+        ``src_path`` and the retrieved archive
+        have the same checksum.
+        If it fails,
+        the retrieved archive is removed and
+        an :class:`InterruptedError` is raised.
+
         Args:
             src_path: path to archive on backend
             dst_root: local destination directory
             version: version string
             tmp_root: directory under which archive is temporarily extracted.
                 Defaults to temporary directory of system
+            validate: verify archive was successfully
+                retrieved from the backend
             verbose: show debug messages
 
         Returns:
@@ -220,6 +243,7 @@ class Versioned(Base):
             BackendError: if an error is raised on the backend,
                 e.g. ``src_path`` does not exist
             FileNotFoundError: if ``tmp_root`` does not exist
+            InterruptedError: if validation fails
             NotADirectoryError: if ``dst_root`` is not a directory
             PermissionError: if the user lacks write permissions
                 for ``dst_path``
@@ -240,6 +264,7 @@ class Versioned(Base):
             src_path_with_version,
             dst_root,
             tmp_root=tmp_root,
+            validate=validate,
             verbose=verbose,
         )
 
@@ -249,6 +274,7 @@ class Versioned(Base):
             dst_path: str,
             version: str,
             *,
+            validate: bool = False,
             verbose: bool = False,
     ) -> str:
         r"""Get file from backend.
@@ -263,14 +289,20 @@ class Versioned(Base):
         or otherwise,
         the operation is silently skipped.
 
-        To ensure the file is completely retrieved,
-        it is first stored in a temporary directory
-        and afterwards moved to ``dst_path``.
+        If ``validate`` is set to ``True``,
+        a final check is performed to assert that
+        ``src_path`` and ``dst_path``
+        have the same checksum.
+        If it fails,
+        ``dst_path`` is removed and
+        an :class:`InterruptedError` is raised.
 
         Args:
             src_path: path to file on backend
             dst_path: destination path to local file
             version: version string
+            validate: verify file was successfully
+                retrieved from the backend
             verbose: show debug messages
 
         Returns:
@@ -279,6 +311,7 @@ class Versioned(Base):
         Raises:
             BackendError: if an error is raised on the backend,
                 e.g. ``src_path`` does not exist
+            InterruptedError: if validation fails
             IsADirectoryError: if ``dst_path`` points to an existing folder
             PermissionError: if the user lacks write permissions
                 for ``dst_path``
@@ -489,6 +522,7 @@ class Versioned(Base):
             dst_path: str,
             *,
             version: str = None,
+            validate: bool = False,
             verbose: bool = False,
     ):
         r"""Move file on backend.
@@ -504,17 +538,33 @@ class Versioned(Base):
         ``src_path``
         is removed and the operation silently skipped.
 
+        If ``validate`` is set to ``True``,
+        a final check is performed to assert that
+        ``src_path`` and ``dst_path``
+        have the same checksum.
+        If it fails,
+        ``dst_path`` is removed and
+        an :class:`InterruptedError` is raised.
+        In addition,
+        ``src_path`` is restored from a temporary copy.
+        Note that keeping this copy creates
+        additional costs on top of the checksums.
+
         Args:
             src_path: source path to file on backend
             dst_path: destination path to file on backend
             version: version string
+            validate: verify file was successfully moved
             verbose: show debug messages
 
         Raises:
             BackendError: if an error is raised on the backend
+            InterruptedError: if validation fails
             ValueError: if ``src_path`` or ``dst_path``
                 does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``version`` is empty or
+                does not match ``'[A-Za-z0-9._-]+'``
 
         Examples:
             >>> versioned.exists('/move.ext', '1.0.0')
@@ -524,14 +574,6 @@ class Versioned(Base):
             True
             >>> versioned.exists('/f.ext', '1.0.0')
             False
-
-        Raises:
-            BackendError: if an error is raised on the backend
-            ValueError: if ``src_path`` or ``dst_path``
-                does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
-            ValueError: if ``version`` is empty or
-                does not match ``'[A-Za-z0-9._-]+'``
 
         """
         if version is None:
@@ -545,6 +587,7 @@ class Versioned(Base):
             self.backend.move_file(
                 src_path_with_version,
                 dst_path_with_version,
+                validate=validate,
                 verbose=verbose,
             )
 
@@ -590,6 +633,7 @@ class Versioned(Base):
             *,
             files: typing.Union[str, typing.Sequence[str]] = None,
             tmp_root: str = None,
+            validate: bool = False,
             verbose: bool = False,
     ):
         r"""Create archive and put on backend.
@@ -600,6 +644,14 @@ class Versioned(Base):
         The operation is silently skipped,
         if an archive with the same checksum
         already exists on the backend.
+
+        If ``validate`` is set to ``True``,
+        a final check is performed to assert that
+        the local archive and ``dst_path``
+        have the same checksum.
+        If it fails,
+        ``dst_path`` is removed and
+        an :class:`InterruptedError` is raised.
 
         Args:
             src_root: local root directory where files are located.
@@ -613,6 +665,8 @@ class Versioned(Base):
                 Must exist within ``src_root``
             tmp_root: directory under which archive is temporarily created.
                 Defaults to temporary directory of system
+            validate: verify archive was successfully
+                put on the backend
             verbose: show debug messages
 
         Raises:
@@ -620,6 +674,7 @@ class Versioned(Base):
             FileNotFoundError: if ``src_root``,
                 ``tmp_root``,
                 or one or more ``files`` do not exist
+            InterruptedError: if validation fails
             NotADirectoryError: if ``src_root`` is not a folder
             RuntimeError: if ``dst_path`` does not end with
                 ``zip`` or ``tar.gz``
@@ -652,6 +707,7 @@ class Versioned(Base):
             dst_path: str,
             version: str,
             *,
+            validate: bool = False,
             verbose: bool = False,
     ):
         r"""Put file on backend.
@@ -660,10 +716,20 @@ class Versioned(Base):
         if a file with the same checksum
         already exists on the backend.
 
+        If ``validate`` is set to ``True``,
+        a final check is performed to assert that
+        ``src_path`` and ``dst_path``
+        have the same checksum.
+        If it fails,
+        ``dst_path`` is removed and
+        an :class:`InterruptedError` is raised.
+
         Args:
             src_path: path to local file
             dst_path: path to file on backend
             version: version string
+            validate: verify file was successfully
+                put on the backend
             verbose: show debug messages
 
         Returns:
@@ -672,6 +738,7 @@ class Versioned(Base):
         Raises:
             BackendError: if an error is raised on the backend
             FileNotFoundError: if ``src_path`` does not exist
+            InterruptedError: if validation fails
             IsADirectoryError: if ``src_path`` is a folder
             ValueError: if ``dst_path`` does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
@@ -690,6 +757,7 @@ class Versioned(Base):
         return self.backend.put_file(
             src_path,
             dst_path_with_version,
+            validate=validate,
             verbose=verbose,
         )
 


### PR DESCRIPTION
Closes #189 

Adds `validate` argument to the following functions:

* `copy_file()`
* `get_archive()`
* `get_file()`
* `move_file()`
* `put_archive()`
* `put_file()`

If set to `True` a final check is performed to assert that the new file has the expected checksum. If the check fails, an `InterruptedError` is raised. This comes with additional costs calculating the checksum of the original and new file. In case of `move_file()` the file is copied and only removed if the check was successful.

### DOC

Here are the new docstrings of `backend.Base`:

![image](https://github.com/audeering/audbackend/assets/10383417/7928d878-717f-4d72-b4aa-52444f219d7a)

![image](https://github.com/audeering/audbackend/assets/10383417/f84b966a-3f9f-43bf-b0bf-594929808a23)

![image](https://github.com/audeering/audbackend/assets/10383417/eacf6df1-8e4f-478e-9a1c-f843af099f64)

![image](https://github.com/audeering/audbackend/assets/10383417/cf09a202-c402-45a0-a117-f6cdb0c62501)

![image](https://github.com/audeering/audbackend/assets/10383417/509102ed-5baa-4aa0-bc1d-7da0959d4fe3)

![image](https://github.com/audeering/audbackend/assets/10383417/e288e69e-650b-42df-a65f-4aa5d1a69f90)

Similar changes were made to `interface.Unversioned` and `interface.Versioned`