### PR TITLE
Fix audbackend.interface.Maven.ls() on sub-path

### DIFF
--- a/audbackend/core/interface/maven.py
+++ b/audbackend/core/interface/maven.py
@@ -144,6 +144,15 @@ class Maven(Versioned):
                 path,
                 suppress_backend_errors=suppress_backend_errors,
             )
+            # Files are also stored as sub-folder,
+            # e.g. `/file/version/file-version.ext`,
+            # so we need to skip those
+            sub_paths = len(path.split("/")) - 2
+            if sub_paths > 0:
+                paths = [
+                    path for path in paths
+                    if len(path.split(self.sep)) > 3 + sub_paths
+                ]
 
         else:  # find versions of path
             root, file = self.split(path)

--- a/audbackend/core/interface/maven.py
+++ b/audbackend/core/interface/maven.py
@@ -150,8 +150,7 @@ class Maven(Versioned):
             sub_paths = len(path.split("/")) - 2
             if sub_paths > 0:
                 paths = [
-                    path for path in paths
-                    if len(path.split(self.sep)) > 3 + sub_paths
+                    path for path in paths if len(path.split(self.sep)) > 3 + sub_paths
                 ]
 
         else:  # find versions of path

--- a/tests/test_interface_maven.py
+++ b/tests/test_interface_maven.py
@@ -81,93 +81,256 @@ def test_errors(tmpdir, interface):
     ],
     indirect=True,
 )
