### PR TITLE
Raise ValueError if backend path ends with "/"

### DIFF
--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -411,7 +411,7 @@ class Base:
             RuntimeError: if extension of ``src_path`` is not supported
                 or ``src_path`` is a malformed archive
             ValueError: if ``src_path`` does not start with ``'/'``,
-                ends on ``'/'`',
+                ends on ``'/'``,
                 or does not match ``'[A-Za-z0-9/._-]+'``
 
         """
@@ -491,7 +491,7 @@ class Base:
             PermissionError: if the user lacks write permissions
                 for ``dst_path``
             ValueError: if ``src_path`` does not start with ``'/'``,
-                ends on ``'/'`',
+                ends on ``'/'``,
                 or does not match ``'[A-Za-z0-9/._-]+'``
 
         """

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -533,7 +533,7 @@ class Base:
         path: str,
         *paths,
     ) -> str:
-        r"""Join to path on backend.
+        r"""Join to (sub-)path on backend.
 
         Args:
             path: first part of path
@@ -548,13 +548,13 @@ class Base:
                 or if joined path contains invalid character
 
         """
-        path = utils.check_path(path)
+        path = utils.check_path(path, allow_sub_path=True)
 
         paths = [path] + [p for p in paths]
         paths = [path for path in paths if path]  # remove empty or None
         path = self.sep.join(paths)
 
-        path = utils.check_path(path)
+        path = utils.check_path(path, allow_sub_path=True)
 
         return path
 
@@ -616,7 +616,7 @@ class Base:
                 does not match ``'[A-Za-z0-9/._-]+'``
 
         """
-        path = utils.check_path(path)
+        path = utils.check_path(path, allow_sub_path=True)
 
         if path.endswith("/"):  # find files under sub-path
             paths = utils.call_function_on_backend(
@@ -1024,7 +1024,7 @@ class Base:
                 does not match ``'[A-Za-z0-9/._-]+'``
 
         """
-        path = utils.check_path(path)
+        path = utils.check_path(path, allow_sub_path=True)
 
         root = self.sep.join(path.split(self.sep)[:-1]) + self.sep
         basename = path.split(self.sep)[-1]

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -187,8 +187,9 @@ class Base:
             BackendError: if an error is raised on the backend
             InterruptedError: if validation fails
             ValueError: if ``src_path`` or ``dst_path``
-                does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+                does not start with ``'/'``,
+                ends on ``'/'``,
+                or does not match ``'[A-Za-z0-9/._-]+'``
 
         """
         src_path = utils.check_path(src_path)
@@ -409,8 +410,9 @@ class Base:
                 for ``dst_path``
             RuntimeError: if extension of ``src_path`` is not supported
                 or ``src_path`` is a malformed archive
-            ValueError: if ``src_path`` does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``src_path`` does not start with ``'/'``,
+                ends on ``'/'`',
+                or does not match ``'[A-Za-z0-9/._-]+'``
 
         """
         src_path = utils.check_path(src_path)
@@ -488,8 +490,9 @@ class Base:
             IsADirectoryError: if ``dst_path`` points to an existing folder
             PermissionError: if the user lacks write permissions
                 for ``dst_path``
