### PR TITLE
DOC: improve interface names in docstring examples

### DIFF
--- a/audbackend/core/conftest.py
+++ b/audbackend/core/conftest.py
@@ -10,9 +10,6 @@ import audbackend
 
 
 class DoctestFileSystem(audbackend.backend.FileSystem):
-    def __repr__(self) -> str:  # noqa: D105
-        return f"audbackend.backend.FileSystem('{self.host}', '{self.repository}')"
-
     def _date(
         self,
         path: str,
@@ -36,16 +33,16 @@ def prepare_docstring_tests(doctest_namespace):
         os.chdir(tmp)
         # Prepare backend
         audeer.mkdir("host")
-        DoctestFileSystem.create("host", "repo")
+        audbackend.backend.FileSystem.create("host", "repo")
         # Provide DoctestFileSystem as FileSystem,
         # and audbackend
         # in docstring examples
-        doctest_namespace["FileSystem"] = DoctestFileSystem
+        doctest_namespace["DoctestFileSystem"] = DoctestFileSystem
         doctest_namespace["audbackend"] = audbackend
 
         yield
 
         # Remove backend
-        DoctestFileSystem.delete("host", "repo")
+        audbackend.backend.FileSystem.delete("host", "repo")
         # Change back to current dir
         os.chdir(current_dir)

--- a/audbackend/core/conftest.py
+++ b/audbackend/core/conftest.py
@@ -53,23 +53,6 @@ def prepare_docstring_tests(doctest_namespace):
             with DoctestFileSystem("host", "repo-unversioned") as backend_unversioned:
                 # versioned interface
 
-                versioned = audbackend.interface.Versioned(backend_versioned)
-                versioned.put_archive(".", "/a.zip", "1.0.0", files=[file])
-                versioned.put_file(file, "/a/b.ext", "1.0.0")
-                for version in ["1.0.0", "2.0.0"]:
-                    versioned.put_file(file, "/f.ext", version)
-                doctest_namespace["versioned"] = versioned
-
-                # unversioned interface
-
-                unversioned = audbackend.interface.Unversioned(backend_unversioned)
-                unversioned.put_archive(".", "/a.zip", files=[file])
-                unversioned.put_file(file, "/a/b.ext")
-                unversioned.put_file(file, "/f.ext")
-                doctest_namespace["unversioned"] = unversioned
-
-                yield
-
         DoctestFileSystem.delete("host", "repo")
         DoctestFileSystem.delete("host", "repo-unversioned")
 

--- a/audbackend/core/conftest.py
+++ b/audbackend/core/conftest.py
@@ -25,7 +25,7 @@ class DoctestFileSystem(audbackend.backend.FileSystem):
         return "doctest"
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(scope="function", autouse=True)
 def prepare_docstring_tests(doctest_namespace):
     with tempfile.TemporaryDirectory() as tmp:
         # Change to tmp dir
@@ -34,6 +34,8 @@ def prepare_docstring_tests(doctest_namespace):
         # Prepare backend
         audeer.mkdir("host")
         audbackend.backend.FileSystem.create("host", "repo")
+        # Provide example file `src.txt`
+        audeer.touch("src.txt")
         # Provide DoctestFileSystem as FileSystem,
         # and audbackend
         # in docstring examples

--- a/audbackend/core/errors.py
+++ b/audbackend/core/errors.py
@@ -9,10 +9,9 @@ class BackendError(Exception):
         >>> import audeer
         >>> audeer.rmdir("host", "repo")
         >>> _ = audeer.mkdir("host")
-        >>> FileSystem.create("host", "repo")
 
     Examples:
-        >>> backend = FileSystem("host", "repo")
+        >>> backend = audbackend.backend.FileSystem("host", "repo")
         >>> try:
         ...     interface = audbackend.interface.Unversioned(backend)
         ...     interface.checksum("/does/not/exist")

--- a/audbackend/core/errors.py
+++ b/audbackend/core/errors.py
@@ -4,14 +4,24 @@ class BackendError(Exception):
     Args:
         exception: exception raised by backend
 
+    .. Prepare backend and interface for docstring examples
+
+        >>> import audeer
+        >>> audeer.rmdir("host", "repo")
+        >>> _ = audeer.mkdir("host")
+        >>> FileSystem.create("host", "repo")
+
     Examples:
+        >>> backend = FileSystem("host", "repo")
         >>> try:
-        ...     unversioned.checksum("/does/not/exist")
+        ...     interface = audbackend.interface.Unversioned(backend)
+        ...     interface.checksum("/does/not/exist")
         ... except BackendError as ex:
         ...     ex.exception
         FileNotFoundError(2, 'No such file or directory')
         >>> try:
-        ...     versioned.checksum("/does/not/exist", "1.0.0")
+        ...     interface = audbackend.interface.Versioned(backend)
+        ...     interface.checksum("/does/not/exist", "1.0.0")
         ... except BackendError as ex:
         ...     ex.exception
         FileNotFoundError(2, 'No such file or directory')

--- a/audbackend/core/interface/base.py
+++ b/audbackend/core/interface/base.py
@@ -18,15 +18,9 @@ class Base:
     Args:
         backend: backend object
 
-    .. Prepare backend and interface for docstring examples
-
-        >>> import audeer
-        >>> audeer.rmdir("host", "repo")
-        >>> _ = audeer.mkdir("host")
-        >>> FileSystem.create("host", "repo")
-
     Examples:
-        >>> interface = Base(FileSystem("host", "repo"))
+        >>> backend = audbackend.backend.FileSystem("host", "repo")
+        >>> interface = Base(backend)
 
     """
 
@@ -48,7 +42,8 @@ class Base:
             backend object
 
         ..
-            >>> interface = Base(FileSystem("host", "repo"))
+            >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> interface = Base(backend)
 
         Examples:
             >>> interface.backend
@@ -64,7 +59,8 @@ class Base:
         Returns: host path
 
         ..
-            >>> interface = Base(FileSystem("host", "repo"))
+            >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> interface = Base(backend)
 
         Examples:
             >>> interface.host
@@ -93,7 +89,8 @@ class Base:
                 or if joined path contains invalid character
 
         ..
-            >>> interface = Base(FileSystem("host", "repo"))
+            >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> interface = Base(backend)
 
         Examples:
             >>> interface.join("/", "f.ext")
@@ -114,7 +111,8 @@ class Base:
             repository name
 
         ..
-            >>> interface = Base(FileSystem("host", "repo"))
+            >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> interface = Base(backend)
 
         Examples:
             >>> interface.repository
@@ -131,7 +129,8 @@ class Base:
             file separator
 
         ..
-            >>> interface = Base(FileSystem("host", "repo"))
+            >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> interface = Base(backend)
 
         Examples:
             >>> interface.sep
@@ -157,7 +156,8 @@ class Base:
                 does not match ``'[A-Za-z0-9/._-]+'``
 
         ..
-            >>> interface = Base(FileSystem("host", "repo"))
+            >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> interface = Base(backend)
 
         Examples:
             >>> interface.split("/")

--- a/audbackend/core/interface/base.py
+++ b/audbackend/core/interface/base.py
@@ -18,10 +18,6 @@ class Base:
     Args:
         backend: backend object
 
-    Examples:
-        >>> backend = audbackend.backend.FileSystem("host", "repo")
-        >>> interface = Base(backend)
-
     """
 
     def __init__(

--- a/audbackend/core/interface/base.py
+++ b/audbackend/core/interface/base.py
@@ -18,6 +18,16 @@ class Base:
     Args:
         backend: backend object
 
+    .. Prepare backend and interface for docstring examples
+
+        >>> import audeer
+        >>> audeer.rmdir("host", "repo")
+        >>> _ = audeer.mkdir("host")
+        >>> FileSystem.create("host", "repo")
+
+    Examples:
+        >>> interface = Base(FileSystem("host", "repo"))
+
     """
 
     def __init__(
@@ -37,9 +47,12 @@ class Base:
         Returns:
             backend object
 
+        ..
+            >>> interface = Base(FileSystem("host", "repo"))
+
         Examples:
             >>> interface.backend
-            audbackend.backend.Base('host', 'repo')
+            audbackend.backend.FileSystem('host', 'repo')
 
         """
         return self._backend
@@ -49,6 +62,9 @@ class Base:
         r"""Host path.
 
         Returns: host path
+
+        ..
+            >>> interface = Base(FileSystem("host", "repo"))
 
         Examples:
             >>> interface.host
@@ -76,6 +92,9 @@ class Base:
                 or does not start with ``'/'``,
                 or if joined path contains invalid character
 
+        ..
+            >>> interface = Base(FileSystem("host", "repo"))
+
         Examples:
             >>> interface.join("/", "f.ext")
             '/f.ext'
@@ -94,6 +113,9 @@ class Base:
         Returns:
             repository name
 
+        ..
+            >>> interface = Base(FileSystem("host", "repo"))
+
         Examples:
             >>> interface.repository
             'repo'
@@ -107,6 +129,9 @@ class Base:
 
         Returns:
             file separator
+
+        ..
+            >>> interface = Base(FileSystem("host", "repo"))
 
         Examples:
             >>> interface.sep
@@ -130,6 +155,9 @@ class Base:
         Raises:
             ValueError: if ``path`` does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
+
+        ..
+            >>> interface = Base(FileSystem("host", "repo"))
 
         Examples:
             >>> interface.split("/")

--- a/audbackend/core/interface/base.py
+++ b/audbackend/core/interface/base.py
@@ -89,12 +89,12 @@ class Base:
             >>> interface = Base(backend)
 
         Examples:
-            >>> interface.join("/", "f.ext")
-            '/f.ext'
-            >>> interface.join("/sub", "f.ext")
-            '/sub/f.ext'
-            >>> interface.join("//sub//", "/", "", None, "/f.ext")
-            '/sub/f.ext'
+            >>> interface.join("/", "file.txt")
+            '/file.txt'
+            >>> interface.join("/sub", "file.txt")
+            '/sub/file.txt'
+            >>> interface.join("//sub//", "/", "", None, "/file.txt")
+            '/sub/file.txt'
 
         """
         return self.backend.join(path, *paths)
@@ -158,12 +158,12 @@ class Base:
         Examples:
             >>> interface.split("/")
             ('/', '')
-            >>> interface.split("/f.ext")
-            ('/', 'f.ext')
+            >>> interface.split("/file.txt")
+            ('/', 'file.txt')
             >>> interface.split("/sub/")
             ('/sub/', '')
-            >>> interface.split("/sub//f.ext")
-            ('/sub/', 'f.ext')
+            >>> interface.split("/sub//file.txt")
+            ('/sub/', 'file.txt')
 
         """
         return self.backend.split(path)

--- a/audbackend/core/interface/maven.py
+++ b/audbackend/core/interface/maven.py
@@ -64,9 +64,7 @@ class Maven(Versioned):
             as extensions
 
     Examples:
-        >>> import audeer
         >>> file = "src.txt"
-        >>> _ = audeer.touch(file)
         >>> backend = audbackend.backend.FileSystem("host", "repo")
         >>> interface = Maven(backend)
         >>> interface.put_archive(".", "/sub/archive.zip", "1.0.0", files=[file])
@@ -74,6 +72,8 @@ class Maven(Versioned):
         ...     interface.put_file(file, "/file.txt", version)
         >>> interface.ls()
         [('/file.txt', '1.0.0'), ('/file.txt', '2.0.0'), ('/sub/archive.zip', '1.0.0')]
+        >>> interface.get_file("/file.txt", "dst.txt", "2.0.0")
+        '.../dst.txt'
 
     """  # noqa: E501
 
@@ -141,6 +141,10 @@ class Maven(Versioned):
             >>> interface = Maven(backend)
 
         Examples:
+            >>> file = "src.txt"
+            >>> interface.put_archive(".", "/sub/archive.zip", "1.0.0", files=[file])
+            >>> for version in ["1.0.0", "2.0.0"]:
+            ...     interface.put_file(file, "/file.txt", version)
             >>> interface.ls()
             [('/file.txt', '1.0.0'), ('/file.txt', '2.0.0'), ('/sub/archive.zip', '1.0.0')]
             >>> interface.ls(latest_version=True)

--- a/audbackend/core/interface/maven.py
+++ b/audbackend/core/interface/maven.py
@@ -73,7 +73,7 @@ class Maven(Versioned):
         >>> interface.ls()
         [('/file.txt', '1.0.0'), ('/file.txt', '2.0.0'), ('/sub/archive.zip', '1.0.0')]
         >>> interface.get_file("/file.txt", "dst.txt", "2.0.0")
-        '.../dst.txt'
+        '...dst.txt'
 
     """  # noqa: E501
 

--- a/audbackend/core/interface/maven.py
+++ b/audbackend/core/interface/maven.py
@@ -150,6 +150,8 @@ class Maven(Versioned):
             [('/a/b.ext', '1.0.0'), ('/f.ext', '1.0.0'), ('/f.ext', '2.0.0')]
             >>> interface.ls(pattern="b.*")
             [('/a/b.ext', '1.0.0')]
+            >>> interface.ls("/a/")
+            [('/a/b.ext', '1.0.0')]
 
         """  # noqa: E501
         if path.endswith("/"):  # find files under sub-path

--- a/audbackend/core/interface/maven.py
+++ b/audbackend/core/interface/maven.py
@@ -63,7 +63,19 @@ class Maven(Versioned):
             ...
             as extensions
 
-    """
+    Examples:
+        >>> import audeer
+        >>> file = "src.pth"
+        >>> _ = audeer.touch(file)
+        >>> interface = Maven(FileSystem("host", "repo"))
+        >>> interface.put_archive(".", "/a.zip", "1.0.0", files=[file])
+        >>> interface.put_file(file, "/a/b.ext", "1.0.0")
+        >>> for version in ["1.0.0", "2.0.0"]:
+        ...     interface.put_file(file, "/f.ext", version)
+        >>> interface.ls()
+        [('/a.zip', '1.0.0'), ('/a/b.ext', '1.0.0'), ('/f.ext', '1.0.0'), ('/f.ext', '2.0.0')]
+
+    """  # noqa: E501
 
     def __init__(
         self,
@@ -124,18 +136,19 @@ class Maven(Versioned):
             ValueError: if ``path`` does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
 
+        ..
+            >>> interface = Maven(FileSystem("host", "repo"))
+
         Examples:
-            >>> versioned.ls()
+            >>> interface.ls()
             [('/a.zip', '1.0.0'), ('/a/b.ext', '1.0.0'), ('/f.ext', '1.0.0'), ('/f.ext', '2.0.0')]
-            >>> versioned.ls(latest_version=True)
+            >>> interface.ls(latest_version=True)
             [('/a.zip', '1.0.0'), ('/a/b.ext', '1.0.0'), ('/f.ext', '2.0.0')]
-            >>> versioned.ls("/f.ext")
+            >>> interface.ls("/f.ext")
             [('/f.ext', '1.0.0'), ('/f.ext', '2.0.0')]
-            >>> versioned.ls(pattern="*.ext")
+            >>> interface.ls(pattern="*.ext")
             [('/a/b.ext', '1.0.0'), ('/f.ext', '1.0.0'), ('/f.ext', '2.0.0')]
-            >>> versioned.ls(pattern="b.*")
-            [('/a/b.ext', '1.0.0')]
-            >>> versioned.ls("/a/")
+            >>> interface.ls(pattern="b.*")
             [('/a/b.ext', '1.0.0')]
 
         """  # noqa: E501

--- a/audbackend/core/interface/maven.py
+++ b/audbackend/core/interface/maven.py
@@ -67,7 +67,8 @@ class Maven(Versioned):
         >>> import audeer
         >>> file = "src.pth"
         >>> _ = audeer.touch(file)
-        >>> interface = Maven(FileSystem("host", "repo"))
+        >>> backend = audbackend.backend.FileSystem("host", "repo")
+        >>> interface = Maven(backend)
         >>> interface.put_archive(".", "/a.zip", "1.0.0", files=[file])
         >>> interface.put_file(file, "/a/b.ext", "1.0.0")
         >>> for version in ["1.0.0", "2.0.0"]:
@@ -137,7 +138,8 @@ class Maven(Versioned):
                 does not match ``'[A-Za-z0-9/._-]+'``
 
         ..
-            >>> interface = Maven(FileSystem("host", "repo"))
+            >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> interface = Maven(backend)
 
         Examples:
             >>> interface.ls()

--- a/audbackend/core/interface/maven.py
+++ b/audbackend/core/interface/maven.py
@@ -65,16 +65,15 @@ class Maven(Versioned):
 
     Examples:
         >>> import audeer
-        >>> file = "src.pth"
+        >>> file = "src.txt"
         >>> _ = audeer.touch(file)
         >>> backend = audbackend.backend.FileSystem("host", "repo")
         >>> interface = Maven(backend)
-        >>> interface.put_archive(".", "/a.zip", "1.0.0", files=[file])
-        >>> interface.put_file(file, "/a/b.ext", "1.0.0")
+        >>> interface.put_archive(".", "/sub/archive.zip", "1.0.0", files=[file])
         >>> for version in ["1.0.0", "2.0.0"]:
-        ...     interface.put_file(file, "/f.ext", version)
+        ...     interface.put_file(file, "/file.txt", version)
         >>> interface.ls()
-        [('/a.zip', '1.0.0'), ('/a/b.ext', '1.0.0'), ('/f.ext', '1.0.0'), ('/f.ext', '2.0.0')]
+        [('/file.txt', '1.0.0'), ('/file.txt', '2.0.0'), ('/sub/archive.zip', '1.0.0')]
 
     """  # noqa: E501
 
@@ -143,17 +142,17 @@ class Maven(Versioned):
 
         Examples:
             >>> interface.ls()
-            [('/a.zip', '1.0.0'), ('/a/b.ext', '1.0.0'), ('/f.ext', '1.0.0'), ('/f.ext', '2.0.0')]
+            [('/file.txt', '1.0.0'), ('/file.txt', '2.0.0'), ('/sub/archive.zip', '1.0.0')]
             >>> interface.ls(latest_version=True)
-            [('/a.zip', '1.0.0'), ('/a/b.ext', '1.0.0'), ('/f.ext', '2.0.0')]
-            >>> interface.ls("/f.ext")
-            [('/f.ext', '1.0.0'), ('/f.ext', '2.0.0')]
-            >>> interface.ls(pattern="*.ext")
-            [('/a/b.ext', '1.0.0'), ('/f.ext', '1.0.0'), ('/f.ext', '2.0.0')]
-            >>> interface.ls(pattern="b.*")
-            [('/a/b.ext', '1.0.0')]
-            >>> interface.ls("/a/")
-            [('/a/b.ext', '1.0.0')]
+            [('/file.txt', '2.0.0'), ('/sub/archive.zip', '1.0.0')]
+            >>> interface.ls("/file.txt")
+            [('/file.txt', '1.0.0'), ('/file.txt', '2.0.0')]
+            >>> interface.ls(pattern="*.txt")
+            [('/file.txt', '1.0.0'), ('/file.txt', '2.0.0')]
+            >>> interface.ls(pattern="archive.*")
+            [('/sub/archive.zip', '1.0.0')]
+            >>> interface.ls("/sub/")
+            [('/sub/archive.zip', '1.0.0')]
 
         """  # noqa: E501
         if path.endswith("/"):  # find files under sub-path

--- a/audbackend/core/interface/unversioned.py
+++ b/audbackend/core/interface/unversioned.py
@@ -138,7 +138,7 @@ class Unversioned(Base):
             >>> interface = Unversioned(backend)
 
         Examples:
-              >>> interface.date("/copy.txt")
+              >>> interface.date("/file.txt")
               '1991-02-20'
 
         """

--- a/audbackend/core/interface/unversioned.py
+++ b/audbackend/core/interface/unversioned.py
@@ -625,10 +625,10 @@ class Unversioned(Base):
 
         Examples:
             >>> file = "src.txt"
-            >>> interface.exists("/sub/file.txt")
+            >>> interface.exists("/file.txt")
             False
-            >>> interface.put_file("src.txt", "/sub/file.txt")
-            >>> interface.exists("/sub/file.txt")
+            >>> interface.put_file("src.txt", "/file.txt")
+            >>> interface.exists("/file.txt")
             True
 
         """

--- a/audbackend/core/interface/unversioned.py
+++ b/audbackend/core/interface/unversioned.py
@@ -17,7 +17,8 @@ class Unversioned(Base):
         >>> import audeer
         >>> file = "src.pth"
         >>> _ = audeer.touch(file)
-        >>> interface = Unversioned(FileSystem("host", "repo"))
+        >>> backend = audbackend.backend.FileSystem("host", "repo")
+        >>> interface = Unversioned(backend)
         >>> interface.put_archive(".", "/a.zip", files=[file])
         >>> interface.put_file(file, "/a/b.ext")
         >>> interface.put_file(file, "/f.ext")
@@ -45,7 +46,8 @@ class Unversioned(Base):
                 does not match ``'[A-Za-z0-9/._-]+'``
 
         ..
-            >>> interface = Unversioned(FileSystem("host", "repo"))
+            >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> interface = Unversioned(backend)
 
         Examples:
             >>> interface.checksum("/f.ext")
@@ -92,7 +94,8 @@ class Unversioned(Base):
                 does not match ``'[A-Za-z0-9/._-]+'``
 
         ..
-            >>> interface = Unversioned(FileSystem("host", "repo"))
+            >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> interface = Unversioned(backend)
 
         Examples:
             >>> interface.exists("/copy.ext")
@@ -132,7 +135,8 @@ class Unversioned(Base):
                 does not match ``'[A-Za-z0-9/._-]+'``
 
         ..
-            >>> interface = Unversioned(FileSystem("host", "repo"))
+            >>> backend = DoctestFileSystem("host", "repo")
+            >>> interface = Unversioned(backend)
 
         Examples:
               >>> interface.date("/f.ext")
@@ -168,7 +172,8 @@ class Unversioned(Base):
                 does not match ``'[A-Za-z0-9._-]+'``
 
         ..
-            >>> interface = Unversioned(FileSystem("host", "repo"))
+            >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> interface = Unversioned(backend)
 
         Examples:
             >>> interface.exists("/f.ext")
@@ -231,7 +236,8 @@ class Unversioned(Base):
                 does not match ``'[A-Za-z0-9/._-]+'``
 
         ..
-            >>> interface = Unversioned(FileSystem("host", "repo"))
+            >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> interface = Unversioned(backend)
 
         Examples:
             >>> interface.get_archive("/a.zip", ".")
@@ -295,7 +301,8 @@ class Unversioned(Base):
                 does not match ``'[A-Za-z0-9/._-]+'``
 
         ..
-            >>> interface = Unversioned(FileSystem("host", "repo"))
+            >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> interface = Unversioned(backend)
 
         Examples:
             >>> os.path.exists("dst.pth")
@@ -358,7 +365,8 @@ class Unversioned(Base):
                 does not match ``'[A-Za-z0-9/._-]+'``
 
         ..
-            >>> interface = Unversioned(FileSystem("host", "repo"))
+            >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> interface = Unversioned(backend)
 
         Examples:
             >>> interface.ls()
@@ -421,7 +429,8 @@ class Unversioned(Base):
                 does not match ``'[A-Za-z0-9/._-]+'``
 
         ..
-            >>> interface = Unversioned(FileSystem("host", "repo"))
+            >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> interface = Unversioned(backend)
 
         Examples:
             >>> interface.exists("/move.ext")
@@ -464,7 +473,8 @@ class Unversioned(Base):
                 does not match ``'[A-Za-z0-9/._-]+'``
 
         ..
-            >>> interface = Unversioned(FileSystem("host", "repo"))
+            >>> backend = DoctestFileSystem("host", "repo")
+            >>> interface = Unversioned(backend)
 
         Examples:
               >>> interface.owner("/f.ext")
@@ -529,7 +539,8 @@ class Unversioned(Base):
                 does not match ``'[A-Za-z0-9/._-]+'``
 
         ..
-            >>> interface = Unversioned(FileSystem("host", "repo"))
+            >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> interface = Unversioned(backend)
 
         Examples:
             >>> interface.exists("/a.tar.gz")
@@ -586,7 +597,8 @@ class Unversioned(Base):
                 does not match ``'[A-Za-z0-9/._-]+'``
 
         ..
-            >>> interface = Unversioned(FileSystem("host", "repo"))
+            >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> interface = Unversioned(backend)
 
         Examples:
             >>> interface.exists("/sub/f.ext")
@@ -619,7 +631,8 @@ class Unversioned(Base):
                 does not match ``'[A-Za-z0-9/._-]+'``
 
         ..
-            >>> interface = Unversioned(FileSystem("host", "repo"))
+            >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> interface = Unversioned(backend)
 
         Examples:
             >>> interface.exists("/f.ext")

--- a/audbackend/core/interface/unversioned.py
+++ b/audbackend/core/interface/unversioned.py
@@ -627,7 +627,7 @@ class Unversioned(Base):
             >>> file = "src.txt"
             >>> interface.exists("/file.txt")
             False
-            >>> interface.put_file("src.txt", "/file.txt")
+            >>> interface.put_file(file, "/file.txt")
             >>> interface.exists("/file.txt")
             True
 

--- a/audbackend/core/interface/unversioned.py
+++ b/audbackend/core/interface/unversioned.py
@@ -14,15 +14,15 @@ class Unversioned(Base):
         backend: backend object
 
     Examples:
-        >>> import audeer
         >>> file = "src.txt"
-        >>> _ = audeer.touch(file)
         >>> backend = audbackend.backend.FileSystem("host", "repo")
         >>> interface = Unversioned(backend)
         >>> interface.put_file(file, "/file.txt")
         >>> interface.put_archive(".", "/sub/archive.zip", files=[file])
         >>> interface.ls()
         ['/file.txt', '/sub/archive.zip']
+        >>> interface.get_file("/file.txt", "dst.txt")
+        '.../dst.txt'
 
     """
 
@@ -49,6 +49,11 @@ class Unversioned(Base):
             >>> interface = Unversioned(backend)
 
         Examples:
+            >>> file = "src.txt"
+            >>> import audeer
+            >>> audeer.md5(file)
+            'd41d8cd98f00b204e9800998ecf8427e'
+            >>> interface.put_file(file, "/file.txt")
             >>> interface.checksum("/file.txt")
             'd41d8cd98f00b204e9800998ecf8427e'
 
@@ -97,12 +102,13 @@ class Unversioned(Base):
             >>> interface = Unversioned(backend)
 
         Examples:
+            >>> file = "src.txt"
+            >>> interface.put_file(file, "/file.txt")
             >>> interface.exists("/copy.txt")
             False
             >>> interface.copy_file("/file.txt", "/copy.txt")
             >>> interface.exists("/copy.txt")
             True
-            >>> interface.remove_file("/copy.txt")
 
         """
         self.backend.copy_file(
@@ -138,6 +144,8 @@ class Unversioned(Base):
             >>> interface = Unversioned(backend)
 
         Examples:
+            >>> file = "src.txt"
+            >>> interface.put_file(file, "/file.txt")
             >>> interface.date("/file.txt")
             '1991-02-20'
 
@@ -175,6 +183,10 @@ class Unversioned(Base):
             >>> interface = Unversioned(backend)
 
         Examples:
+            >>> file = "src.txt"
+            >>> interface.exists("/file.txt")
+            False
+            >>> interface.put_file(file, "/file.txt")
             >>> interface.exists("/file.txt")
             True
 
@@ -239,6 +251,9 @@ class Unversioned(Base):
             >>> interface = Unversioned(backend)
 
         Examples:
+            >>> file = "src.txt"
+            >>> interface.put_archive(".", "/sub/archive.zip", files=[file])
+            >>> os.remove(file)
             >>> interface.get_archive("/sub/archive.zip", ".")
             ['src.txt']
 
@@ -304,6 +319,8 @@ class Unversioned(Base):
             >>> interface = Unversioned(backend)
 
         Examples:
+            >>> file = "src.txt"
+            >>> interface.put_file(file, "/file.txt")
             >>> os.path.exists("dst.txt")
             False
             >>> _ = interface.get_file("/file.txt", "dst.txt")
@@ -368,6 +385,9 @@ class Unversioned(Base):
             >>> interface = Unversioned(backend)
 
         Examples:
+            >>> file = "src.txt"
+            >>> interface.put_file(file, "/file.txt")
+            >>> interface.put_archive(".", "/sub/archive.zip", files=[file])
             >>> interface.ls()
             ['/file.txt', '/sub/archive.zip']
             >>> interface.ls("/file.txt")
@@ -432,6 +452,8 @@ class Unversioned(Base):
             >>> interface = Unversioned(backend)
 
         Examples:
+            >>> file = "src.txt"
+            >>> interface.put_file(file, "/file.txt")
             >>> interface.exists("/move.txt")
             False
             >>> interface.move_file("/file.txt", "/move.txt")
@@ -439,7 +461,6 @@ class Unversioned(Base):
             True
             >>> interface.exists("/file.txt")
             False
-            >>> interface.move_file("/move.txt", "/file.txt")
 
         """
         self.backend.move_file(
@@ -476,6 +497,8 @@ class Unversioned(Base):
             >>> interface = Unversioned(backend)
 
         Examples:
+            >>> file = "src.txt"
+            >>> interface.put_file(file, "/file.txt")
             >>> interface.owner("/file.txt")
             'doctest'
 
@@ -542,6 +565,7 @@ class Unversioned(Base):
             >>> interface = Unversioned(backend)
 
         Examples:
+            >>> file = "src.txt"
             >>> interface.exists("/sub/archive.tar.gz")
             False
             >>> interface.put_archive(".", "/sub/archive.tar.gz")
@@ -600,6 +624,7 @@ class Unversioned(Base):
             >>> interface = Unversioned(backend)
 
         Examples:
+            >>> file = "src.txt"
             >>> interface.exists("/sub/file.txt")
             False
             >>> interface.put_file("src.txt", "/sub/file.txt")
@@ -634,6 +659,8 @@ class Unversioned(Base):
             >>> interface = Unversioned(backend)
 
         Examples:
+            >>> file = "src.txt"
+            >>> interface.put_file(file, "/file.txt")
             >>> interface.exists("/file.txt")
             True
             >>> interface.remove_file("/file.txt")

--- a/audbackend/core/interface/unversioned.py
+++ b/audbackend/core/interface/unversioned.py
@@ -22,7 +22,7 @@ class Unversioned(Base):
         >>> interface.ls()
         ['/file.txt', '/sub/archive.zip']
         >>> interface.get_file("/file.txt", "dst.txt")
-        '.../dst.txt'
+        '...dst.txt'
 
     """
 

--- a/audbackend/core/interface/unversioned.py
+++ b/audbackend/core/interface/unversioned.py
@@ -138,8 +138,8 @@ class Unversioned(Base):
             >>> interface = Unversioned(backend)
 
         Examples:
-              >>> interface.date("/file.txt")
-              '1991-02-20'
+            >>> interface.date("/file.txt")
+            '1991-02-20'
 
         """
         return self.backend.date(path)
@@ -476,8 +476,8 @@ class Unversioned(Base):
             >>> interface = Unversioned(backend)
 
         Examples:
-              >>> interface.owner("/file.txt")
-              'doctest'
+            >>> interface.owner("/file.txt")
+            'doctest'
 
         """
         return self.backend.owner(path)

--- a/audbackend/core/interface/unversioned.py
+++ b/audbackend/core/interface/unversioned.py
@@ -10,6 +10,20 @@ class Unversioned(Base):
     Use this interface if you don't care about versioning.
     For every backend path exactly one file exists on the backend.
 
+    Args:
+        backend: backend object
+
+    Examples:
+        >>> import audeer
+        >>> file = "src.pth"
+        >>> _ = audeer.touch(file)
+        >>> interface = Unversioned(FileSystem("host", "repo"))
+        >>> interface.put_archive(".", "/a.zip", files=[file])
+        >>> interface.put_file(file, "/a/b.ext")
+        >>> interface.put_file(file, "/f.ext")
+        >>> interface.ls()
+        ['/a.zip', '/a/b.ext', '/f.ext']
+
     """
 
     def checksum(
@@ -30,8 +44,11 @@ class Unversioned(Base):
             ValueError: if ``path`` does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
 
+        ..
+            >>> interface = Unversioned(FileSystem("host", "repo"))
+
         Examples:
-            >>> unversioned.checksum("/f.ext")
+            >>> interface.checksum("/f.ext")
             'd41d8cd98f00b204e9800998ecf8427e'
 
         """
@@ -74,12 +91,16 @@ class Unversioned(Base):
                 does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
 
+        ..
+            >>> interface = Unversioned(FileSystem("host", "repo"))
+
         Examples:
-            >>> unversioned.exists("/copy.ext")
+            >>> interface.exists("/copy.ext")
             False
-            >>> unversioned.copy_file("/f.ext", "/copy.ext")
-            >>> unversioned.exists("/copy.ext")
+            >>> interface.copy_file("/f.ext", "/copy.ext")
+            >>> interface.exists("/copy.ext")
             True
+            >>> interface.remove_file("/copy.ext")
 
         """
         self.backend.copy_file(
@@ -110,8 +131,11 @@ class Unversioned(Base):
             ValueError: if ``path`` does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
 
+        ..
+            >>> interface = Unversioned(FileSystem("host", "repo"))
+
         Examples:
-              >>> unversioned.date("/f.ext")
+              >>> interface.date("/f.ext")
               '1991-02-20'
 
         """
@@ -143,8 +167,11 @@ class Unversioned(Base):
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
 
+        ..
+            >>> interface = Unversioned(FileSystem("host", "repo"))
+
         Examples:
-            >>> unversioned.exists("/f.ext")
+            >>> interface.exists("/f.ext")
             True
 
         """
@@ -203,8 +230,11 @@ class Unversioned(Base):
             ValueError: if ``src_path`` does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
 
+        ..
+            >>> interface = Unversioned(FileSystem("host", "repo"))
+
         Examples:
-            >>> unversioned.get_archive("/a.zip", ".")
+            >>> interface.get_archive("/a.zip", ".")
             ['src.pth']
 
         """
@@ -264,10 +294,13 @@ class Unversioned(Base):
             ValueError: if ``src_path`` does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
 
+        ..
+            >>> interface = Unversioned(FileSystem("host", "repo"))
+
         Examples:
             >>> os.path.exists("dst.pth")
             False
-            >>> _ = unversioned.get_file("/f.ext", "dst.pth")
+            >>> _ = interface.get_file("/f.ext", "dst.pth")
             >>> os.path.exists("dst.pth")
             True
 
@@ -324,16 +357,19 @@ class Unversioned(Base):
             ValueError: if ``path`` does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
 
+        ..
+            >>> interface = Unversioned(FileSystem("host", "repo"))
+
         Examples:
-            >>> unversioned.ls()
+            >>> interface.ls()
             ['/a.zip', '/a/b.ext', '/f.ext']
-            >>> unversioned.ls("/f.ext")
+            >>> interface.ls("/f.ext")
             ['/f.ext']
-            >>> unversioned.ls(pattern="*.ext")
+            >>> interface.ls(pattern="*.ext")
             ['/a/b.ext', '/f.ext']
-            >>> unversioned.ls(pattern="b.*")
+            >>> interface.ls(pattern="b.*")
             ['/a/b.ext']
-            >>> unversioned.ls("/a/")
+            >>> interface.ls("/a/")
             ['/a/b.ext']
 
         """  # noqa: E501
@@ -384,14 +420,18 @@ class Unversioned(Base):
                 does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
 
+        ..
+            >>> interface = Unversioned(FileSystem("host", "repo"))
+
         Examples:
-            >>> unversioned.exists("/move.ext")
+            >>> interface.exists("/move.ext")
             False
-            >>> unversioned.move_file("/f.ext", "/move.ext")
-            >>> unversioned.exists("/move.ext")
+            >>> interface.move_file("/f.ext", "/move.ext")
+            >>> interface.exists("/move.ext")
             True
-            >>> unversioned.exists("/f.ext")
+            >>> interface.exists("/f.ext")
             False
+            >>> interface.move_file("/move.ext", "/f.ext")
 
         """
         self.backend.move_file(
@@ -423,8 +463,11 @@ class Unversioned(Base):
             ValueError: if ``path`` does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
 
+        ..
+            >>> interface = Unversioned(FileSystem("host", "repo"))
+
         Examples:
-              >>> unversioned.owner("/f.ext")
+              >>> interface.owner("/f.ext")
               'doctest'
 
         """
@@ -485,11 +528,14 @@ class Unversioned(Base):
             ValueError: if ``dst_path`` does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
 
+        ..
+            >>> interface = Unversioned(FileSystem("host", "repo"))
+
         Examples:
-            >>> unversioned.exists("/a.tar.gz")
+            >>> interface.exists("/a.tar.gz")
             False
-            >>> unversioned.put_archive(".", "/a.tar.gz")
-            >>> unversioned.exists("/a.tar.gz")
+            >>> interface.put_archive(".", "/a.tar.gz")
+            >>> interface.exists("/a.tar.gz")
             True
 
         """
@@ -539,11 +585,14 @@ class Unversioned(Base):
             ValueError: if ``dst_path`` does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
 
+        ..
+            >>> interface = Unversioned(FileSystem("host", "repo"))
+
         Examples:
-            >>> unversioned.exists("/sub/f.ext")
+            >>> interface.exists("/sub/f.ext")
             False
-            >>> unversioned.put_file("src.pth", "/sub/f.ext")
-            >>> unversioned.exists("/sub/f.ext")
+            >>> interface.put_file("src.pth", "/sub/f.ext")
+            >>> interface.exists("/sub/f.ext")
             True
 
         """
@@ -569,11 +618,14 @@ class Unversioned(Base):
             ValueError: if ``path`` does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
 
+        ..
+            >>> interface = Unversioned(FileSystem("host", "repo"))
+
         Examples:
-            >>> unversioned.exists("/f.ext")
+            >>> interface.exists("/f.ext")
             True
-            >>> unversioned.remove_file("/f.ext")
-            >>> unversioned.exists("/f.ext")
+            >>> interface.remove_file("/f.ext")
+            >>> interface.exists("/f.ext")
             False
 
         """

--- a/audbackend/core/interface/unversioned.py
+++ b/audbackend/core/interface/unversioned.py
@@ -15,15 +15,14 @@ class Unversioned(Base):
 
     Examples:
         >>> import audeer
-        >>> file = "src.pth"
+        >>> file = "src.txt"
         >>> _ = audeer.touch(file)
         >>> backend = audbackend.backend.FileSystem("host", "repo")
         >>> interface = Unversioned(backend)
-        >>> interface.put_archive(".", "/a.zip", files=[file])
-        >>> interface.put_file(file, "/a/b.ext")
-        >>> interface.put_file(file, "/f.ext")
+        >>> interface.put_file(file, "/file.txt")
+        >>> interface.put_archive(".", "/sub/archive.zip", files=[file])
         >>> interface.ls()
-        ['/a.zip', '/a/b.ext', '/f.ext']
+        ['/file.txt', '/sub/archive.zip']
 
     """
 
@@ -50,7 +49,7 @@ class Unversioned(Base):
             >>> interface = Unversioned(backend)
 
         Examples:
-            >>> interface.checksum("/f.ext")
+            >>> interface.checksum("/file.txt")
             'd41d8cd98f00b204e9800998ecf8427e'
 
         """
@@ -98,12 +97,12 @@ class Unversioned(Base):
             >>> interface = Unversioned(backend)
 
         Examples:
-            >>> interface.exists("/copy.ext")
+            >>> interface.exists("/copy.txt")
             False
-            >>> interface.copy_file("/f.ext", "/copy.ext")
-            >>> interface.exists("/copy.ext")
+            >>> interface.copy_file("/file.txt", "/copy.txt")
+            >>> interface.exists("/copy.txt")
             True
-            >>> interface.remove_file("/copy.ext")
+            >>> interface.remove_file("/copy.txt")
 
         """
         self.backend.copy_file(
@@ -139,7 +138,7 @@ class Unversioned(Base):
             >>> interface = Unversioned(backend)
 
         Examples:
-              >>> interface.date("/f.ext")
+              >>> interface.date("/copy.txt")
               '1991-02-20'
 
         """
@@ -176,7 +175,7 @@ class Unversioned(Base):
             >>> interface = Unversioned(backend)
 
         Examples:
-            >>> interface.exists("/f.ext")
+            >>> interface.exists("/file.txt")
             True
 
         """
@@ -240,8 +239,8 @@ class Unversioned(Base):
             >>> interface = Unversioned(backend)
 
         Examples:
-            >>> interface.get_archive("/a.zip", ".")
-            ['src.pth']
+            >>> interface.get_archive("/sub/archive.zip", ".")
+            ['src.txt']
 
         """
         return self.backend.get_archive(
@@ -305,10 +304,10 @@ class Unversioned(Base):
             >>> interface = Unversioned(backend)
 
         Examples:
-            >>> os.path.exists("dst.pth")
+            >>> os.path.exists("dst.txt")
             False
-            >>> _ = interface.get_file("/f.ext", "dst.pth")
-            >>> os.path.exists("dst.pth")
+            >>> _ = interface.get_file("/file.txt", "dst.txt")
+            >>> os.path.exists("dst.txt")
             True
 
         """
@@ -370,15 +369,15 @@ class Unversioned(Base):
 
         Examples:
             >>> interface.ls()
-            ['/a.zip', '/a/b.ext', '/f.ext']
-            >>> interface.ls("/f.ext")
-            ['/f.ext']
-            >>> interface.ls(pattern="*.ext")
-            ['/a/b.ext', '/f.ext']
-            >>> interface.ls(pattern="b.*")
-            ['/a/b.ext']
-            >>> interface.ls("/a/")
-            ['/a/b.ext']
+            ['/file.txt', '/sub/archive.zip']
+            >>> interface.ls("/file.txt")
+            ['/file.txt']
+            >>> interface.ls(pattern="*.txt")
+            ['/file.txt']
+            >>> interface.ls(pattern="archive.*")
+            ['/sub/archive.zip']
+            >>> interface.ls("/sub/")
+            ['/sub/archive.zip']
 
         """  # noqa: E501
         return self.backend.ls(
@@ -433,14 +432,14 @@ class Unversioned(Base):
             >>> interface = Unversioned(backend)
 
         Examples:
-            >>> interface.exists("/move.ext")
+            >>> interface.exists("/move.txt")
             False
-            >>> interface.move_file("/f.ext", "/move.ext")
-            >>> interface.exists("/move.ext")
+            >>> interface.move_file("/file.txt", "/move.txt")
+            >>> interface.exists("/move.txt")
             True
-            >>> interface.exists("/f.ext")
+            >>> interface.exists("/file.txt")
             False
-            >>> interface.move_file("/move.ext", "/f.ext")
+            >>> interface.move_file("/move.txt", "/file.txt")
 
         """
         self.backend.move_file(
@@ -477,7 +476,7 @@ class Unversioned(Base):
             >>> interface = Unversioned(backend)
 
         Examples:
-              >>> interface.owner("/f.ext")
+              >>> interface.owner("/file.txt")
               'doctest'
 
         """
@@ -543,10 +542,10 @@ class Unversioned(Base):
             >>> interface = Unversioned(backend)
 
         Examples:
-            >>> interface.exists("/a.tar.gz")
+            >>> interface.exists("/sub/archive.tar.gz")
             False
-            >>> interface.put_archive(".", "/a.tar.gz")
-            >>> interface.exists("/a.tar.gz")
+            >>> interface.put_archive(".", "/sub/archive.tar.gz")
+            >>> interface.exists("/sub/archive.tar.gz")
             True
 
         """
@@ -601,10 +600,10 @@ class Unversioned(Base):
             >>> interface = Unversioned(backend)
 
         Examples:
-            >>> interface.exists("/sub/f.ext")
+            >>> interface.exists("/sub/file.txt")
             False
-            >>> interface.put_file("src.pth", "/sub/f.ext")
-            >>> interface.exists("/sub/f.ext")
+            >>> interface.put_file("src.txt", "/sub/file.txt")
+            >>> interface.exists("/sub/file.txt")
             True
 
         """
@@ -635,10 +634,10 @@ class Unversioned(Base):
             >>> interface = Unversioned(backend)
 
         Examples:
-            >>> interface.exists("/f.ext")
+            >>> interface.exists("/file.txt")
             True
-            >>> interface.remove_file("/f.ext")
-            >>> interface.exists("/f.ext")
+            >>> interface.remove_file("/file.txt")
+            >>> interface.exists("/file.txt")
             False
 
         """

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -25,7 +25,8 @@ class Versioned(Base):
         >>> import audeer
         >>> file = "src.pth"
         >>> _ = audeer.touch(file)
-        >>> interface = Versioned(FileSystem("host", "repo"))
+        >>> backend = audbackend.backend.FileSystem("host", "repo")
+        >>> interface = Versioned(backend)
         >>> interface.put_archive(".", "/a.zip", "1.0.0", files=[file])
         >>> interface.put_file(file, "/a/b.ext", "1.0.0")
         >>> for version in ["1.0.0", "2.0.0"]:
@@ -64,7 +65,8 @@ class Versioned(Base):
                 does not match ``'[A-Za-z0-9._-]+'``
 
         ..
-            >>> interface = Versioned(FileSystem("host", "repo"))
+            >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> interface = Versioned(backend)
 
         Examples:
             >>> interface.checksum("/f.ext", "1.0.0")
@@ -120,7 +122,8 @@ class Versioned(Base):
                 does not match ``'[A-Za-z0-9._-]+'``
 
         ..
-            >>> interface = Versioned(FileSystem("host", "repo"))
+            >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> interface = Versioned(backend)
 
         Examples:
             >>> interface.exists("/copy.ext", "1.0.0")
@@ -172,7 +175,8 @@ class Versioned(Base):
                 does not match ``'[A-Za-z0-9._-]+'``
 
         ..
-            >>> interface = Versioned(FileSystem("host", "repo"))
+            >>> backend = DoctestFileSystem("host", "repo")
+            >>> interface = Versioned(backend)
 
         Examples:
               >>> interface.date("/f.ext", "1.0.0")
@@ -211,7 +215,8 @@ class Versioned(Base):
                 does not match ``'[A-Za-z0-9._-]+'``
 
         ..
-            >>> interface = Versioned(FileSystem("host", "repo"))
+            >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> interface = Versioned(backend)
 
         Examples:
             >>> interface.exists("/f.ext", "1.0.0")
@@ -279,7 +284,8 @@ class Versioned(Base):
                 does not match ``'[A-Za-z0-9._-]+'``
 
         ..
-            >>> interface = Versioned(FileSystem("host", "repo"))
+            >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> interface = Versioned(backend)
 
         Examples:
             >>> interface.get_archive("/a.zip", ".", "1.0.0")
@@ -348,7 +354,8 @@ class Versioned(Base):
                 does not match ``'[A-Za-z0-9._-]+'``
 
         ..
-            >>> interface = Versioned(FileSystem("host", "repo"))
+            >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> interface = Versioned(backend)
 
         Examples:
             >>> os.path.exists("dst.pth")
@@ -385,7 +392,8 @@ class Versioned(Base):
                 does not match ``'[A-Za-z0-9/._-]+'``
 
          ..
-            >>> interface = Versioned(FileSystem("host", "repo"))
+            >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> interface = Versioned(backend)
 
         Examples:
             >>> interface.latest_version("/f.ext")
@@ -444,7 +452,8 @@ class Versioned(Base):
                 does not match ``'[A-Za-z0-9/._-]+'``
 
         ..
-            >>> interface = Versioned(FileSystem("host", "repo"))
+            >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> interface = Versioned(backend)
 
         Examples:
             >>> interface.ls()
@@ -578,7 +587,8 @@ class Versioned(Base):
                 does not match ``'[A-Za-z0-9._-]+'``
 
         ..
-            >>> interface = Versioned(FileSystem("host", "repo"))
+            >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> interface = Versioned(backend)
 
         Examples:
             >>> interface.exists("/move.ext", "1.0.0")
@@ -633,7 +643,8 @@ class Versioned(Base):
                 does not match ``'[A-Za-z0-9._-]+'``
 
         ..
-            >>> interface = Versioned(FileSystem("host", "repo"))
+            >>> backend = DoctestFileSystem("host", "repo")
+            >>> interface = Versioned(backend)
 
         Examples:
               >>> interface.owner("/f.ext", "1.0.0")
@@ -703,7 +714,8 @@ class Versioned(Base):
                 does not match ``'[A-Za-z0-9._-]+'``
 
         ..
-            >>> interface = Versioned(FileSystem("host", "repo"))
+            >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> interface = Versioned(backend)
 
         Examples:
             >>> interface.exists("/a.tar.gz", "1.0.0")
@@ -768,7 +780,8 @@ class Versioned(Base):
                 does not match ``'[A-Za-z0-9._-]+'``
 
         ..
-            >>> interface = Versioned(FileSystem("host", "repo"))
+            >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> interface = Versioned(backend)
 
         Examples:
             >>> interface.exists("/sub/f.ext", "3.0.0")
@@ -806,7 +819,8 @@ class Versioned(Base):
                 does not match ``'[A-Za-z0-9._-]+'``
 
         ..
-            >>> interface = Versioned(FileSystem("host", "repo"))
+            >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> interface = Versioned(backend)
 
         Examples:
             >>> interface.exists("/f.ext", "1.0.0")
@@ -845,7 +859,8 @@ class Versioned(Base):
                 does not match ``'[A-Za-z0-9/._-]+'``
 
         ..
-            >>> interface = Versioned(FileSystem("host", "repo"))
+            >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> interface = Versioned(backend)
 
         Examples:
             >>> interface.versions("/f.ext")

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -22,9 +22,7 @@ class Versioned(Base):
     .. Prepare backend and interface for docstring examples
 
     Examples:
-        >>> import audeer
         >>> file = "src.txt"
-        >>> _ = audeer.touch(file)
         >>> backend = audbackend.backend.FileSystem("host", "repo")
         >>> interface = Versioned(backend)
         >>> interface.put_archive(".", "/sub/archive.zip", "1.0.0", files=[file])
@@ -32,6 +30,9 @@ class Versioned(Base):
         ...     interface.put_file(file, "/file.txt", version)
         >>> interface.ls()
         [('/file.txt', '1.0.0'), ('/file.txt', '2.0.0'), ('/sub/archive.zip', '1.0.0')]
+        >>> interface.get_file("/file.txt", "dst.txt", "2.0.0")
+        '.../dst.txt'
+
 
     """
 
@@ -68,6 +69,11 @@ class Versioned(Base):
             >>> interface = Versioned(backend)
 
         Examples:
+            >>> file = "src.txt"
+            >>> import audeer
+            >>> audeer.md5(file)
+            'd41d8cd98f00b204e9800998ecf8427e'
+            >>> interface.put_file(file, "/file.txt", "1.0.0")
             >>> interface.checksum("/file.txt", "1.0.0")
             'd41d8cd98f00b204e9800998ecf8427e'
 
@@ -125,12 +131,13 @@ class Versioned(Base):
             >>> interface = Versioned(backend)
 
         Examples:
+            >>> file = "src.txt"
+            >>> interface.put_file(file, "/file.txt", "1.0.0")
             >>> interface.exists("/copy.txt", "1.0.0")
             False
             >>> interface.copy_file("/file.txt", "/copy.txt", version="1.0.0")
             >>> interface.exists("/copy.txt", "1.0.0")
             True
-            >>> interface.remove_file("/copy.txt", "1.0.0")
 
         """
         if version is None:
@@ -178,6 +185,8 @@ class Versioned(Base):
             >>> interface = Versioned(backend)
 
         Examples:
+            >>> file = "src.txt"
+            >>> interface.put_file(file, "/file.txt", "1.0.0")
             >>> interface.date("/file.txt", "1.0.0")
             '1991-02-20'
 
@@ -218,6 +227,10 @@ class Versioned(Base):
             >>> interface = Versioned(backend)
 
         Examples:
+            >>> file = "src.txt"
+            >>> interface.exists("/file.txt", "1.0.0")
+            False
+            >>> interface.put_file(file, "/file.txt", "1.0.0")
             >>> interface.exists("/file.txt", "1.0.0")
             True
 
@@ -287,6 +300,9 @@ class Versioned(Base):
             >>> interface = Versioned(backend)
 
         Examples:
+            >>> file = "src.txt"
+            >>> interface.put_archive(".", "/sub/archive.zip", "1.0.0", files=[file])
+            >>> os.remove(file)
             >>> interface.get_archive("/sub/archive.zip", ".", "1.0.0")
             ['src.txt']
 
@@ -357,6 +373,8 @@ class Versioned(Base):
             >>> interface = Versioned(backend)
 
         Examples:
+            >>> file = "src.txt"
+            >>> interface.put_file(file, "/file.txt", "1.0.0")
             >>> os.path.exists("dst.txt")
             False
             >>> _ = interface.get_file("/file.txt", "dst.txt", "1.0.0")
@@ -395,6 +413,9 @@ class Versioned(Base):
             >>> interface = Versioned(backend)
 
         Examples:
+            >>> file = "src.txt"
+            >>> interface.put_file(file, "/file.txt", "1.0.0")
+            >>> interface.put_file(file, "/file.txt", "2.0.0")
             >>> interface.latest_version("/file.txt")
             '2.0.0'
 
@@ -455,6 +476,10 @@ class Versioned(Base):
             >>> interface = Versioned(backend)
 
         Examples:
+            >>> file = "src.txt"
+            >>> interface.put_file(file, "/file.txt", "1.0.0")
+            >>> interface.put_file(file, "/file.txt", "2.0.0")
+            >>> interface.put_archive(".", "/sub/archive.zip", "1.0.0", files=[file])
             >>> interface.ls()
             [('/file.txt', '1.0.0'), ('/file.txt', '2.0.0'), ('/sub/archive.zip', '1.0.0')]
             >>> interface.ls(latest_version=True)
@@ -590,6 +615,8 @@ class Versioned(Base):
             >>> interface = Versioned(backend)
 
         Examples:
+            >>> file = "src.txt"
+            >>> interface.put_file(file, "/file.txt", "1.0.0")
             >>> interface.exists("/move.txt", "1.0.0")
             False
             >>> interface.move_file("/file.txt", "/move.txt", version="1.0.0")
@@ -597,7 +624,6 @@ class Versioned(Base):
             True
             >>> interface.exists("/file.txt", "1.0.0")
             False
-            >>> interface.move_file("/move.txt", "/file.txt", version="1.0.0")
 
         """
         if version is None:
@@ -646,6 +672,8 @@ class Versioned(Base):
             >>> interface = Versioned(backend)
 
         Examples:
+            >>> file = "src.txt"
+            >>> interface.put_file(file, "/file.txt", "1.0.0")
             >>> interface.owner("/file.txt", "1.0.0")
             'doctest'
 
@@ -717,6 +745,7 @@ class Versioned(Base):
             >>> interface = Versioned(backend)
 
         Examples:
+            >>> file = "src.txt"
             >>> interface.exists("/sub/archive.tar.gz", "1.0.0")
             False
             >>> interface.put_archive(".", "/sub/archive.tar.gz", "1.0.0")
@@ -783,10 +812,11 @@ class Versioned(Base):
             >>> interface = Versioned(backend)
 
         Examples:
-            >>> interface.exists("/sub/file.txt", "3.0.0")
+            >>> file = "src.txt"
+            >>> interface.exists("/file.txt", "3.0.0")
             False
-            >>> interface.put_file("src.txt", "/sub/file.txt", "3.0.0")
-            >>> interface.exists("/sub/file.txt", "3.0.0")
+            >>> interface.put_file(file, "/file.txt", "3.0.0")
+            >>> interface.exists("/file.txt", "3.0.0")
             True
 
         """
@@ -822,12 +852,13 @@ class Versioned(Base):
             >>> interface = Versioned(backend)
 
         Examples:
+            >>> file = "src.txt"
+            >>> interface.put_file(file, "/file.txt", "1.0.0")
             >>> interface.exists("/file.txt", "1.0.0")
             True
             >>> interface.remove_file("/file.txt", "1.0.0")
             >>> interface.exists("/file.txt", "1.0.0")
             False
-            >>> interface.put_file("src.txt", "/file.txt", "1.0.0")
 
         """
         path_with_version = self._path_with_version(path, version)
@@ -862,6 +893,9 @@ class Versioned(Base):
             >>> interface = Versioned(backend)
 
         Examples:
+            >>> file = "src.txt"
+            >>> interface.put_file(file, "/file.txt", "1.0.0")
+            >>> interface.put_file(file, "/file.txt", "2.0.0")
             >>> interface.versions("/file.txt")
             ['1.0.0', '2.0.0']
 

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -23,18 +23,17 @@ class Versioned(Base):
 
     Examples:
         >>> import audeer
-        >>> file = "src.pth"
+        >>> file = "src.txt"
         >>> _ = audeer.touch(file)
         >>> backend = audbackend.backend.FileSystem("host", "repo")
         >>> interface = Versioned(backend)
-        >>> interface.put_archive(".", "/a.zip", "1.0.0", files=[file])
-        >>> interface.put_file(file, "/a/b.ext", "1.0.0")
+        >>> interface.put_archive(".", "/sub/archive.zip", "1.0.0", files=[file])
         >>> for version in ["1.0.0", "2.0.0"]:
-        ...     interface.put_file(file, "/f.ext", version)
+        ...     interface.put_file(file, "/file.txt", version)
         >>> interface.ls()
-        [('/a.zip', '1.0.0'), ('/a/b.ext', '1.0.0'), ('/f.ext', '1.0.0'), ('/f.ext', '2.0.0')]
+        [('/file.txt', '1.0.0'), ('/file.txt', '2.0.0'), ('/sub/archive.zip', '1.0.0')]
 
-    """  # noqa: E501
+    """
 
     def __init__(
         self,
@@ -69,7 +68,7 @@ class Versioned(Base):
             >>> interface = Versioned(backend)
 
         Examples:
-            >>> interface.checksum("/f.ext", "1.0.0")
+            >>> interface.checksum("/file.txt", "1.0.0")
             'd41d8cd98f00b204e9800998ecf8427e'
 
         """
@@ -126,12 +125,12 @@ class Versioned(Base):
             >>> interface = Versioned(backend)
 
         Examples:
-            >>> interface.exists("/copy.ext", "1.0.0")
+            >>> interface.exists("/copy.txt", "1.0.0")
             False
-            >>> interface.copy_file("/f.ext", "/copy.ext", version="1.0.0")
-            >>> interface.exists("/copy.ext", "1.0.0")
+            >>> interface.copy_file("/file.txt", "/copy.txt", version="1.0.0")
+            >>> interface.exists("/copy.txt", "1.0.0")
             True
-            >>> interface.remove_file("/copy.ext", "1.0.0")
+            >>> interface.remove_file("/copy.txt", "1.0.0")
 
         """
         if version is None:
@@ -179,7 +178,7 @@ class Versioned(Base):
             >>> interface = Versioned(backend)
 
         Examples:
-              >>> interface.date("/f.ext", "1.0.0")
+              >>> interface.date("/file.txt", "1.0.0")
               '1991-02-20'
 
         """
@@ -219,7 +218,7 @@ class Versioned(Base):
             >>> interface = Versioned(backend)
 
         Examples:
-            >>> interface.exists("/f.ext", "1.0.0")
+            >>> interface.exists("/file.txt", "1.0.0")
             True
 
         """
@@ -288,8 +287,8 @@ class Versioned(Base):
             >>> interface = Versioned(backend)
 
         Examples:
-            >>> interface.get_archive("/a.zip", ".", "1.0.0")
-            ['src.pth']
+            >>> interface.get_archive("/sub/archive.zip", ".", "1.0.0")
+            ['src.txt']
 
         """
         src_path_with_version = self._path_with_version(src_path, version)
@@ -358,10 +357,10 @@ class Versioned(Base):
             >>> interface = Versioned(backend)
 
         Examples:
-            >>> os.path.exists("dst.pth")
+            >>> os.path.exists("dst.txt")
             False
-            >>> _ = interface.get_file("/f.ext", "dst.pth", "1.0.0")
-            >>> os.path.exists("dst.pth")
+            >>> _ = interface.get_file("/file.txt", "dst.txt", "1.0.0")
+            >>> os.path.exists("dst.txt")
             True
 
         """
@@ -396,7 +395,7 @@ class Versioned(Base):
             >>> interface = Versioned(backend)
 
         Examples:
-            >>> interface.latest_version("/f.ext")
+            >>> interface.latest_version("/file.txt")
             '2.0.0'
 
         """
@@ -457,17 +456,17 @@ class Versioned(Base):
 
         Examples:
             >>> interface.ls()
-            [('/a.zip', '1.0.0'), ('/a/b.ext', '1.0.0'), ('/f.ext', '1.0.0'), ('/f.ext', '2.0.0')]
+            [('/file.txt', '1.0.0'), ('/file.txt', '2.0.0'), ('/sub/archive.zip', '1.0.0')]
             >>> interface.ls(latest_version=True)
-            [('/a.zip', '1.0.0'), ('/a/b.ext', '1.0.0'), ('/f.ext', '2.0.0')]
-            >>> interface.ls("/f.ext")
-            [('/f.ext', '1.0.0'), ('/f.ext', '2.0.0')]
-            >>> interface.ls(pattern="*.ext")
-            [('/a/b.ext', '1.0.0'), ('/f.ext', '1.0.0'), ('/f.ext', '2.0.0')]
-            >>> interface.ls(pattern="b.*")
-            [('/a/b.ext', '1.0.0')]
-            >>> interface.ls("/a/")
-            [('/a/b.ext', '1.0.0')]
+            [('/file.txt', '2.0.0'), ('/sub/archive.zip', '1.0.0')]
+            >>> interface.ls("/file.txt")
+            [('/file.txt', '1.0.0'), ('/file.txt', '2.0.0')]
+            >>> interface.ls(pattern="*.txt")
+            [('/file.txt', '1.0.0'), ('/file.txt', '2.0.0')]
+            >>> interface.ls(pattern="archive.*")
+            [('/sub/archive.zip', '1.0.0')]
+            >>> interface.ls("/sub/")
+            [('/sub/archive.zip', '1.0.0')]
 
         """  # noqa: E501
         if path.endswith("/"):  # find files under sub-path
@@ -591,14 +590,14 @@ class Versioned(Base):
             >>> interface = Versioned(backend)
 
         Examples:
-            >>> interface.exists("/move.ext", "1.0.0")
+            >>> interface.exists("/move.txt", "1.0.0")
             False
-            >>> interface.move_file("/f.ext", "/move.ext", version="1.0.0")
-            >>> interface.exists("/move.ext", "1.0.0")
+            >>> interface.move_file("/file.txt", "/move.txt", version="1.0.0")
+            >>> interface.exists("/move.txt", "1.0.0")
             True
-            >>> interface.exists("/f.ext", "1.0.0")
+            >>> interface.exists("/file.txt", "1.0.0")
             False
-            >>> interface.move_file("/move.ext", "/f.ext", version="1.0.0")
+            >>> interface.move_file("/move.txt", "/file.txt", version="1.0.0")
 
         """
         if version is None:
@@ -647,7 +646,7 @@ class Versioned(Base):
             >>> interface = Versioned(backend)
 
         Examples:
-              >>> interface.owner("/f.ext", "1.0.0")
+              >>> interface.owner("/file.txt", "1.0.0")
               'doctest'
 
         """
@@ -718,10 +717,10 @@ class Versioned(Base):
             >>> interface = Versioned(backend)
 
         Examples:
-            >>> interface.exists("/a.tar.gz", "1.0.0")
+            >>> interface.exists("/sub/archive.tar.gz", "1.0.0")
             False
-            >>> interface.put_archive(".", "/a.tar.gz", "1.0.0")
-            >>> interface.exists("/a.tar.gz", "1.0.0")
+            >>> interface.put_archive(".", "/sub/archive.tar.gz", "1.0.0")
+            >>> interface.exists("/sub/archive.tar.gz", "1.0.0")
             True
 
         """
@@ -784,10 +783,10 @@ class Versioned(Base):
             >>> interface = Versioned(backend)
 
         Examples:
-            >>> interface.exists("/sub/f.ext", "3.0.0")
+            >>> interface.exists("/sub/file.txt", "3.0.0")
             False
-            >>> interface.put_file("src.pth", "/sub/f.ext", "3.0.0")
-            >>> interface.exists("/sub/f.ext", "3.0.0")
+            >>> interface.put_file("src.txt", "/sub/file.txt", "3.0.0")
+            >>> interface.exists("/sub/file.txt", "3.0.0")
             True
 
         """
@@ -823,12 +822,12 @@ class Versioned(Base):
             >>> interface = Versioned(backend)
 
         Examples:
-            >>> interface.exists("/f.ext", "1.0.0")
+            >>> interface.exists("/file.txt", "1.0.0")
             True
-            >>> interface.remove_file("/f.ext", "1.0.0")
-            >>> interface.exists("/f.ext", "1.0.0")
+            >>> interface.remove_file("/file.txt", "1.0.0")
+            >>> interface.exists("/file.txt", "1.0.0")
             False
-            >>> interface.put_file("src.pth", "/f.ext", "1.0.0")
+            >>> interface.put_file("src.txt", "/file.txt", "1.0.0")
 
         """
         path_with_version = self._path_with_version(path, version)
@@ -863,7 +862,7 @@ class Versioned(Base):
             >>> interface = Versioned(backend)
 
         Examples:
-            >>> interface.versions("/f.ext")
+            >>> interface.versions("/file.txt")
             ['1.0.0', '2.0.0']
 
         """

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -31,7 +31,7 @@ class Versioned(Base):
         >>> interface.ls()
         [('/file.txt', '1.0.0'), ('/file.txt', '2.0.0'), ('/sub/archive.zip', '1.0.0')]
         >>> interface.get_file("/file.txt", "dst.txt", "2.0.0")
-        '.../dst.txt'
+        '...dst.txt'
 
 
     """

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -178,8 +178,8 @@ class Versioned(Base):
             >>> interface = Versioned(backend)
 
         Examples:
-              >>> interface.date("/file.txt", "1.0.0")
-              '1991-02-20'
+            >>> interface.date("/file.txt", "1.0.0")
+            '1991-02-20'
 
         """
         path_with_version = self._path_with_version(path, version)
@@ -646,8 +646,8 @@ class Versioned(Base):
             >>> interface = Versioned(backend)
 
         Examples:
-              >>> interface.owner("/file.txt", "1.0.0")
-              'doctest'
+            >>> interface.owner("/file.txt", "1.0.0")
+            'doctest'
 
         """
         path_with_version = self._path_with_version(path, version)

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -16,7 +16,24 @@ class Versioned(Base):
     Use this interface if you care about versioning.
     For each file on the backend path one or more versions may exist.
 
-    """
+    Args:
+        backend: backend object
+
+    .. Prepare backend and interface for docstring examples
+
+    Examples:
+        >>> import audeer
+        >>> file = "src.pth"
+        >>> _ = audeer.touch(file)
+        >>> interface = Versioned(FileSystem("host", "repo"))
+        >>> interface.put_archive(".", "/a.zip", "1.0.0", files=[file])
+        >>> interface.put_file(file, "/a/b.ext", "1.0.0")
+        >>> for version in ["1.0.0", "2.0.0"]:
+        ...     interface.put_file(file, "/f.ext", version)
+        >>> interface.ls()
+        [('/a.zip', '1.0.0'), ('/a/b.ext', '1.0.0'), ('/f.ext', '1.0.0'), ('/f.ext', '2.0.0')]
+
+    """  # noqa: E501
 
     def __init__(
         self,
@@ -46,8 +63,11 @@ class Versioned(Base):
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
 
+        ..
+            >>> interface = Versioned(FileSystem("host", "repo"))
+
         Examples:
-            >>> versioned.checksum("/f.ext", "1.0.0")
+            >>> interface.checksum("/f.ext", "1.0.0")
             'd41d8cd98f00b204e9800998ecf8427e'
 
         """
@@ -90,13 +110,6 @@ class Versioned(Base):
             version: version string
             verbose: show debug messages
 
-        Examples:
-            >>> versioned.exists("/copy.ext", "1.0.0")
-            False
-            >>> versioned.copy_file("/f.ext", "/copy.ext", version="1.0.0")
-            >>> versioned.exists("/copy.ext", "1.0.0")
-            True
-
         Raises:
             BackendError: if an error is raised on the backend
             InterruptedError: if validation fails
@@ -105,6 +118,17 @@ class Versioned(Base):
                 does not match ``'[A-Za-z0-9/._-]+'``
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
+
+        ..
+            >>> interface = Versioned(FileSystem("host", "repo"))
+
+        Examples:
+            >>> interface.exists("/copy.ext", "1.0.0")
+            False
+            >>> interface.copy_file("/f.ext", "/copy.ext", version="1.0.0")
+            >>> interface.exists("/copy.ext", "1.0.0")
+            True
+            >>> interface.remove_file("/copy.ext", "1.0.0")
 
         """
         if version is None:
@@ -147,8 +171,11 @@ class Versioned(Base):
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
 
+        ..
+            >>> interface = Versioned(FileSystem("host", "repo"))
+
         Examples:
-              >>> versioned.date("/f.ext", "1.0.0")
+              >>> interface.date("/f.ext", "1.0.0")
               '1991-02-20'
 
         """
@@ -183,8 +210,11 @@ class Versioned(Base):
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
 
+        ..
+            >>> interface = Versioned(FileSystem("host", "repo"))
+
         Examples:
-            >>> versioned.exists("/f.ext", "1.0.0")
+            >>> interface.exists("/f.ext", "1.0.0")
             True
 
         """
@@ -248,8 +278,11 @@ class Versioned(Base):
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
 
+        ..
+            >>> interface = Versioned(FileSystem("host", "repo"))
+
         Examples:
-            >>> versioned.get_archive("/a.zip", ".", "1.0.0")
+            >>> interface.get_archive("/a.zip", ".", "1.0.0")
             ['src.pth']
 
         """
@@ -314,10 +347,13 @@ class Versioned(Base):
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
 
+        ..
+            >>> interface = Versioned(FileSystem("host", "repo"))
+
         Examples:
             >>> os.path.exists("dst.pth")
             False
-            >>> _ = versioned.get_file("/f.ext", "dst.pth", "1.0.0")
+            >>> _ = interface.get_file("/f.ext", "dst.pth", "1.0.0")
             >>> os.path.exists("dst.pth")
             True
 
@@ -348,8 +384,11 @@ class Versioned(Base):
             ValueError: if ``path`` does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
 
+         ..
+            >>> interface = Versioned(FileSystem("host", "repo"))
+
         Examples:
-            >>> versioned.latest_version("/f.ext")
+            >>> interface.latest_version("/f.ext")
             '2.0.0'
 
         """
@@ -404,18 +443,21 @@ class Versioned(Base):
             ValueError: if ``path`` does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
 
+        ..
+            >>> interface = Versioned(FileSystem("host", "repo"))
+
         Examples:
-            >>> versioned.ls()
+            >>> interface.ls()
             [('/a.zip', '1.0.0'), ('/a/b.ext', '1.0.0'), ('/f.ext', '1.0.0'), ('/f.ext', '2.0.0')]
-            >>> versioned.ls(latest_version=True)
+            >>> interface.ls(latest_version=True)
             [('/a.zip', '1.0.0'), ('/a/b.ext', '1.0.0'), ('/f.ext', '2.0.0')]
-            >>> versioned.ls("/f.ext")
+            >>> interface.ls("/f.ext")
             [('/f.ext', '1.0.0'), ('/f.ext', '2.0.0')]
-            >>> versioned.ls(pattern="*.ext")
+            >>> interface.ls(pattern="*.ext")
             [('/a/b.ext', '1.0.0'), ('/f.ext', '1.0.0'), ('/f.ext', '2.0.0')]
-            >>> versioned.ls(pattern="b.*")
+            >>> interface.ls(pattern="b.*")
             [('/a/b.ext', '1.0.0')]
-            >>> versioned.ls("/a/")
+            >>> interface.ls("/a/")
             [('/a/b.ext', '1.0.0')]
 
         """  # noqa: E501
@@ -535,14 +577,18 @@ class Versioned(Base):
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
 
+        ..
+            >>> interface = Versioned(FileSystem("host", "repo"))
+
         Examples:
-            >>> versioned.exists("/move.ext", "1.0.0")
+            >>> interface.exists("/move.ext", "1.0.0")
             False
-            >>> versioned.move_file("/f.ext", "/move.ext", version="1.0.0")
-            >>> versioned.exists("/move.ext", "1.0.0")
+            >>> interface.move_file("/f.ext", "/move.ext", version="1.0.0")
+            >>> interface.exists("/move.ext", "1.0.0")
             True
-            >>> versioned.exists("/f.ext", "1.0.0")
+            >>> interface.exists("/f.ext", "1.0.0")
             False
+            >>> interface.move_file("/move.ext", "/f.ext", version="1.0.0")
 
         """
         if version is None:
@@ -586,8 +632,11 @@ class Versioned(Base):
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
 
+        ..
+            >>> interface = Versioned(FileSystem("host", "repo"))
+
         Examples:
-              >>> versioned.owner("/f.ext", "1.0.0")
+              >>> interface.owner("/f.ext", "1.0.0")
               'doctest'
 
         """
@@ -653,11 +702,14 @@ class Versioned(Base):
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
 
+        ..
+            >>> interface = Versioned(FileSystem("host", "repo"))
+
         Examples:
-            >>> versioned.exists("/a.tar.gz", "1.0.0")
+            >>> interface.exists("/a.tar.gz", "1.0.0")
             False
-            >>> versioned.put_archive(".", "/a.tar.gz", "1.0.0")
-            >>> versioned.exists("/a.tar.gz", "1.0.0")
+            >>> interface.put_archive(".", "/a.tar.gz", "1.0.0")
+            >>> interface.exists("/a.tar.gz", "1.0.0")
             True
 
         """
@@ -715,11 +767,14 @@ class Versioned(Base):
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
 
+        ..
+            >>> interface = Versioned(FileSystem("host", "repo"))
+
         Examples:
-            >>> versioned.exists("/sub/f.ext", "3.0.0")
+            >>> interface.exists("/sub/f.ext", "3.0.0")
             False
-            >>> versioned.put_file("src.pth", "/sub/f.ext", "3.0.0")
-            >>> versioned.exists("/sub/f.ext", "3.0.0")
+            >>> interface.put_file("src.pth", "/sub/f.ext", "3.0.0")
+            >>> interface.exists("/sub/f.ext", "3.0.0")
             True
 
         """
@@ -750,12 +805,16 @@ class Versioned(Base):
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
 
+        ..
+            >>> interface = Versioned(FileSystem("host", "repo"))
+
         Examples:
-            >>> versioned.exists("/f.ext", "1.0.0")
+            >>> interface.exists("/f.ext", "1.0.0")
             True
-            >>> versioned.remove_file("/f.ext", "1.0.0")
-            >>> versioned.exists("/f.ext", "1.0.0")
+            >>> interface.remove_file("/f.ext", "1.0.0")
+            >>> interface.exists("/f.ext", "1.0.0")
             False
+            >>> interface.put_file("src.pth", "/f.ext", "1.0.0")
 
         """
         path_with_version = self._path_with_version(path, version)
@@ -785,8 +844,11 @@ class Versioned(Base):
             ValueError: if ``path`` does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
 
+        ..
+            >>> interface = Versioned(FileSystem("host", "repo"))
+
         Examples:
-            >>> versioned.versions("/f.ext")
+            >>> interface.versions("/f.ext")
             ['1.0.0', '2.0.0']
 
         """


### PR DESCRIPTION
This pull request ensures that the docstring examples of all interfaces use always the word `interface` as variable name for an interface. Before,it could have been a mixture of `versioned`, `maven`, ..., depending which methods were inherited and which not  (as first discussed in https://github.com/audeering/audbackend/pull/194).

The examples for `audbackend.interface.Unversioned` now are:

![image](https://github.com/audeering/audbackend/assets/173624/f3cac314-9e0d-410e-ae7a-c6b46d2863a4)