-def test_ls(tmpdir, interface):
+@pytest.mark.parametrize(
+    "files",
+    [
+        [
+            ("/file.bar", "1.0.0"),
+            ("/file.bar", "2.0.0"),
+            ("/file.foo", "1.0.0"),
+            ("/sub/file.foo", "1.0.0"),
+            ("/sub/file.foo", "2.0.0"),
+            ("/sub/sub.ext", "1.0.0"),
+            ("/sub/sub/sub.ext", "1.0.0"),
+            ("/.sub/.file.foo", "1.0.0"),
+            ("/.sub/.file.foo", "2.0.0"),
+        ],
+    ],
+)
+@pytest.mark.parametrize(
+    "path, latest, pattern, expected",
+    [
+        (
+            "/",
+            False,
+            None,
+            [
+                ("/file.bar", "1.0.0"),
+                ("/file.bar", "2.0.0"),
+                ("/file.foo", "1.0.0"),
+                ("/sub/file.foo", "1.0.0"),
+                ("/sub/file.foo", "2.0.0"),
+                ("/sub/sub.ext", "1.0.0"),
+                ("/sub/sub/sub.ext", "1.0.0"),
+                ("/.sub/.file.foo", "1.0.0"),
+                ("/.sub/.file.foo", "2.0.0"),
+            ],
+        ),
+        (
+            "/",
+            True,
+            None,
+            [
+                ("/file.bar", "2.0.0"),
+                ("/file.foo", "1.0.0"),
+                ("/sub/file.foo", "2.0.0"),
+                ("/sub/sub.ext", "1.0.0"),
+                ("/sub/sub/sub.ext", "1.0.0"),
+                ("/.sub/.file.foo", "2.0.0"),
+            ],
+        ),
+        (
+            "/",
+            False,
+            "*.foo",
+            [
+                ("/file.foo", "1.0.0"),
+                ("/sub/file.foo", "1.0.0"),
+                ("/sub/file.foo", "2.0.0"),
+                ("/.sub/.file.foo", "1.0.0"),
+                ("/.sub/.file.foo", "2.0.0"),
+            ],
+        ),
+        (
+            "/",
+            True,
+            "*.foo",
+            [
+                ("/file.foo", "1.0.0"),
+                ("/sub/file.foo", "2.0.0"),
+                ("/.sub/.file.foo", "2.0.0"),
+            ],
+        ),
+        (
+            "/sub/",
+            False,
+            None,
+            [
+                ("/sub/file.foo", "1.0.0"),
+                ("/sub/file.foo", "2.0.0"),
+                ("/sub/sub.ext", "1.0.0"),
+                ("/sub/sub/sub.ext", "1.0.0"),
+            ],
+        ),
+        (
+            "/sub/",
+            True,
+            None,
+            [
+                ("/sub/file.foo", "2.0.0"),
+                ("/sub/sub.ext", "1.0.0"),
+                ("/sub/sub/sub.ext", "1.0.0"),
+            ],
+        ),
+        (
+            "/sub/",
+            False,
+            "*.bar",
+            [],
+        ),
+        (
+            "/sub/",
+            True,
+            "*.bar",
+            [],
+        ),
+        (
+            "/sub/",
+            False,
+            "file.*",
+            [
+                ("/sub/file.foo", "1.0.0"),
+                ("/sub/file.foo", "2.0.0"),
+            ],
+        ),
+        (
+            "/sub/",
+            True,
+            "file.*",
+            [
+                ("/sub/file.foo", "2.0.0"),
+            ],
+        ),
+        (
+            "/.sub/",
+            False,
+            None,
+            [
+                ("/.sub/.file.foo", "1.0.0"),
+                ("/.sub/.file.foo", "2.0.0"),
+            ],
+        ),
+        (
+            "/.sub/",
+            True,
+            None,
+            [
+                ("/.sub/.file.foo", "2.0.0"),
+            ],
+        ),
+        (
+            "/file.bar",
+            False,
+            None,
+            [
+                ("/file.bar", "1.0.0"),
+                ("/file.bar", "2.0.0"),
+            ],
+        ),
+        (
+            "/file.bar",
+            True,
+            None,
+            [
+                ("/file.bar", "2.0.0"),
+            ],
+        ),
+        (
+            "/sub/file.foo",
+            False,
+            None,
+            [
+                ("/sub/file.foo", "1.0.0"),
+                ("/sub/file.foo", "2.0.0"),
+            ],
+        ),
+        (
+            "/sub/file.foo",
+            True,
+            None,
+            [
+                ("/sub/file.foo", "2.0.0"),
+            ],
+        ),
+        (
+            "/sub/file.foo",
+            False,
+            "file.*",
+            [
+                ("/sub/file.foo", "1.0.0"),
+                ("/sub/file.foo", "2.0.0"),
+            ],
+        ),
+        (
+            "/sub/file.foo",
+            True,
+            "file.*",
+            [
+                ("/sub/file.foo", "2.0.0"),
+            ],
+        ),
+        (
+            "/sub/file.foo",
+            False,
+            "*.bar",
+            [],
+        ),
+        (
+            "/sub/file.foo",
+            True,
+            "*.bar",
+            [],
+        ),
+        (
+            "/.sub/.file.foo",
+            False,
+            None,
+            [
+                ("/.sub/.file.foo", "1.0.0"),
+                ("/.sub/.file.foo", "2.0.0"),
+            ],
+        ),
+        (
+            "/.sub/.file.foo",
+            True,
+            None,
+            [
+                ("/.sub/.file.foo", "2.0.0"),
+            ],
+        ),
+        (
+            "/sub/sub/",
+            False,
+            None,
+            [
+                ("/sub/sub/sub.ext", "1.0.0"),
+            ],
+        ),
+        (
+            "/sub/sub/",
+            True,
+            None,
+            [
+                ("/sub/sub/sub.ext", "1.0.0"),
+            ],
+        ),
+    ],
+)
+def test_ls(tmpdir, interface, files, path, latest, pattern, expected):
     assert interface.ls() == []
     assert interface.ls("/") == []
 
