### PR TITLE
Add audbackend.interface.Maven

### DIFF
--- a/audbackend/core/interface/maven.py
+++ b/audbackend/core/interface/maven.py
@@ -1,0 +1,259 @@
+import os
+import re
+import typing
+
+import audeer
+
+from audbackend.core import utils
+from audbackend.core.backend.base import Base as Backend
+from audbackend.core.errors import BackendError
+from audbackend.core.interface.versioned import Versioned
+
+
+class Maven(Versioned):
+    r"""Interface for Maven style versioned file access.
+
+    Use this interface,
+    if you want to version files
+    similar to how it is handled by Maven.
+    For each file on the backend path
+    one or more versions may exist.
+
+    Files are stored under
+    ``".../<name-wo-ext>/<version>/<name-wo-ext>-<version>.<ext>"``.
+    By default,
+    the extension
+    ``<ext>``
+    is set to the string after the last dot.
+    I.e.,
+    the backend path
+    ``".../file.tar.gz"``
+    will translate into
+    ``".../file.tar/1.0.0/file.tar-1.0.0.gz"``.
+    However,
+    by passing a list with custom extensions
+    it is possible to overwrite
+    the default behavior
+    for certain extensions.
+    E.g.,
+    with ``extensions=["tar.gz"]``
+    it is ensured that
+    ``"tar.gz"``
+    will be recognized as an extension
+    and the backend path
+    ``".../file.tar.gz"``
+    will then translate into
+    ``".../file/1.0.0/file-1.0.0.tar.gz"``.
+    If ``regex`` is set to ``True``,
+    the extensions are treated as regular expressions.
+
+    Args:
+        backend: file storage backend
+        extensions: list of file extensions to support
+            including a ``"."``.
+            Per default only the part after the last ``"."``,
+            is considered as a file extension
+        regex: if ``True``,
+            ``extensions`` entries
+            are treated as regular expressions.
+            E.g. ``"\d+.tar.gz"`` will match
+            ``"1.tar.gz"``,
+            ``"1.tar.gz"``,
+            ...
+            as extensions
+
+    """
+
+    def __init__(
+        self,
+        backend: Backend,
+        *,
+        extensions: typing.Sequence[str] = [],
+        regex: bool = False,
+    ):
+        super().__init__(backend)
+        self.extensions = extensions
+        self.regex = regex
+
+    def ls(
+        self,
+        path: str = "/",
+        *,
+        latest_version: bool = False,
+        pattern: str = None,
+        suppress_backend_errors: bool = False,
+    ) -> typing.List[typing.Tuple[str, str]]:
+        r"""List files on backend.
+
+        Returns a sorted list of tuples
+        with path and version.
+        If a full path
+        (e.g. ``/sub/file.ext``)
+        is provided,
+        all versions of the path are returned.
+        If a sub-path
+        (e.g. ``/sub/``)
+        is provided,
+        all files that start with
+        the sub-path are returned.
+        When ``path`` is set to ``'/'``
+        a (possibly empty) list with
+        all files on the backend is returned.
+
+        Args:
+            path: path or sub-path
+                (if it ends with ``'/'``)
+                on backend
+            latest_version: if multiple versions of a file exist,
+                only include the latest
+            pattern: if not ``None``,
+                return only files matching the pattern string,
+                see :func:`fnmatch.fnmatch`
+            suppress_backend_errors: if set to ``True``,
+                silently catch errors raised on the backend
+                and return an empty list
+
+        Returns:
+            list of tuples (path, version)
+
+        Raises:
+            BackendError: if ``suppress_backend_errors`` is ``False``
+                and an error is raised on the backend,
+                e.g. ``path`` does not exist
+            ValueError: if ``path`` does not start with ``'/'`` or
+                does not match ``'[A-Za-z0-9/._-]+'``
+
+        Examples:
+            >>> versioned.ls()
+            [('/a.zip', '1.0.0'), ('/a/b.ext', '1.0.0'), ('/f.ext', '1.0.0'), ('/f.ext', '2.0.0')]
+            >>> versioned.ls(latest_version=True)
+            [('/a.zip', '1.0.0'), ('/a/b.ext', '1.0.0'), ('/f.ext', '2.0.0')]
+            >>> versioned.ls("/f.ext")
+            [('/f.ext', '1.0.0'), ('/f.ext', '2.0.0')]
+            >>> versioned.ls(pattern="*.ext")
+            [('/a/b.ext', '1.0.0'), ('/f.ext', '1.0.0'), ('/f.ext', '2.0.0')]
+            >>> versioned.ls(pattern="b.*")
+            [('/a/b.ext', '1.0.0')]
+            >>> versioned.ls("/a/")
+            [('/a/b.ext', '1.0.0')]
+
+        """  # noqa: E501
+        if path.endswith("/"):  # find files under sub-path
+            paths = self.backend.ls(
+                path,
+                pattern=pattern,
+                suppress_backend_errors=suppress_backend_errors,
+            )
+            print(f"{paths=}")
+
+        else:  # find versions of path
+            root, file = self.split(path)
+
+            paths = self.backend.ls(
+                root,
+                pattern=pattern,
+                suppress_backend_errors=suppress_backend_errors,
+            )
+
+            # filter for '/root/version/file'
+            depth = root.count("/") + 2
+            name, ext = self._split_ext(file)
+            match = re.compile(rf"{name}-\d+\.\d+.\d+{ext}")
+            paths = [
+                p
+                for p in paths
+                if (p.count("/") == depth and match.match(os.path.basename(p)))
+            ]
+
+            if not paths and not suppress_backend_errors:
+                # since the backend does no longer raise an error
+                # if the path does not exist
+                # we have to do it
+                try:
+                    utils.raise_file_not_found_error(path)
+                except FileNotFoundError as ex:
+                    raise BackendError(ex)
+
+        if not paths:
+            return []
+
+        paths_and_versions = []
+        for p in paths:
+            tokens = p.split(self.sep)
+
+            name = tokens[-1]
+            version = tokens[-2]
+
+            if version:
+                base = tokens[-3]
+                ext = name[len(base) + len(version) + 1 :]
+                name = f"{base}{ext}"
+                path = self.sep.join(tokens[:-3])
+
+                path = self.sep + path
+                path = self.join(path, name)
+
+                paths_and_versions.append((path, version))
+
+        paths_and_versions = sorted(paths_and_versions)
+
+        if latest_version:
+            # d[path] = ['1.0.0', '2.0.0']
+            d = {}
+            for p, v in paths_and_versions:
+                if p not in d:
+                    d[p] = []
+                d[p].append(v)
+            # d[path] = '2.0.0'
+            for p, vs in d.items():
+                d[p] = audeer.sort_versions(vs)[-1]
+            # [(path, '2.0.0')]
+            paths_and_versions = [(p, v) for p, v in d.items()]
+
+        return paths_and_versions
+
+    def _split_ext(
+        self,
+        name: str,
+    ) -> typing.Tuple[str, str]:
+        r"""Split name into basename and extension."""
+        ext = None
+        for custom_ext in self.extensions:
+            # check for custom extension
+            # ensure basename is not empty
+            if self.regex:
+                pattern = rf"\.({custom_ext})$"
+                match = re.search(pattern, name[1:])
+                if match:
+                    ext = match.group(1)
+            elif name[1:].endswith(f".{custom_ext}"):
+                ext = custom_ext
+        if ext is None:
+            # if no custom extension is found
+            # use last string after dot
+            ext = audeer.file_extension(name)
+
+        base = audeer.replace_file_extension(name, "", ext=ext)
+
+        if ext:
+            ext = f".{ext}"
+
+        return base, ext
+
+    def _path_with_version(
+        self,
+        path: str,
+        version: str,
+    ) -> str:
+        r"""Convert to versioned path.
+
+        <root>/<base><ext>
+        ->
+        <root>/<base>/<version>/<base>-<version><ext>
+
+        """
+        version = utils.check_version(version)
+        root, name = self.split(path)
+        base, ext = self._split_ext(name)
+        path = self.join(root, base, version, f"{base}-{version}{ext}")
+        return path