-            ValueError: if ``src_path`` does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``src_path`` does not start with ``'/'``,
+                ends on ``'/'`',
+                or does not match ``'[A-Za-z0-9/._-]+'``
 
         """
         src_path = utils.check_path(src_path)
@@ -709,8 +712,9 @@ class Base:
             BackendError: if an error is raised on the backend
             InterruptedError: if validation fails
             ValueError: if ``src_path`` or ``dst_path``
-                does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+                does not start with ``'/'``,
+                ends on ``'/'``,
+                or does not match ``'[A-Za-z0-9/._-]+'``
 
         """
         src_path = utils.check_path(src_path)
@@ -871,8 +875,9 @@ class Base:
             RuntimeError: if ``dst_path`` does not end with
                 ``zip`` or ``tar.gz``
                 or a file in ``files`` is not below ``root``
-            ValueError: if ``dst_path`` does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``dst_path`` does not start with ``'/'``,
+                ends on ``'/'``,
+                or does not match ``'[A-Za-z0-9/._-]+'``
 
         """
         dst_path = utils.check_path(dst_path)
@@ -943,8 +948,9 @@ class Base:
             FileNotFoundError: if ``src_path`` does not exist
             InterruptedError: if validation fails
             IsADirectoryError: if ``src_path`` is a folder
-            ValueError: if ``dst_path`` does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``dst_path`` does not start with ``'/'``,
+                ends on ``'/'``,
+                or does not match ``'[A-Za-z0-9/._-]+'``
 
         """
         dst_path = utils.check_path(dst_path)

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -105,8 +105,9 @@ class Base:
         Raises:
             BackendError: if an error is raised on the backend,
                 e.g. ``path`` does not exist
-            ValueError: if ``path`` does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``path`` does not start with ``'/'``,
+                ends on ``'/'``,
+                or does not match ``'[A-Za-z0-9/._-]+'``
 
         """
         path = utils.check_path(path)
@@ -277,8 +278,9 @@ class Base:
         Raises:
             BackendError: if an error is raised on the backend,
                 e.g. ``path`` does not exist
-            ValueError: if ``path`` does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``path`` does not start with ``'/'``,
+                ends on ``'/'``,
+                or does not match ``'[A-Za-z0-9/._-]+'``
 
         """
         path = utils.check_path(path)
@@ -345,8 +347,9 @@ class Base:
             BackendError: if ``suppress_backend_errors`` is ``False``
                 and an error is raised on the backend,
                 e.g. due to a connection timeout
-            ValueError: if ``path`` does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``path`` does not start with ``'/'``,
+                ends on ``'/'``,
+                or does not match ``'[A-Za-z0-9/._-]+'``
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
 
@@ -805,8 +808,9 @@ class Base:
         Raises:
             BackendError: if an error is raised on the backend,
                 e.g. ``path`` does not exist
-            ValueError: if ``path`` does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``path`` does not start with ``'/'``,
+                ends on ``'/'``,
+                or does not match ``'[A-Za-z0-9/._-]+'``
 
         """
         path = utils.check_path(path)
@@ -988,8 +992,9 @@ class Base:
         Raises:
             BackendError: if an error is raised on the backend,
                 e.g. ``path`` does not exist
-            ValueError: if ``path`` does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``path`` does not start with ``'/'``,
+                ends on ``'/'``,
+                or does not match ``'[A-Za-z0-9/._-]+'``
 
         """
         path = utils.check_path(path)

--- a/audbackend/core/interface/unversioned.py
+++ b/audbackend/core/interface/unversioned.py
@@ -72,8 +72,9 @@ class Unversioned(Base):
             BackendError: if an error is raised on the backend
             InterruptedError: if validation fails
             ValueError: if ``src_path`` or ``dst_path``
-                does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+                does not start with ``'/'``,
+                ends on ``'/'``,
+                or does not match ``'[A-Za-z0-9/._-]+'``
 
         Examples:
             >>> unversioned.exists("/copy.ext")
@@ -203,8 +204,9 @@ class Unversioned(Base):
                 for ``dst_path``
             RuntimeError: if extension of ``src_path`` is not supported
                 or ``src_path`` is a malformed archive
-            ValueError: if ``src_path`` does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``src_path`` does not start with ``'/'``,
+                ends on ``'/'`',
+                or does not match ``'[A-Za-z0-9/._-]+'``
 
         Examples:
             >>> unversioned.get_archive("/a.zip", ".")
@@ -264,8 +266,9 @@ class Unversioned(Base):
             IsADirectoryError: if ``dst_path`` points to an existing folder
             PermissionError: if the user lacks write permissions
                 for ``dst_path``
