### PR TITLE
Remove audbackend.available()

### DIFF
--- a/audbackend/__init__.py
+++ b/audbackend/__init__.py
@@ -1,7 +1,6 @@
 from audbackend import backend
 from audbackend import interface
 from audbackend.core.api import access
-from audbackend.core.api import available
 from audbackend.core.api import create
 from audbackend.core.api import delete
 from audbackend.core.api import register

--- a/audbackend/core/api.py
+++ b/audbackend/core/api.py
@@ -60,11 +60,6 @@ def access(
     on the backend with alias ``name``
     (see :func:`audbackend.register`).
 
-    Use :func:`audbackend.available`
-    to list available repositories
-    or :func:`audbackend.create`
-    to create a new repository.
-
     Args:
         name: backend alias
         host: host address
@@ -92,38 +87,6 @@ def access(
     return interface(backend, **interface_kwargs)
 
 
-def available() -> typing.Dict[str, typing.List[Base]]:
-    r"""List available repositories.
-
-    Returns a dictionary with
-    backend alias name as key
-    (see :func:`audbackend.register`)
-    and a list with repositories
-    on that backend as value
-    (see :func:`audbackend.create`).
-
-    Returns:
-        dictionary with repositories
-
-    Examples:
-        >>> list(available())
-        ['artifactory', 'file-system']
-        >>> available()["file-system"][0]
-        ('audbackend.core.backend.filesystem.FileSystem', 'host', 'repo')
-
-    """  # noqa: E501
-    result = {}
-
-    for name in sorted(backend_registry):
-        result[name] = []
-        if name in backends:
-            for repository in backends[name].values():
-                for backend in repository.values():
-                    result[name].append(backend)
-
-    return result
-
-
 def create(
     name: str,
     host: str,
@@ -135,11 +98,6 @@ def create(
     located at ``host``
     on the backend with alias ``name``
     (see :func:`audbackend.register`).
-
-    Use :func:`audbackend.available`
-    to list available repositories
-    and :func:`audbackend.access`
-    to access the repository.
 
     .. note:: For legacy reasons the method
         returns an (undocumented) instance of
@@ -181,10 +139,7 @@ def delete(
     Deletes the repository
     with name ``repository``
     located at ``host``
-    on the backend with alias ``name``
-    and removes it from the
-    list of available repositories
-    (see :func:`audbackend.available`).
+    on the backend with alias ``name``.
 
     Args:
         name: backend alias

--- a/audbackend/core/conftest.py
+++ b/audbackend/core/conftest.py
@@ -62,18 +62,8 @@ def prepare_docstring_tests(doctest_namespace):
 
         # versioned interface
 
-        audbackend.create(
-            "file-system",
-            "host",
-            "repo",
-        )
-        versioned = audbackend.access(
-            "file-system",
-            "host",
-            "repo",
-            interface=audbackend.interface.Versioned,
-        )
-        assert isinstance(versioned, audbackend.interface.Versioned)
+        DoctestFileSystem.create("host", "repo")
+        versioned = audbackend.interface.Versioned(DoctestFileSystem("host", "repo"))
         versioned.put_archive(".", "/a.zip", "1.0.0", files=[file])
         versioned.put_file(file, "/a/b.ext", "1.0.0")
         for version in ["1.0.0", "2.0.0"]:
@@ -82,18 +72,10 @@ def prepare_docstring_tests(doctest_namespace):
 
         # unversioned interface
 
-        audbackend.create(
-            "file-system",
-            "host",
-            "repo-unversioned",
+        DoctestFileSystem.create("host", "repo-unversioned")
+        unversioned = audbackend.interface.Unversioned(
+            DoctestFileSystem("host", "repo-unversioned")
         )
-        unversioned = audbackend.access(
-            "file-system",
-            "host",
-            "repo-unversioned",
-            interface=audbackend.interface.Unversioned,
-        )
-        assert isinstance(unversioned, audbackend.interface.Unversioned)
         unversioned.put_archive(".", "/a.zip", files=[file])
         unversioned.put_file(file, "/a/b.ext")
         unversioned.put_file(file, "/f.ext")

--- a/docs/api-src/audbackend.rst
+++ b/docs/api-src/audbackend.rst
@@ -32,7 +32,6 @@ and functions are available.
     BackendError
     Repository
     access
-    available
     create
     delete
     register

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -70,11 +70,8 @@ def test_api(hosts, name, host, repository, cls):
 
     interface = audbackend.access(name, host, repository)
     assert isinstance(interface.backend, cls)
-    assert interface.backend in audbackend.available()[name]
 
     audbackend.delete(name, host, repository)
-
-    assert interface.backend not in audbackend.available()[name]
 
     with pytest.raises(audbackend.BackendError, match=error_msg):
         audbackend.access(name, host, repository)


### PR DESCRIPTION
Relates to #197 

This pull request proposes to remove `audbackend.available()` as we cannot maintain its current behavior/results with the new approach of accessing backends by instantiating them, introduced in #200.

There might be ways to preserve its original behavior, but I don't think this is worse the effort.

I also updated `audbackend/core/conftest.py` as proposed in https://github.com/audeering/audbackend/pull/200#issuecomment-2024615148.