### PR TITLE
Fix Versioned.ls(file, pattern=...)

### DIFF
--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -1,3 +1,4 @@
+import fnmatch
 import os
 import re
 import typing
@@ -428,7 +429,6 @@ class Versioned(Base):
         if path.endswith("/"):  # find files under sub-path
             paths = self.backend.ls(
                 path,
-                pattern=pattern,
                 suppress_backend_errors=suppress_backend_errors,
             )
 
@@ -437,7 +437,6 @@ class Versioned(Base):
 
             paths = self.backend.ls(
                 root,
-                pattern=pattern,
                 suppress_backend_errors=suppress_backend_errors,
             )
 
@@ -467,6 +466,9 @@ class Versioned(Base):
                     utils.raise_file_not_found_error(path)
                 except FileNotFoundError as ex:
                     raise BackendError(ex)
+
+        if pattern:
+            paths = [p for p in paths if fnmatch.fnmatch(os.path.basename(p), pattern)]
 
         if not paths:
             return []


### PR DESCRIPTION
Closes https://github.com/audeering/audbackend/issues/196

We first to call `backend.ls()` without passing `pattern`. If this returns an empty list we raise an error. Otherwise, we know that the directory exists. Now we apply `pattern` and return a possibly empty list.