-            ValueError: if ``src_path`` does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``src_path`` does not start with ``'/'``,
+                ends on ``'/'`',
+                or does not match ``'[A-Za-z0-9/._-]+'``
 
         Examples:
             >>> os.path.exists("dst.pth")
@@ -384,8 +387,9 @@ class Unversioned(Base):
             BackendError: if an error is raised on the backend
             InterruptedError: if validation fails
             ValueError: if ``src_path`` or ``dst_path``
-                does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+                does not start with ``'/'``,
+                ends on ``'/'``,
+                or does not match ``'[A-Za-z0-9/._-]+'``
 
         Examples:
             >>> unversioned.exists("/move.ext")
@@ -486,8 +490,9 @@ class Unversioned(Base):
             RuntimeError: if ``dst_path`` does not end with
                 ``zip`` or ``tar.gz``
                 or a file in ``files`` is not below ``root``
-            ValueError: if ``dst_path`` does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``dst_path`` does not start with ``'/'``,
+                ends on ``'/'``,
+                or does not match ``'[A-Za-z0-9/._-]+'``
 
         Examples:
             >>> unversioned.exists("/a.tar.gz")
@@ -540,8 +545,9 @@ class Unversioned(Base):
             FileNotFoundError: if ``src_path`` does not exist
             InterruptedError: if validation fails
             IsADirectoryError: if ``src_path`` is a folder
-            ValueError: if ``dst_path`` does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``dst_path`` does not start with ``'/'``,
+                ends on ``'/'``,
+                or does not match ``'[A-Za-z0-9/._-]+'``
 
         Examples:
             >>> unversioned.exists("/sub/f.ext")

--- a/audbackend/core/interface/unversioned.py
+++ b/audbackend/core/interface/unversioned.py
@@ -27,8 +27,9 @@ class Unversioned(Base):
         Raises:
             BackendError: if an error is raised on the backend,
                 e.g. ``path`` does not exist
-            ValueError: if ``path`` does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``path`` does not start with ``'/'``,
+                ends on ``'/'``,
+                or does not match ``'[A-Za-z0-9/._-]+'``
 
         Examples:
             >>> unversioned.checksum("/f.ext")
@@ -107,8 +108,9 @@ class Unversioned(Base):
         Raises:
             BackendError: if an error is raised on the backend,
                 e.g. ``path`` does not exist
-            ValueError: if ``path`` does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``path`` does not start with ``'/'``,
+                ends on ``'/'``,
+                or does not match ``'[A-Za-z0-9/._-]+'``
 
         Examples:
               >>> unversioned.date("/f.ext")
@@ -138,8 +140,9 @@ class Unversioned(Base):
             BackendError: if ``suppress_backend_errors`` is ``False``
                 and an error is raised on the backend,
                 e.g. due to a connection timeout
-            ValueError: if ``path`` does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``path`` does not start with ``'/'``,
+                ends on ``'/'``,
+                or does not match ``'[A-Za-z0-9/._-]+'``
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
 
@@ -420,8 +423,9 @@ class Unversioned(Base):
         Raises:
             BackendError: if an error is raised on the backend,
                 e.g. ``path`` does not exist
-            ValueError: if ``path`` does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``path`` does not start with ``'/'``,
+                ends on ``'/'``,
+                or does not match ``'[A-Za-z0-9/._-]+'``
 
         Examples:
               >>> unversioned.owner("/f.ext")
@@ -566,8 +570,9 @@ class Unversioned(Base):
         Raises:
             BackendError: if an error is raised on the backend,
                 e.g. ``path`` does not exist
-            ValueError: if ``path`` does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``path`` does not start with ``'/'``,
+                ends on ``'/'``,
+                or does not match ``'[A-Za-z0-9/._-]+'``
 
         Examples:
             >>> unversioned.exists("/f.ext")

--- a/audbackend/core/interface/unversioned.py
+++ b/audbackend/core/interface/unversioned.py
@@ -205,7 +205,7 @@ class Unversioned(Base):
             RuntimeError: if extension of ``src_path`` is not supported
                 or ``src_path`` is a malformed archive
             ValueError: if ``src_path`` does not start with ``'/'``,
-                ends on ``'/'`',
+                ends on ``'/'``,
                 or does not match ``'[A-Za-z0-9/._-]+'``
 
         Examples:
@@ -267,7 +267,7 @@ class Unversioned(Base):
             PermissionError: if the user lacks write permissions
                 for ``dst_path``
             ValueError: if ``src_path`` does not start with ``'/'``,
-                ends on ``'/'`',
+                ends on ``'/'``,
                 or does not match ``'[A-Za-z0-9/._-]+'``
 
         Examples:

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -248,7 +248,7 @@ class Versioned(Base):
             RuntimeError: if extension of ``src_path`` is not supported
                 or ``src_path`` is a malformed archive
             ValueError: if ``src_path`` does not start with ``'/'``,
-                ends on ``'/'`',
+                ends on ``'/'``,
                 or does not match ``'[A-Za-z0-9/._-]+'``
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
@@ -315,7 +315,7 @@ class Versioned(Base):
             PermissionError: if the user lacks write permissions
                 for ``dst_path``
             ValueError: if ``src_path`` does not start with ``'/'``,
-                ends on ``'/'`',
+                ends on ``'/'``,
                 or does not match ``'[A-Za-z0-9/._-]+'``
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -102,8 +102,9 @@ class Versioned(Base):
             BackendError: if an error is raised on the backend
             InterruptedError: if validation fails
             ValueError: if ``src_path`` or ``dst_path``
-                does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+                does not start with ``'/'``,
+                ends on ``'/'``,
+                or does not match ``'[A-Za-z0-9/._-]+'``
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
 
@@ -246,8 +247,9 @@ class Versioned(Base):
                 for ``dst_path``
             RuntimeError: if extension of ``src_path`` is not supported
                 or ``src_path`` is a malformed archive
-            ValueError: if ``src_path`` does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``src_path`` does not start with ``'/'``,
+                ends on ``'/'`',
+                or does not match ``'[A-Za-z0-9/._-]+'``
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
 
@@ -312,8 +314,9 @@ class Versioned(Base):
             IsADirectoryError: if ``dst_path`` points to an existing folder
             PermissionError: if the user lacks write permissions
                 for ``dst_path``