-    root = [
-        ("/file.bar", "1.0.0"),
-        ("/file.bar", "2.0.0"),
-        ("/file.foo", "1.0.0"),
-    ]
-    root_latest = [
-        ("/file.bar", "2.0.0"),
-        ("/file.foo", "1.0.0"),
-    ]
-    root_foo = [
-        ("/file.foo", "1.0.0"),
-    ]
-    root_bar = [
-        ("/file.bar", "1.0.0"),
-        ("/file.bar", "2.0.0"),
-    ]
-    root_bar_latest = [
-        ("/file.bar", "2.0.0"),
-    ]
-    sub = [
-        ("/sub/file.foo", "1.0.0"),
-        ("/sub/file.foo", "2.0.0"),
-    ]
-    sub_latest = [
-        ("/sub/file.foo", "2.0.0"),
-    ]
-    sub_extra = [
-        ("/sub/sub.ext", "1.0.0"),
-    ]
-    sub_sub = [
-        ("/sub/sub/sub.ext", "1.0.0"),
-    ]
-    hidden = [
-        ("/.sub/.file.foo", "1.0.0"),
-        ("/.sub/.file.foo", "2.0.0"),
-    ]
-    hidden_latest = [
-        ("/.sub/.file.foo", "2.0.0"),
-    ]
-
     # create content
-
-    tmp_file = os.path.join(tmpdir, "~")
-    for path, version in root + sub + sub_extra + sub_sub + hidden:
-        audeer.touch(tmp_file)
-        interface.put_file(
-            tmp_file,
-            path,
-            version,
-        )
+    tmp_file = audeer.touch(tmpdir, "~")
+    for file_path, file_version in files:
+        interface.put_file(tmp_file, file_path, file_version)
 
     # test
-
-    for path, latest, pattern, expected in [
-        ("/", False, None, root + sub + sub_extra + sub_sub + hidden),
-        ("/", True, None, root_latest + sub_latest + sub_extra + sub_sub + hidden_latest),
-        ("/", False, "*.foo", root_foo + sub + hidden),
-        ("/", True, "*.foo", root_foo + sub_latest + hidden_latest),
-        ("/sub/", False, None, sub + sub_extra + sub_sub),
-        ("/sub/", True, None, sub_latest + sub_extra + sub_sub),
-        ("/sub/", False, "*.bar", []),
-        ("/sub/", True, "*.bar", []),
-        ("/sub/", False, "file.*", sub),
-        ("/sub/", True, "file.*", sub_latest),
-        ("/.sub/", False, None, hidden),
-        ("/.sub/", True, None, hidden_latest),
-        ("/file.bar", False, None, root_bar),
-        ("/file.bar", True, None, root_bar_latest),
-        ("/sub/file.foo", False, None, sub),
-        ("/sub/file.foo", True, None, sub_latest),
-        ("/sub/file.foo", False, "file.*", sub),
-        ("/sub/file.foo", True, "file.*", sub_latest),
-        ("/sub/file.foo", False, "*.bar", []),
-        ("/sub/file.foo", True, "*.bar", []),
-        ("/.sub/.file.foo", False, None, hidden),
-        ("/.sub/.file.foo", True, None, hidden_latest),
-        ("/sub/sub/", False, None, sub_sub),
-    ]:
-        assert interface.ls(
-            path,
-            latest_version=latest,
-            pattern=pattern,
-        ) == sorted(expected)
+    assert interface.ls(
+        path,
+        latest_version=latest,
+        pattern=pattern,
+    ) == sorted(expected)
 
 
 def test_repr():

--- a/tests/test_interface_maven.py
+++ b/tests/test_interface_maven.py
@@ -89,10 +89,12 @@ def test_ls(tmpdir, interface):
         ("/file.bar", "1.0.0"),
         ("/file.bar", "2.0.0"),
         ("/file.foo", "1.0.0"),