--- a/audbackend/core/interface/maven.py
+++ b/audbackend/core/interface/maven.py
@@ -59,7 +59,7 @@ class Maven(Versioned):
             are treated as regular expressions.
             E.g. ``"\d+.tar.gz"`` will match
             ``"1.tar.gz"``,
-            ``"1.tar.gz"``,
+            ``"2.tar.gz"``,
             ...
             as extensions
 

--- a/audbackend/core/interface/maven.py
+++ b/audbackend/core/interface/maven.py
@@ -1,3 +1,4 @@
+import fnmatch
 import os
 import re
 import typing
@@ -141,17 +142,14 @@ class Maven(Versioned):
         if path.endswith("/"):  # find files under sub-path
             paths = self.backend.ls(
                 path,
-                pattern=pattern,
                 suppress_backend_errors=suppress_backend_errors,
             )
-            print(f"{paths=}")
 
         else:  # find versions of path
             root, file = self.split(path)
 
             paths = self.backend.ls(
                 root,
-                pattern=pattern,
                 suppress_backend_errors=suppress_backend_errors,
             )
 
@@ -193,7 +191,8 @@ class Maven(Versioned):
                 path = self.sep + path
                 path = self.join(path, name)
 
-                paths_and_versions.append((path, version))
+                if not pattern or fnmatch.fnmatch(os.path.basename(path), pattern):
+                    paths_and_versions.append((path, version))
 
         paths_and_versions = sorted(paths_and_versions)
 

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -1,5 +1,4 @@
 import os
