### PR TITLE
TST: depend on pytest<8.1.0

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
-pytest
+pytest<8.1.0  #  INTERNALERROR> Argument(s) {'path'} are declared in the hookimpl but can not be found in the hookspec
 pytest-cov
 pytest-doctestplus

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
-pytest<8.1.0  #  INTERNALERROR> Argument(s) {'path'} are declared in the hookimpl but can not be found in the hookspec
+pytest<8.1.0  # required by doctestplus
 pytest-cov
 pytest-doctestplus


### PR DESCRIPTION
`doctestplus` is not compatible with `pytest==8.1.0`, see https://github.com/audeering/audbackend/pull/190#issuecomment-1976241914