-            ValueError: if ``src_path`` does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``src_path`` does not start with ``'/'``,
+                ends on ``'/'`',
+                or does not match ``'[A-Za-z0-9/._-]+'``
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
 
@@ -534,8 +537,9 @@ class Versioned(Base):
             BackendError: if an error is raised on the backend
             InterruptedError: if validation fails
             ValueError: if ``src_path`` or ``dst_path``
-                does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+                does not start with ``'/'``,
+                ends on ``'/'``,
+                or does not match ``'[A-Za-z0-9/._-]+'``
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
 
@@ -653,8 +657,9 @@ class Versioned(Base):
             RuntimeError: if ``dst_path`` does not end with
                 ``zip`` or ``tar.gz``
                 or a file in ``files`` is not below ``root``
-            ValueError: if ``dst_path`` does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``dst_path`` does not start with ``'/'``,
+                ends on ``'/'``,
+                or does not match ``'[A-Za-z0-9/._-]+'``
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
 
@@ -715,8 +720,9 @@ class Versioned(Base):
             FileNotFoundError: if ``src_path`` does not exist
             InterruptedError: if validation fails
             IsADirectoryError: if ``src_path`` is a folder
-            ValueError: if ``dst_path`` does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``dst_path`` does not start with ``'/'``,
+                ends on ``'/'``,
+                or does not match ``'[A-Za-z0-9/._-]+'``
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
 

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -41,8 +41,9 @@ class Versioned(Base):
         Raises:
             BackendError: if an error is raised on the backend,
                 e.g. ``path`` does not exist
-            ValueError: if ``path`` does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``path`` does not start with ``'/'``,
+                ends on ``'/'``,
+                or does not match ``'[A-Za-z0-9/._-]+'``
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
 
@@ -142,8 +143,9 @@ class Versioned(Base):
         Raises:
             BackendError: if an error is raised on the backend,
                 e.g. ``path`` does not exist
-            ValueError: if ``path`` does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``path`` does not start with ``'/'``,
+                ends on ``'/'``,
+                or does not match ``'[A-Za-z0-9/._-]+'``
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
 
@@ -178,8 +180,9 @@ class Versioned(Base):
             BackendError: if ``suppress_backend_errors`` is ``False``
                 and an error is raised on the backend,
                 e.g. due to a connection timeout
-            ValueError: if ``path`` does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``path`` does not start with ``'/'``,
+                ends on ``'/'``,
+                or does not match ``'[A-Za-z0-9/._-]+'``
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
 
@@ -345,8 +348,9 @@ class Versioned(Base):
         Raises:
             BackendError: if an error is raised on the backend,
                 e.g. ``path`` does not exist
-            ValueError: if ``path`` does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``path`` does not start with ``'/'``,
+                ends on ``'/'``,
+                or does not match ``'[A-Za-z0-9/._-]+'``
 
         Examples:
             >>> versioned.latest_version("/f.ext")
@@ -581,8 +585,9 @@ class Versioned(Base):
         Raises:
             BackendError: if an error is raised on the backend,
                 e.g. ``path`` does not exist
-            ValueError: if ``path`` does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``path`` does not start with ``'/'``,
+                ends on ``'/'``,
+                or does not match ``'[A-Za-z0-9/._-]+'``
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
 
@@ -745,8 +750,9 @@ class Versioned(Base):
         Raises:
             BackendError: if an error is raised on the backend,
                 e.g. ``path`` does not exist
-            ValueError: if ``path`` does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``path`` does not start with ``'/'``,
+                ends on ``'/'``,
+                or does not match ``'[A-Za-z0-9/._-]+'``
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
 
@@ -782,8 +788,9 @@ class Versioned(Base):
             BackendError: if ``suppress_backend_errors`` is ``False``
                 and an error is raised on the backend,
                 e.g. ``path`` does not exist
-            ValueError: if ``path`` does not start with ``'/'`` or
-                does not match ``'[A-Za-z0-9/._-]+'``
+            ValueError: if ``path`` does not start with ``'/'``,
+                ends on ``'/'``,
+                or does not match ``'[A-Za-z0-9/._-]+'``
 
         Examples:
             >>> versioned.versions("/f.ext")

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -790,8 +790,11 @@ class Versioned(Base):
             ['1.0.0', '2.0.0']
 
         """
+        utils.check_path(path)
+
         paths = self.ls(path, suppress_backend_errors=suppress_backend_errors)
         vs = [v for _, v in paths]
+
         return vs
 
     def _path_with_version(
@@ -806,6 +809,7 @@ class Versioned(Base):
         <root>/<version>/<base><ext>
 
         """
+        path = utils.check_path(path)
         version = utils.check_version(version)
         root, name = self.split(path)
         path = self.join(root, version, name)

--- a/audbackend/core/utils.py
+++ b/audbackend/core/utils.py
@@ -41,13 +41,11 @@ def check_path(
     # Assert path starts with sep and does not contain invalid characters.
     if not path.startswith(BACKEND_SEPARATOR):
         raise ValueError(
-            f"Invalid backend path '{path}', "
-            f"must start with '{BACKEND_SEPARATOR}'."
+            f"Invalid backend path '{path}', must start with '{BACKEND_SEPARATOR}'."
         )
     if not allow_sub_path and path.endswith(BACKEND_SEPARATOR):
         raise ValueError(
-            f"Invalid backend path '{path}', "
-            f"must not end on '{BACKEND_SEPARATOR}'."
+            f"Invalid backend path '{path}', must not end on '{BACKEND_SEPARATOR}'."
         )
     if path and BACKEND_ALLOWED_CHARS_COMPILED.fullmatch(path) is None:
         raise ValueError(

--- a/audbackend/core/utils.py
+++ b/audbackend/core/utils.py
@@ -32,12 +32,22 @@ def call_function_on_backend(
             raise BackendError(ex)
 
 
-def check_path(path: str) -> str:
+def check_path(
+    path: str,
+    *,
+    allow_sub_path: bool = False,
+) -> str:
     r"""Check path."""
     # Assert path starts with sep and does not contain invalid characters.
     if not path.startswith(BACKEND_SEPARATOR):
         raise ValueError(
-            f"Invalid backend path '{path}', " f"must start with '{BACKEND_SEPARATOR}'."
+            f"Invalid backend path '{path}', "
+            f"must start with '{BACKEND_SEPARATOR}'."
+        )
+    if not allow_sub_path and path.endswith(BACKEND_SEPARATOR):
+        raise ValueError(
+            f"Invalid backend path '{path}', "
+            f"must not end on '{BACKEND_SEPARATOR}'."
         )
     if path and BACKEND_ALLOWED_CHARS_COMPILED.fullmatch(path) is None:
         raise ValueError(

--- a/tests/test_interface_unversioned.py
+++ b/tests/test_interface_unversioned.py
@@ -240,6 +240,10 @@ def test_errors(tmpdir, interface):
     error_invalid_path = re.escape(
         f"Invalid backend path '{file_invalid_path}', " f"must start with '/'."
     )
+    file_sub_path = "/sub/"
+    error_sub_path = re.escape(
+        f"Invalid backend path '{file_sub_path}', " f"must not end on '/'."
+    )
     file_invalid_char = "/invalid/char.txt?"
     error_invalid_char = re.escape(
         f"Invalid backend path '{file_invalid_char}', "
@@ -266,6 +270,12 @@ def test_errors(tmpdir, interface):
     # `path` missing
     with pytest.raises(audbackend.BackendError, match=error_backend):
         interface.checksum("/missing.txt")
+    # `path` without leading '/'
+    with pytest.raises(ValueError, match=error_invalid_char):
+        interface.checksum(file_invalid_char)
+    # `path` with trailing '/'
+    with pytest.raises(ValueError, match=error_sub_path):
+        interface.checksum(file_sub_path)
     # `path` contains invalid character
     with pytest.raises(ValueError, match=error_invalid_char):
         interface.checksum(file_invalid_char)
@@ -277,12 +287,18 @@ def test_errors(tmpdir, interface):
     # `src_path` without leading '/'
     with pytest.raises(ValueError, match=error_invalid_path):
         interface.copy_file(file_invalid_path, "/file.txt")
+    # `src_path` with trailing '/'
+    with pytest.raises(ValueError, match=error_sub_path):
+        interface.copy_file(file_sub_path, "/file.txt")
     # `src_path` contains invalid character
     with pytest.raises(ValueError, match=error_invalid_char):
         interface.copy_file(file_invalid_char, "/file.txt")
     # `dst_path` without leading '/'
     with pytest.raises(ValueError, match=error_invalid_path):
         interface.copy_file("/file.txt", file_invalid_path)
+    # `dst_path` with trailing '/'
+    with pytest.raises(ValueError, match=error_sub_path):
+        interface.copy_file("/file.txt", file_sub_path)
     # `dst_path` contains invalid character
     with pytest.raises(ValueError, match=error_invalid_char):
         interface.copy_file("/file.txt", file_invalid_char)
@@ -291,6 +307,9 @@ def test_errors(tmpdir, interface):
     # `path` without leading '/'
     with pytest.raises(ValueError, match=error_invalid_path):
         interface.exists(file_invalid_path)
+    # `path` without trailing '/'
+    with pytest.raises(ValueError, match=error_sub_path):
+        interface.exists(file_sub_path)
     # `path` contains invalid character
     with pytest.raises(ValueError, match=error_invalid_char):
         interface.exists(file_invalid_char)
@@ -302,6 +321,9 @@ def test_errors(tmpdir, interface):
     # `src_path` without leading '/'
     with pytest.raises(ValueError, match=error_invalid_path):
         interface.get_archive(file_invalid_path, tmpdir)
+    # `src_path` with trailing '/'
+    with pytest.raises(ValueError, match=error_sub_path):
+        interface.get_archive(file_sub_path, tmpdir)
     # `src_path` contains invalid character
     with pytest.raises(ValueError, match=error_invalid_char):
         interface.get_archive(file_invalid_char, tmpdir)
@@ -344,6 +366,9 @@ def test_errors(tmpdir, interface):
     # `src_path` without leading '/'
     with pytest.raises(ValueError, match=error_invalid_path):
         interface.get_file(file_invalid_path, tmpdir)
+    # `src_path` with trailing '/'
+    with pytest.raises(ValueError, match=error_sub_path):
+        interface.get_file(file_sub_path, tmpdir)
     # `src_path` contains invalid character
     with pytest.raises(ValueError, match=error_invalid_char):
         interface.get_file(file_invalid_char, tmpdir)
@@ -396,12 +421,18 @@ def test_errors(tmpdir, interface):
     # `src_path` without leading '/'
     with pytest.raises(ValueError, match=error_invalid_path):
         interface.move_file(file_invalid_path, "/file.txt")
+    # `src_path` with trailing '/'
+    with pytest.raises(ValueError, match=error_sub_path):
+        interface.move_file(file_sub_path, "/file.txt")
     # `src_path` contains invalid character
     with pytest.raises(ValueError, match=error_invalid_char):
         interface.move_file(file_invalid_char, "/file.txt")
     # `dst_path` without leading '/'
     with pytest.raises(ValueError, match=error_invalid_path):
         interface.move_file("/file.txt", file_invalid_path)
+    # `dst_path` with trailing '/'
+    with pytest.raises(ValueError, match=error_sub_path):
+        interface.move_file("/file.txt", file_sub_path)
     # `dst_path` contains invalid character
     with pytest.raises(ValueError, match=error_invalid_char):
         interface.move_file("/file.txt", file_invalid_char)
@@ -427,6 +458,13 @@ def test_errors(tmpdir, interface):
         interface.put_archive(
             tmpdir,
             file_invalid_path,
+            files=local_file,
+        )
+    # `dst_path` with trailing '/'
+    with pytest.raises(ValueError, match=error_sub_path):
+        interface.put_archive(
+            tmpdir,
+            file_sub_path,
             files=local_file,
         )
     # `dst_path` contains invalid character
@@ -455,6 +493,9 @@ def test_errors(tmpdir, interface):
     # `dst_path` without leading '/'
     with pytest.raises(ValueError, match=error_invalid_path):
         interface.put_file(local_path, file_invalid_path)
+    # `dst_path` with trailing '/'
+    with pytest.raises(ValueError, match=error_sub_path):
+        interface.put_file(local_path, file_sub_path)
     # `dst_path` contains invalid character
     with pytest.raises(ValueError, match=error_invalid_char):
         interface.put_file(local_path, file_invalid_char)
@@ -466,6 +507,9 @@ def test_errors(tmpdir, interface):
     # `path` without leading '/'
     with pytest.raises(ValueError, match=error_invalid_path):
         interface.remove_file(file_invalid_path)
+    # `path` with trailing '/'
+    with pytest.raises(ValueError, match=error_sub_path):
+        interface.remove_file(file_sub_path)
     # `path` contains invalid character
     with pytest.raises(ValueError, match=error_invalid_char):
         interface.remove_file(file_invalid_char)

--- a/tests/test_interface_unversioned.py
+++ b/tests/test_interface_unversioned.py
@@ -303,6 +303,17 @@ def test_errors(tmpdir, interface):
     with pytest.raises(ValueError, match=error_invalid_char):
         interface.copy_file("/file.txt", file_invalid_char)
 
+    # --- date ---
+    # `path` without leading '/'
+    with pytest.raises(ValueError, match=error_invalid_path):
+        interface.date(file_invalid_path)
+    # `path` without trailing '/'
+    with pytest.raises(ValueError, match=error_sub_path):
+        interface.date(file_sub_path)
+    # `path` contains invalid character
+    with pytest.raises(ValueError, match=error_invalid_char):
+        interface.date(file_invalid_char)
+
     # --- exists ---
     # `path` without leading '/'
     with pytest.raises(ValueError, match=error_invalid_path):
@@ -436,6 +447,17 @@ def test_errors(tmpdir, interface):
     # `dst_path` contains invalid character
     with pytest.raises(ValueError, match=error_invalid_char):
         interface.move_file("/file.txt", file_invalid_char)
+
+    # --- owner ---
+    # `path` without leading '/'
+    with pytest.raises(ValueError, match=error_invalid_path):
+        interface.owner(file_invalid_path)
+    # `path` without trailing '/'
+    with pytest.raises(ValueError, match=error_sub_path):
+        interface.owner(file_sub_path)
+    # `path` contains invalid character
+    with pytest.raises(ValueError, match=error_invalid_char):
+        interface.owner(file_invalid_char)
 
     # --- put_archive ---
     # `src_root` missing

--- a/tests/test_interface_versioned.py
+++ b/tests/test_interface_versioned.py
@@ -265,6 +265,10 @@ def test_errors(tmpdir, interface):
     error_invalid_path = re.escape(
         f"Invalid backend path '{file_invalid_path}', " f"must start with '/'."
     )
+    file_sub_path = "/sub/"
+    error_sub_path = re.escape(
+        f"Invalid backend path '{file_sub_path}', " f"must not end on '/'."
+    )
     file_invalid_char = "/invalid/char.txt?"
     error_invalid_char = re.escape(
         f"Invalid backend path '{file_invalid_char}', "
@@ -300,6 +304,12 @@ def test_errors(tmpdir, interface):
     # `path` contains invalid character
     with pytest.raises(ValueError, match=error_invalid_char):
         interface.checksum(file_invalid_char, version)
+    # `path` without leading '/'
+    with pytest.raises(ValueError, match=error_invalid_char):
+        interface.checksum(file_invalid_char, version)
+    # `path` with trailing '/'
+    with pytest.raises(ValueError, match=error_sub_path):
+        interface.checksum(file_sub_path, version)
     # invalid version
     with pytest.raises(ValueError, match=error_empty_version):
         interface.checksum(remote_file, empty_version)
@@ -316,9 +326,15 @@ def test_errors(tmpdir, interface):
     # `src_path` contains invalid character
     with pytest.raises(ValueError, match=error_invalid_char):
         interface.copy_file(file_invalid_char, "/file.txt")
+    # `src_path` with trailing '/'
+    with pytest.raises(ValueError, match=error_sub_path):
+        interface.copy_file(file_sub_path, "/file.txt")
     # `dst_path` without leading '/'
     with pytest.raises(ValueError, match=error_invalid_path):
         interface.copy_file("/file.txt", file_invalid_path)
+    # `dst_path` with trailing '/'
+    with pytest.raises(ValueError, match=error_sub_path):
+        interface.copy_file("/file.txt", file_sub_path)
     # `dst_path` contains invalid character
     with pytest.raises(ValueError, match=error_invalid_char):
         interface.copy_file("/file.txt", file_invalid_char)
@@ -330,6 +346,9 @@ def test_errors(tmpdir, interface):
     # `path` without leading '/'
     with pytest.raises(ValueError, match=error_invalid_path):
         interface.exists(file_invalid_path, version)
+    # `path` without trailing '/'
+    with pytest.raises(ValueError, match=error_sub_path):
+        interface.exists(file_sub_path, version)
     # `path` contains invalid character
     with pytest.raises(ValueError, match=error_invalid_char):
         interface.exists(file_invalid_char, version)
@@ -346,6 +365,9 @@ def test_errors(tmpdir, interface):
     # `src_path` without leading '/'
     with pytest.raises(ValueError, match=error_invalid_path):
         interface.get_archive(file_invalid_path, tmpdir, version)
+    # `src_path` with trailing '/'
+    with pytest.raises(ValueError, match=error_sub_path):
+        interface.get_archive(file_sub_path, tmpdir, version)
     # `src_path` contains invalid character
     with pytest.raises(ValueError, match=error_invalid_char):
         interface.get_archive(file_invalid_char, tmpdir, version)
@@ -400,6 +422,9 @@ def test_errors(tmpdir, interface):
     # `src_path` without leading '/'
     with pytest.raises(ValueError, match=error_invalid_path):
         interface.get_file(file_invalid_path, tmpdir, version)
+    # `src_path` with trailing '/'
+    with pytest.raises(ValueError, match=error_sub_path):
+        interface.get_file(file_sub_path, tmpdir, version)
     # `src_path` contains invalid character
     with pytest.raises(ValueError, match=error_invalid_char):
         interface.get_file(file_invalid_char, tmpdir, version)
@@ -432,9 +457,12 @@ def test_errors(tmpdir, interface):
     # `path` missing
     with pytest.raises(audbackend.BackendError, match=error_backend):
         interface.latest_version("/missing.txt")
-    # joined path without leading '/'
+    # path without leading '/'
     with pytest.raises(ValueError, match=error_invalid_path):
         interface.latest_version(file_invalid_path)
+    # path with trailing '/'
+    with pytest.raises(ValueError, match=error_sub_path):
+        interface.latest_version(file_sub_path)
     # `path` contains invalid character
     with pytest.raises(ValueError, match=error_invalid_char):
         interface.latest_version(file_invalid_char)
@@ -468,12 +496,18 @@ def test_errors(tmpdir, interface):
     # `src_path` without leading '/'
     with pytest.raises(ValueError, match=error_invalid_path):
         interface.move_file(file_invalid_path, "/file.txt")
+    # `src_path` with trailing '/'
+    with pytest.raises(ValueError, match=error_sub_path):
+        interface.move_file(file_sub_path, "/file.txt")
     # `src_path` contains invalid character
     with pytest.raises(ValueError, match=error_invalid_char):
         interface.move_file(file_invalid_char, "/file.txt")
     # `dst_path` without leading '/'
     with pytest.raises(ValueError, match=error_invalid_path):
         interface.move_file("/file.txt", file_invalid_path)
+    # `dst_path` with trailing '/'
+    with pytest.raises(ValueError, match=error_sub_path):
+        interface.move_file("/file.txt", file_sub_path)
     # `dst_path` contains invalid character
     with pytest.raises(ValueError, match=error_invalid_char):
         interface.move_file("/file.txt", file_invalid_char)
@@ -544,6 +578,9 @@ def test_errors(tmpdir, interface):
     # `dst_path` without leading '/'
     with pytest.raises(ValueError, match=error_invalid_path):
         interface.put_file(local_path, file_invalid_path, version)
+    # `dst_path` with trailing '/'
+    with pytest.raises(ValueError, match=error_sub_path):
+        interface.put_file(local_path, file_sub_path, version)
     # `dst_path` contains invalid character
     with pytest.raises(ValueError, match=error_invalid_char):
         interface.put_file(local_path, file_invalid_char, version)
@@ -560,6 +597,9 @@ def test_errors(tmpdir, interface):
     # `path` without leading '/'
     with pytest.raises(ValueError, match=error_invalid_path):
         interface.remove_file(file_invalid_path, version)
+    # `path` with trailing '/'
+    with pytest.raises(ValueError, match=error_sub_path):
+        interface.remove_file(file_sub_path, version)
     # `path` contains invalid character
     with pytest.raises(ValueError, match=error_invalid_char):
         interface.remove_file(file_invalid_char, version)
@@ -581,6 +621,9 @@ def test_errors(tmpdir, interface):
     # `path` without leading '/'
     with pytest.raises(ValueError, match=error_invalid_path):
         interface.versions(file_invalid_path)
+    # `path` with trailing '/'
+    with pytest.raises(ValueError, match=error_sub_path):
+        interface.versions(file_sub_path)
     # `path` contains invalid character
     with pytest.raises(ValueError, match=error_invalid_char):
         interface.versions(file_invalid_char)

--- a/tests/test_interface_versioned.py
+++ b/tests/test_interface_versioned.py
@@ -342,6 +342,22 @@ def test_errors(tmpdir, interface):
     with pytest.raises(ValueError, match=error_empty_version):
         interface.copy_file(remote_file, "/file.txt", version=empty_version)
 
+    # --- date ---
+    # `path` without leading '/'
+    with pytest.raises(ValueError, match=error_invalid_path):
+        interface.date(file_invalid_path, version)
+    # `path` without trailing '/'
+    with pytest.raises(ValueError, match=error_sub_path):
+        interface.date(file_sub_path, version)
+    # `path` contains invalid character
+    with pytest.raises(ValueError, match=error_invalid_char):
+        interface.date(file_invalid_char, version)
+    # invalid version
+    with pytest.raises(ValueError, match=error_empty_version):
+        interface.date(remote_file, empty_version)
+    with pytest.raises(ValueError, match=error_invalid_version):
+        interface.date(remote_file, invalid_version)
+
     # --- exists ---
     # `path` without leading '/'
     with pytest.raises(ValueError, match=error_invalid_path):
@@ -489,7 +505,7 @@ def test_errors(tmpdir, interface):
     with pytest.raises(ValueError, match=error_invalid_char):
         interface.ls(file_invalid_char)
 
-    # --- copy_file ---
+    # --- move_file ---
     # `src_path` missing
     with pytest.raises(audbackend.BackendError, match=error_backend):
         interface.move_file("/missing.txt", "/file.txt")
@@ -515,6 +531,22 @@ def test_errors(tmpdir, interface):
     with pytest.raises(ValueError, match=error_empty_version):
         interface.move_file(remote_file, "/file.txt", version=empty_version)
 
+    # --- owner ---
+    # `path` without leading '/'
+    with pytest.raises(ValueError, match=error_invalid_path):
+        interface.owner(file_invalid_path, version)
+    # `path` without trailing '/'
+    with pytest.raises(ValueError, match=error_sub_path):
+        interface.owner(file_sub_path, version)
+    # `path` contains invalid character
+    with pytest.raises(ValueError, match=error_invalid_char):
+        interface.owner(file_invalid_char, version)
+    # invalid version
+    with pytest.raises(ValueError, match=error_empty_version):
+        interface.owner(remote_file, empty_version)
+    with pytest.raises(ValueError, match=error_invalid_version):
+        interface.owner(remote_file, invalid_version)
+
     # --- put_archive ---
     # `src_root` missing
     error_msg = "No such file or directory: ..."
@@ -537,6 +569,14 @@ def test_errors(tmpdir, interface):
         interface.put_archive(
             tmpdir,
             file_invalid_path,
+            version,
+            files=local_file,
+        )
+    # `dst_path` with trailing '/'
+    with pytest.raises(ValueError, match=error_sub_path):
+        interface.put_archive(
+            tmpdir,
+            file_sub_path,
             version,
             files=local_file,
         )


### PR DESCRIPTION
Closes #206

All backend fucntions now raise a `ValueError` if a backend path ends on `'/'` with the exception of `ls()`, `split()` and `join()` as those functions support sub-paths as argument.

The *Raises*  section in the docstrings is changed to:

![image](https://github.com/audeering/audbackend/assets/10383417/5786b9e7-bae0-4a02-98b8-81a6960afc0c)