-import re
 import typing
 
 import audeer

--- a/audbackend/interface/__init__.py
+++ b/audbackend/interface/__init__.py
@@ -1,3 +1,4 @@
 from audbackend.core.interface.base import Base
+from audbackend.core.interface.maven import Maven
 from audbackend.core.interface.unversioned import Unversioned
 from audbackend.core.interface.versioned import Versioned

--- a/docs/api-src/audbackend.interface.rst
+++ b/docs/api-src/audbackend.interface.rst
@@ -12,6 +12,7 @@ can use the following interfaces:
     :toctree:
     :nosignatures:
 
+    Maven
     Unversioned
     Versioned
 

--- a/docs/legacy.rst
+++ b/docs/legacy.rst
@@ -15,7 +15,7 @@
 Legacy backends
 ===============
 
-The file structure on the backend
+The default file structure on the backend
 has changed with version 1.0.0.
 
 Before,
@@ -34,9 +34,7 @@ Now it is stored under
     /sub/1.0.0/file.txt
 
 To force the old file structure
-call the hidden method
-``_use_legacy_file_structure()``
-after instantiating the backend.
+use the :class:`audbackend.interface.Maven` interface.
 We recommend this 
 for existing repositories
 that store files

--- a/docs/legacy.rst
+++ b/docs/legacy.rst
@@ -51,9 +51,14 @@ you have to list those extensions explicitly.
     import audbackend
 
     audbackend.create("file-system", "./host", "repo")
-    interface = audbackend.access("file-system", "./host", "repo")
-    extensions = ["tar.gz"]
-    interface._use_legacy_file_structure(extensions=extensions)
+
+    interface = audbackend.access(
+        "file-system",
+        "./host",
+        "repo",
+        interface=audbackend.interface.Maven,
+        interface_kwargs={"extensions": ["tar.gz"]},
+    )
 
 Afterwards we upload an TAR.GZ archive
 and check that it is stored as expected.

--- a/tests/test_backend_artifactory.py
+++ b/tests/test_backend_artifactory.py
@@ -138,19 +138,12 @@ def test_errors(tmpdir, interface):
 
 @pytest.mark.parametrize(
     "interface",
-    [("artifactory", audbackend.interface.Versioned)],
+    [("artifactory", audbackend.interface.Maven)],
     indirect=True,
 )
 @pytest.mark.parametrize(
     "file, version, extensions, regex, expected",
     [
-        (
-            "/file.tar.gz",
-            "1.0.0",
-            None,
-            False,
-            "file.tar/1.0.0/file.tar-1.0.0.gz",
-        ),
         (
             "/file.tar.gz",
             "1.0.0",
@@ -182,21 +175,21 @@ def test_errors(tmpdir, interface):
         (
             "/.tar.gz",
             "1.0.0",
-            None,
+            [],
             False,
             ".tar/1.0.0/.tar-1.0.0.gz",
         ),
         (
             "/.tar",
             "1.0.0",
-            None,
+            [],
             False,
             ".tar/1.0.0/.tar-1.0.0",
         ),
         (
             "/tar",
             "1.0.0",
-            None,
+            [],
             False,
             "tar/1.0.0/tar-1.0.0",
         ),
@@ -252,10 +245,11 @@ def test_errors(tmpdir, interface):
         ),
     ],
 )
