### PR TITLE
TST: raise warning for failed Artifactory cleanup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import getpass
 import os
 import time
+import warnings
 
 import pytest
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,14 +96,14 @@ def interface(tmpdir_factory, request):
             break
         except audbackend.BackendError:
             if n == 2:
-                error_msg = (
+                warning_msg = (
                     f"Cleaning up of repo {repository} failed.\n"
                     "Please delete remaining repositories manually \n"
                     "by running the following command \n"
                     "when no tests are actively running:\n"
                     f"python tests/misc/cleanup_artifactory.py"
                 )
-                raise RuntimeError(error_msg)
+                warnings.warn(warning_msg, UserWarning)
             time.sleep(1)
 
 


### PR DESCRIPTION
As we have continously failing tests due to the failed cleanup on Artifactory, I would propose we change this to a warning.
Then we will most likely collect some folders on Artifactory, but I think you will still see it from time to time locally, and are then reminded to clean it up.