### PR TITLE
Deprecate audbackend.register()

### DIFF
--- a/audbackend/core/api.py
+++ b/audbackend/core/api.py
@@ -180,13 +180,13 @@ def register(
     registered under the alias ``name``
     it will be overwritten.
 
-    ..Warning::
+    .. Warning::
 
         ``audbackend.register()`` is deprecated
         and will be removed in version 2.2.0.
-        We now longer use names for backends,
-        but directly backend classes,
-        e.g. :class:`audbackend.backend.FileSystem`.
+        Instead of backend names
+        we now use backend classes,
+        such as :class:`audbackend.backend.FileSystem`.
 
     Args:
         name: backend alias

--- a/audbackend/core/api.py
+++ b/audbackend/core/api.py
@@ -1,5 +1,7 @@
 import typing
 
+import audeer
+
 from audbackend.core import utils
 from audbackend.core.backend.base import Base
 from audbackend.core.backend.filesystem import FileSystem
@@ -166,6 +168,7 @@ def delete(
     backends[name][host].pop(repository)
 
 
+@audeer.deprecated(removal_version="2.2.0", alternative="backend classes directly")
 def register(
     name: str,
     cls: typing.Type[Base],
@@ -176,12 +179,17 @@ def register(
     registered under the alias ``name``
     it will be overwritten.
 
+    ..Warning::
+
+        ``audbackend.register()`` is deprecated
+        and will be removed in version 2.2.0.
+        We now longer use names for backends,
+        but directly backend classes,
+        e.g. :class:`audbackend.backend.FileSystem`.
+
     Args:
         name: backend alias
         cls: backend class
-
-    Examples:
-        >>> register("file-system", FileSystem)
 
     """
     backend_registry[name] = cls

--- a/audbackend/core/api.py
+++ b/audbackend/core/api.py
@@ -1,4 +1,5 @@
 import typing
+import warnings
 
 import audeer
 
@@ -195,12 +196,14 @@ def register(
     backend_registry[name] = cls
 
 
-register("file-system", FileSystem)
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    register("file-system", FileSystem)
 
-# Register optional backends
-try:
-    from audbackend.core.backend.artifactory import Artifactory
+    # Register optional backends
+    try:
+        from audbackend.core.backend.artifactory import Artifactory
 
-    register("artifactory", Artifactory)
-except ImportError:  # pragma: no cover
-    pass
+        register("artifactory", Artifactory)
+    except ImportError:  # pragma: no cover
+        pass

--- a/audbackend/core/conftest.py
+++ b/audbackend/core/conftest.py
@@ -44,10 +44,16 @@ def prepare_docstring_tests(doctest_namespace):
         current_dir = os.getcwd()
         os.chdir(tmp)
 
+        warning = (
+            "register is deprecated and will be removed with version 2.2.0. "
+            "Use backend classes directly instead."
+        )
+
         file = "src.pth"
         audeer.touch(file)
 
-        audbackend.register("file-system", DoctestFileSystem)
+        with pytest.warns(UserWarning, match=warning):
+            audbackend.register("file-system", DoctestFileSystem)
         doctest_namespace["create"] = doctest_create
 
         # backend
@@ -85,7 +91,8 @@ def prepare_docstring_tests(doctest_namespace):
 
         audbackend.delete("file-system", "host", "repo")
         audbackend.delete("file-system", "host", "repo-unversioned")
-        audbackend.register("file-system", audbackend.backend.FileSystem)
+        with pytest.warns(UserWarning, match=warning):
+            audbackend.register("file-system", audbackend.backend.FileSystem)
         doctest_namespace["create"] = audbackend.create
 
         os.chdir(current_dir)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,12 @@ pytest.UID = audeer.uid()[:8]
 
 @pytest.fixture(scope="package", autouse=True)
 def register_single_folder():
-    audbackend.register("single-folder", SingleFolder)
+    warning = (
+        "register is deprecated and will be removed with version 2.2.0. "
+        "Use backend classes directly instead."
+    )
+    with pytest.warns(UserWarning, match=warning):
+        audbackend.register("single-folder", SingleFolder)
 
 
 @pytest.fixture(scope="package", autouse=False)


### PR DESCRIPTION
Relates to #197 

This deprecates `audbackend.register()` and marks it to be removed in version 2.2.0, assuming that the current `dev` branch will be released as version 2.0.0.

![image](https://github.com/audeering/audbackend/assets/173624/e9269c3e-c4f1-43b1-b355-e8168e4f6d08)