-def test_legacy_file_structure(
+def test_maven_file_structure(
     tmpdir, interface, file, version, extensions, regex, expected
 ):
-    interface._use_legacy_file_structure(extensions=extensions, regex=regex)
+    interface.extensions = extensions
+    interface.regex = regex
 
     src_path = audeer.touch(audeer.path(tmpdir, "tmp"))
     interface.put_file(src_path, file, version)

--- a/tests/test_backend_filesystem.py
+++ b/tests/test_backend_filesystem.py
@@ -56,19 +56,12 @@ def test_get_file_interrupt(tmpdir, bad_file_system, interface):
 
 @pytest.mark.parametrize(
     "interface",
-    [("file-system", audbackend.interface.Versioned)],
+    [("file-system", audbackend.interface.Maven)],
     indirect=True,
 )
 @pytest.mark.parametrize(
     "file, version, extensions, regex, expected",
     [
-        (
-            "/file.tar.gz",
-            "1.0.0",
-            None,
-            False,
-            "file.tar/1.0.0/file.tar-1.0.0.gz",
-        ),
         (
             "/file.tar.gz",
             "1.0.0",
@@ -100,21 +93,21 @@ def test_get_file_interrupt(tmpdir, bad_file_system, interface):
         (
             "/.tar.gz",
             "1.0.0",
-            None,
+            [],
             False,
             ".tar/1.0.0/.tar-1.0.0.gz",
         ),
         (
             "/.tar",
             "1.0.0",
-            None,
+            [],
             False,
             ".tar/1.0.0/.tar-1.0.0",
         ),
         (
             "/tar",
             "1.0.0",
-            None,
+            [],
             False,
             "tar/1.0.0/tar-1.0.0",
         ),
@@ -170,12 +163,13 @@ def test_get_file_interrupt(tmpdir, bad_file_system, interface):
         ),
     ],
 )
-def test_legacy_file_structure(
+def test_maven_file_structure(
     tmpdir, interface, file, version, extensions, regex, expected
 ):
     expected = expected.replace("/", os.path.sep)
 
-    interface._use_legacy_file_structure(extensions=extensions, regex=regex)
+    interface.extensions = extensions
+    interface.regex = regex
 
     src_path = audeer.touch(audeer.path(tmpdir, "tmp"))
     interface.put_file(src_path, file, version)

--- a/tests/test_interface_maven.py
+++ b/tests/test_interface_maven.py
@@ -1,10 +1,71 @@
 import os
+import re
+import stat
 
 import pytest
 
 import audeer
 
 import audbackend
+
+
+@pytest.mark.parametrize(
+    "interface",
+    [("file-system", audbackend.interface.Maven)],
+    indirect=True,
+)
+def test_errors(tmpdir, interface):
+    # Ensure we have one file and one archive published on the backend
+    archive = "/archive.zip"
+    local_file = "file.txt"
+    local_path = audeer.touch(audeer.path(tmpdir, local_file))
+    remote_file = f"/{local_file}"
+    version = "1.0.0"
+    interface.put_file(local_path, remote_file, version)
+    interface.put_archive(tmpdir, archive, version, files=[local_file])
+
+    # Create local read-only file and folder
+    file_read_only = audeer.touch(audeer.path(tmpdir, "read-only-file.txt"))
+    os.chmod(file_read_only, stat.S_IRUSR)
+    folder_read_only = audeer.mkdir(audeer.path(tmpdir, "read-only-folder"))
+    os.chmod(folder_read_only, stat.S_IRUSR)
+
+    # Invalid file names / versions and error messages
+    file_invalid_path = "invalid/path.txt"
+    error_invalid_path = re.escape(
+        f"Invalid backend path '{file_invalid_path}', " f"must start with '/'."
+    )
+    file_invalid_char = "/invalid/char.txt?"
+    error_invalid_char = re.escape(
+        f"Invalid backend path '{file_invalid_char}', "
+        f"does not match '[A-Za-z0-9/._-]+'."
+    )
+    error_backend = (
+        "An exception was raised by the backend, "
+        "please see stack trace for further information."
+    )
+
+    # --- ls ---
+    # `path` does not exist
+    with pytest.raises(audbackend.BackendError, match=error_backend):
+        interface.ls("/missing/")
+    interface.ls("/missing/", suppress_backend_errors=True)
+    with pytest.raises(audbackend.BackendError, match=error_backend):
+        interface.ls("/missing.txt")
+    interface.ls("/missing.txt", suppress_backend_errors=True)
+    remote_file_with_wrong_ext = audeer.replace_file_extension(
+        remote_file,
+        "missing",
+    )
+    with pytest.raises(audbackend.BackendError, match=error_backend):
+        interface.ls(remote_file_with_wrong_ext)
+    interface.ls(remote_file_with_wrong_ext, suppress_backend_errors=True)
+    # joined path without leading '/'
+    with pytest.raises(ValueError, match=error_invalid_path):
+        interface.ls(file_invalid_path)
+    # `path` contains invalid character
+    with pytest.raises(ValueError, match=error_invalid_char):
+        interface.ls(file_invalid_char)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_interface_maven.py
+++ b/tests/test_interface_maven.py
@@ -80,6 +80,10 @@ def test_ls(tmpdir, interface):
         ("/file.bar", True, None, root_bar_latest),
         ("/sub/file.foo", False, None, sub),
         ("/sub/file.foo", True, None, sub_latest),
+        ("/sub/file.foo", False, "file.*", sub),
+        ("/sub/file.foo", True, "file.*", sub_latest),
+        ("/sub/file.foo", False, "*.bar", []),
+        ("/sub/file.foo", True, "*.bar", []),
         ("/.sub/.file.foo", False, None, hidden),
         ("/.sub/.file.foo", True, None, hidden_latest),
     ]:

--- a/tests/test_interface_maven.py
+++ b/tests/test_interface_maven.py
@@ -1,0 +1,90 @@
+import os
+
+import pytest
+
+import audeer
+
+import audbackend
+
+
+@pytest.mark.parametrize(
+    "interface",
+    [("file-system", audbackend.interface.Maven)],
+    indirect=True,
+)
+def test_ls(tmpdir, interface):
+    assert interface.ls() == []
+    assert interface.ls("/") == []
+
+    root = [
+        ("/file.bar", "1.0.0"),
+        ("/file.bar", "2.0.0"),
+        ("/file.foo", "1.0.0"),
+    ]
+    root_latest = [
+        ("/file.bar", "2.0.0"),
+        ("/file.foo", "1.0.0"),
+    ]
+    root_foo = [
+        ("/file.foo", "1.0.0"),
+    ]
+    root_bar = [
+        ("/file.bar", "1.0.0"),
+        ("/file.bar", "2.0.0"),
+    ]
+    root_bar_latest = [
+        ("/file.bar", "2.0.0"),
+    ]
+    sub = [
+        ("/sub/file.foo", "1.0.0"),
+        ("/sub/file.foo", "2.0.0"),
+    ]
+    sub_latest = [
+        ("/sub/file.foo", "2.0.0"),
+    ]
+    hidden = [
+        ("/.sub/.file.foo", "1.0.0"),
+        ("/.sub/.file.foo", "2.0.0"),
+    ]
+    hidden_latest = [
+        ("/.sub/.file.foo", "2.0.0"),
+    ]
+
+    # create content
+
+    tmp_file = os.path.join(tmpdir, "~")
+    for path, version in root + sub + hidden:
+        audeer.touch(tmp_file)
+        interface.put_file(
+            tmp_file,
+            path,
+            version,
+        )
+
+    # test
+
+    for path, latest, pattern, expected in [
+        ("/", False, None, root + sub + hidden),
+        ("/", True, None, root_latest + sub_latest + hidden_latest),
+        ("/", False, "*.foo", root_foo + sub + hidden),
+        ("/", True, "*.foo", root_foo + sub_latest + hidden_latest),
+        ("/sub/", False, None, sub),
+        ("/sub/", True, None, sub_latest),
+        ("/sub/", False, "*.bar", []),
+        ("/sub/", True, "*.bar", []),
+        ("/sub/", False, "file.*", sub),
+        ("/sub/", True, "file.*", sub_latest),
+        ("/.sub/", False, None, hidden),
+        ("/.sub/", True, None, hidden_latest),
+        ("/file.bar", False, None, root_bar),
+        ("/file.bar", True, None, root_bar_latest),
+        ("/sub/file.foo", False, None, sub),
+        ("/sub/file.foo", True, None, sub_latest),
+        ("/.sub/.file.foo", False, None, hidden),
+        ("/.sub/.file.foo", True, None, hidden_latest),
+    ]:
+        assert interface.ls(
+            path,
+            latest_version=latest,
+            pattern=pattern,
+        ) == sorted(expected)


### PR DESCRIPTION
Closes #168 

This adds an extra interface to handle our legacy versioned file structure.

I'm still not completely convinced by the `Maven` name. If you have a better proposal, I'm open to change the name.

---

The API documentation is currently slightly broken as it uses the name `versioned` to refer to the interface, but the problem exists also for the `Versioned` and `Unversioned` API, which also uses a mix of `interface` and their actual variable names. I propose to fix this in another pull request, after this one is finished.

Excerpt from the API documentation:

![image](https://github.com/audeering/audbackend/assets/173624/31c98239-0cb4-403a-8e17-e6e647fce1e0)

---

For now I haven't added a new section to the usage documentation, but updated the "Legacy backends" page to

![image](https://github.com/audeering/audbackend/assets/173624/55baecb7-fd42-432c-a859-25554d81055b)
