### PR TITLE
Fix audbackend.interface.Versioned.ls(file, pattern=...)

### DIFF
--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -1,3 +1,4 @@
+import fnmatch
 import os
 import re
 import typing
@@ -428,7 +429,6 @@ class Versioned(Base):
         if path.endswith("/"):  # find files under sub-path
             paths = self.backend.ls(
                 path,
-                pattern=pattern,
                 suppress_backend_errors=suppress_backend_errors,
             )
 
@@ -437,7 +437,6 @@ class Versioned(Base):
 
             paths = self.backend.ls(
                 root,
-                pattern=pattern,
                 suppress_backend_errors=suppress_backend_errors,
             )
 
@@ -467,6 +466,9 @@ class Versioned(Base):
                     utils.raise_file_not_found_error(path)
                 except FileNotFoundError as ex:
                     raise BackendError(ex)
+
+        if pattern:
+            paths = [p for p in paths if fnmatch.fnmatch(os.path.basename(p), pattern)]
 
         if not paths:
             return []

--- a/tests/test_interface_unversioned.py
+++ b/tests/test_interface_unversioned.py
@@ -581,6 +581,8 @@ def test_ls(tmpdir, interface):
         ("/.sub/", None, hidden),
         ("/file.bar", None, root_bar),
         ("/sub/file.foo", None, sub),
+        ("/sub/file.foo", "file.*", sub),
+        ("/sub/file.foo", "*.bar", []),
         ("/.sub/.file.foo", None, hidden),
     ]:
         assert interface.ls(

--- a/tests/test_interface_versioned.py
+++ b/tests/test_interface_versioned.py
@@ -721,6 +721,10 @@ def test_ls(tmpdir, interface):
         ("/file.bar", True, None, root_bar_latest),
         ("/sub/file.foo", False, None, sub),
         ("/sub/file.foo", True, None, sub_latest),
+        ("/sub/file.foo", False, "file.*", sub),
+        ("/sub/file.foo", True, "file.*", sub_latest),
+        ("/sub/file.foo", False, "*.bar", []),
+        ("/sub/file.foo", True, "*.bar", []),
         ("/.sub/.file.foo", False, None, hidden),
         ("/.sub/.file.foo", True, None, hidden_latest),
     ]:


### PR DESCRIPTION
Closes https://github.com/audeering/audbackend/issues/196 (might be that this does not work automatically as we do not merge into the default branch)

Makes sure, `Interface.ls(file, pattern=...)` works for `Versioned()` and `Unversioned` interfaces.