+        ("/sub.ext", "1.0.0"),
     ]
     root_latest = [
         ("/file.bar", "2.0.0"),
         ("/file.foo", "1.0.0"),
+        ("/sub.ext", "1.0.0"),
     ]
     root_foo = [
         ("/file.foo", "1.0.0"),

--- a/tests/test_interface_maven.py
+++ b/tests/test_interface_maven.py
@@ -89,12 +89,10 @@ def test_ls(tmpdir, interface):
         ("/file.bar", "1.0.0"),
         ("/file.bar", "2.0.0"),
         ("/file.foo", "1.0.0"),
-        ("/sub.ext", "1.0.0"),
     ]
     root_latest = [
         ("/file.bar", "2.0.0"),
         ("/file.foo", "1.0.0"),
-        ("/sub.ext", "1.0.0"),
     ]
     root_foo = [
         ("/file.foo", "1.0.0"),
@@ -113,6 +111,12 @@ def test_ls(tmpdir, interface):
     sub_latest = [
         ("/sub/file.foo", "2.0.0"),
     ]
+    sub_extra = [
+        ("/sub/sub.ext", "1.0.0"),
+    ]
+    sub_sub = [
+        ("/sub/sub/sub.ext", "1.0.0"),
+    ]
     hidden = [
         ("/.sub/.file.foo", "1.0.0"),
         ("/.sub/.file.foo", "2.0.0"),
@@ -124,7 +128,7 @@ def test_ls(tmpdir, interface):
     # create content
 
     tmp_file = os.path.join(tmpdir, "~")
-    for path, version in root + sub + hidden:
+    for path, version in root + sub + sub_extra + sub_sub + hidden:
         audeer.touch(tmp_file)
         interface.put_file(
             tmp_file,
@@ -135,12 +139,12 @@ def test_ls(tmpdir, interface):
     # test
 
     for path, latest, pattern, expected in [
-        ("/", False, None, root + sub + hidden),
-        ("/", True, None, root_latest + sub_latest + hidden_latest),
+        ("/", False, None, root + sub + sub_extra + sub_sub + hidden),
+        ("/", True, None, root_latest + sub_latest + sub_extra + sub_sub + hidden_latest),
         ("/", False, "*.foo", root_foo + sub + hidden),
         ("/", True, "*.foo", root_foo + sub_latest + hidden_latest),
-        ("/sub/", False, None, sub),
-        ("/sub/", True, None, sub_latest),
+        ("/sub/", False, None, sub + sub_extra + sub_sub),
+        ("/sub/", True, None, sub_latest + sub_extra + sub_sub),
         ("/sub/", False, "*.bar", []),
         ("/sub/", True, "*.bar", []),
         ("/sub/", False, "file.*", sub),
@@ -157,6 +161,7 @@ def test_ls(tmpdir, interface):
         ("/sub/file.foo", True, "*.bar", []),
         ("/.sub/.file.foo", False, None, hidden),
         ("/.sub/.file.foo", True, None, hidden_latest),
+        ("/sub/sub/", False, None, sub_sub),
     ]:
         assert interface.ls(
             path,

--- a/tests/test_interface_versioned.py
+++ b/tests/test_interface_versioned.py
@@ -711,6 +711,9 @@ def test_ls(tmpdir, interface):
     sub_latest = [
         ("/sub/file.foo", "2.0.0"),
     ]
+    sub_extra = [
+        ("/sub/sub.ext", "1.0.0"),
+    ]
     hidden = [
         ("/.sub/.file.foo", "1.0.0"),
         ("/.sub/.file.foo", "2.0.0"),
@@ -722,7 +725,7 @@ def test_ls(tmpdir, interface):
     # create content
 
     tmp_file = os.path.join(tmpdir, "~")
-    for path, version in root + sub + hidden:
+    for path, version in root + sub + sub_extra + hidden:
         audeer.touch(tmp_file)
         interface.put_file(
             tmp_file,
@@ -733,12 +736,12 @@ def test_ls(tmpdir, interface):
     # test
 
     for path, latest, pattern, expected in [
-        ("/", False, None, root + sub + hidden),
-        ("/", True, None, root_latest + sub_latest + hidden_latest),
+        ("/", False, None, root + sub + sub_extra + hidden),
+        ("/", True, None, root_latest + sub_latest + sub_extra + hidden_latest),
         ("/", False, "*.foo", root_foo + sub + hidden),
         ("/", True, "*.foo", root_foo + sub_latest + hidden_latest),
-        ("/sub/", False, None, sub),
-        ("/sub/", True, None, sub_latest),
+        ("/sub/", False, None, sub + sub_extra),
+        ("/sub/", True, None, sub_latest + sub_extra),
         ("/sub/", False, "*.bar", []),
         ("/sub/", True, "*.bar", []),
         ("/sub/", False, "file.*", sub),

--- a/tests/test_interface_versioned.py
+++ b/tests/test_interface_versioned.py
@@ -687,10 +687,12 @@ def test_ls(tmpdir, interface):
         ("/file.bar", "1.0.0"),
         ("/file.bar", "2.0.0"),
         ("/file.foo", "1.0.0"),
+        ("/sub.ext", "1.0.0"),
     ]
     root_latest = [
         ("/file.bar", "2.0.0"),
         ("/file.foo", "1.0.0"),
+        ("/sub.ext", "1.0.0"),
     ]
     root_foo = [
         ("/file.foo", "1.0.0"),

--- a/tests/test_interface_versioned.py
+++ b/tests/test_interface_versioned.py
@@ -679,91 +679,256 @@ def test_file(tmpdir, src_path, dst_path, version, interface, owner):
     ],
     indirect=True,
 )
-def test_ls(tmpdir, interface):
+@pytest.mark.parametrize(
+    "files",
+    [
+        [
+            ("/file.bar", "1.0.0"),
+            ("/file.bar", "2.0.0"),
+            ("/file.foo", "1.0.0"),
+            ("/sub/file.foo", "1.0.0"),
+            ("/sub/file.foo", "2.0.0"),
+            ("/sub/sub.ext", "1.0.0"),
+            ("/sub/sub/sub.ext", "1.0.0"),
+            ("/.sub/.file.foo", "1.0.0"),
+            ("/.sub/.file.foo", "2.0.0"),
+        ],
+    ],
+)
+@pytest.mark.parametrize(
+    "path, latest, pattern, expected",
+    [
+        (
+            "/",
+            False,
+            None,
+            [
+                ("/file.bar", "1.0.0"),
+                ("/file.bar", "2.0.0"),
+                ("/file.foo", "1.0.0"),
+                ("/sub/file.foo", "1.0.0"),
+                ("/sub/file.foo", "2.0.0"),
+                ("/sub/sub.ext", "1.0.0"),
+                ("/sub/sub/sub.ext", "1.0.0"),
+                ("/.sub/.file.foo", "1.0.0"),
+                ("/.sub/.file.foo", "2.0.0"),
+            ],
+        ),
+        (
+            "/",
+            True,
+            None,
+            [
+                ("/file.bar", "2.0.0"),
+                ("/file.foo", "1.0.0"),
+                ("/sub/file.foo", "2.0.0"),
+                ("/sub/sub.ext", "1.0.0"),
+                ("/sub/sub/sub.ext", "1.0.0"),
+                ("/.sub/.file.foo", "2.0.0"),
+            ],
+        ),
+        (
+            "/",
+            False,
+            "*.foo",
+            [
+                ("/file.foo", "1.0.0"),
+                ("/sub/file.foo", "1.0.0"),
+                ("/sub/file.foo", "2.0.0"),
+                ("/.sub/.file.foo", "1.0.0"),
+                ("/.sub/.file.foo", "2.0.0"),
+            ],
+        ),
+        (
+            "/",
+            True,
+            "*.foo",
+            [
+                ("/file.foo", "1.0.0"),
+                ("/sub/file.foo", "2.0.0"),
+                ("/.sub/.file.foo", "2.0.0"),
+            ],
+        ),
+        (
+            "/sub/",
+            False,
+            None,
+            [
+                ("/sub/file.foo", "1.0.0"),
+                ("/sub/file.foo", "2.0.0"),
+                ("/sub/sub.ext", "1.0.0"),
+                ("/sub/sub/sub.ext", "1.0.0"),
+            ],
+        ),
+        (
+            "/sub/",
+            True,
+            None,
+            [
+                ("/sub/file.foo", "2.0.0"),
+                ("/sub/sub.ext", "1.0.0"),
+                ("/sub/sub/sub.ext", "1.0.0"),
+            ],
+        ),
+        (
+            "/sub/",
+            False,
+            "*.bar",
+            [],
+        ),
+        (
+            "/sub/",
+            True,
+            "*.bar",
+            [],
+        ),
+        (
+            "/sub/",
+            False,
+            "file.*",
+            [
+                ("/sub/file.foo", "1.0.0"),
+                ("/sub/file.foo", "2.0.0"),
+            ],
+        ),
+        (
+            "/sub/",
+            True,
+            "file.*",
+            [
+                ("/sub/file.foo", "2.0.0"),
+            ],
+        ),
+        (
+            "/.sub/",
+            False,
+            None,
+            [
+                ("/.sub/.file.foo", "1.0.0"),
+                ("/.sub/.file.foo", "2.0.0"),
+            ],
+        ),
+        (
+            "/.sub/",
+            True,
+            None,
+            [
+                ("/.sub/.file.foo", "2.0.0"),
+            ],
+        ),
+        (
+            "/file.bar",
+            False,
+            None,
+            [
+                ("/file.bar", "1.0.0"),
+                ("/file.bar", "2.0.0"),
+            ],
+        ),
+        (
+            "/file.bar",
+            True,
+            None,
+            [
+                ("/file.bar", "2.0.0"),
+            ],
+        ),
+        (
+            "/sub/file.foo",
+            False,
+            None,
+            [
+                ("/sub/file.foo", "1.0.0"),
+                ("/sub/file.foo", "2.0.0"),
+            ],
+        ),
+        (
+            "/sub/file.foo",
+            True,
+            None,
+            [
+                ("/sub/file.foo", "2.0.0"),
+            ],
+        ),
+        (
+            "/sub/file.foo",
+            False,
+            "file.*",
+            [
+                ("/sub/file.foo", "1.0.0"),
+                ("/sub/file.foo", "2.0.0"),
+            ],
+        ),
+        (
+            "/sub/file.foo",
+            True,
+            "file.*",
+            [
+                ("/sub/file.foo", "2.0.0"),
+            ],
+        ),
+        (
+            "/sub/file.foo",
+            False,
+            "*.bar",
+            [],
+        ),
+        (
+            "/sub/file.foo",
+            True,
+            "*.bar",
+            [],
+        ),
+        (
+            "/.sub/.file.foo",
+            False,
+            None,
+            [
+                ("/.sub/.file.foo", "1.0.0"),
+                ("/.sub/.file.foo", "2.0.0"),
+            ],
+        ),
+        (
+            "/.sub/.file.foo",
+            True,
+            None,
+            [
+                ("/.sub/.file.foo", "2.0.0"),
+            ],
+        ),
+        (
+            "/sub/sub/",
+            False,
+            None,
+            [
+                ("/sub/sub/sub.ext", "1.0.0"),
+            ],
+        ),
+        (
+            "/sub/sub/",
+            True,
+            None,
+            [
+                ("/sub/sub/sub.ext", "1.0.0"),
+            ],
+        ),
+    ],
+)
+def test_ls(tmpdir, interface, files, path, latest, pattern, expected):
     assert interface.ls() == []
     assert interface.ls("/") == []
 
-    root = [
-        ("/file.bar", "1.0.0"),
-        ("/file.bar", "2.0.0"),
-        ("/file.foo", "1.0.0"),
-        ("/sub.ext", "1.0.0"),
-    ]
-    root_latest = [
-        ("/file.bar", "2.0.0"),
-        ("/file.foo", "1.0.0"),
-        ("/sub.ext", "1.0.0"),
-    ]
-    root_foo = [
-        ("/file.foo", "1.0.0"),
-    ]
-    root_bar = [
-        ("/file.bar", "1.0.0"),
-        ("/file.bar", "2.0.0"),
-    ]
-    root_bar_latest = [
-        ("/file.bar", "2.0.0"),
-    ]
-    sub = [
-        ("/sub/file.foo", "1.0.0"),
-        ("/sub/file.foo", "2.0.0"),
-    ]
-    sub_latest = [
-        ("/sub/file.foo", "2.0.0"),
-    ]
-    sub_extra = [
-        ("/sub/sub.ext", "1.0.0"),
-    ]
-    hidden = [
-        ("/.sub/.file.foo", "1.0.0"),
-        ("/.sub/.file.foo", "2.0.0"),
-    ]
-    hidden_latest = [
-        ("/.sub/.file.foo", "2.0.0"),
-    ]
-
     # create content
-
-    tmp_file = os.path.join(tmpdir, "~")
-    for path, version in root + sub + sub_extra + hidden:
-        audeer.touch(tmp_file)
-        interface.put_file(
-            tmp_file,
-            path,
-            version,
-        )
+    tmp_file = audeer.touch(tmpdir, "~")
+    for file_path, file_version in files:
+        interface.put_file(tmp_file, file_path, file_version)
 
     # test
-
-    for path, latest, pattern, expected in [
-        ("/", False, None, root + sub + sub_extra + hidden),
-        ("/", True, None, root_latest + sub_latest + sub_extra + hidden_latest),
-        ("/", False, "*.foo", root_foo + sub + hidden),
-        ("/", True, "*.foo", root_foo + sub_latest + hidden_latest),
-        ("/sub/", False, None, sub + sub_extra),
-        ("/sub/", True, None, sub_latest + sub_extra),
-        ("/sub/", False, "*.bar", []),
-        ("/sub/", True, "*.bar", []),
-        ("/sub/", False, "file.*", sub),
-        ("/sub/", True, "file.*", sub_latest),
-        ("/.sub/", False, None, hidden),
-        ("/.sub/", True, None, hidden_latest),
-        ("/file.bar", False, None, root_bar),
-        ("/file.bar", True, None, root_bar_latest),
-        ("/sub/file.foo", False, None, sub),
-        ("/sub/file.foo", True, None, sub_latest),
-        ("/sub/file.foo", False, "file.*", sub),
-        ("/sub/file.foo", True, "file.*", sub_latest),
-        ("/sub/file.foo", False, "*.bar", []),
-        ("/sub/file.foo", True, "*.bar", []),
-        ("/.sub/.file.foo", False, None, hidden),
-        ("/.sub/.file.foo", True, None, hidden_latest),
-    ]:
-        assert interface.ls(
-            path,
-            latest_version=latest,
-            pattern=pattern,
-        ) == sorted(expected)
+    assert interface.ls(
+        path,
+        latest_version=latest,
+        pattern=pattern,
+    ) == sorted(expected)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #207 

This updates the tests of `audbackend.interface.Maven` and `audbackend.interface.Versioned` to include files in sub-paths that are named as the sub-path, namely `/sub/sub.ext` and `/sub/sub/sub.ext`. Those tests pass for `audbackend.interface.Versioned`, but failed for `audbackend.interface.Maven` due to #207.

`audbackend.interface.Maven.ls()` is then fixed, by removing results from the returned list of paths for a given sub-path, that contain files. This is neccessary compared to `audbackend.interface.Versioned` as `audbackend.interface.Maven` also stores files in sub-path, e.g. `/file/1.0.0/file-1.0.0.ext`.