### PR TITLE
Update Artifactory cleaning script

### DIFF
--- a/tests/misc/cleanup_artifactory.py
+++ b/tests/misc/cleanup_artifactory.py
@@ -9,7 +9,6 @@ import requests
 import audbackend
 
 
-name = "artifactory"
 host = "https://audeering.jfrog.io/artifactory"
 
 username, api_key = audbackend.core.backend.artifactory._authentication(host)
@@ -21,7 +20,7 @@ if r.status_code == 200:
     length = len(repos)
     for n, repo in enumerate(repos):
         try:
-            audbackend.delete(name, host, repo)
+            audbackend.backend.Artifactory.delete(host, repo)
             print(f"{n + 1:4.0f} / {length:4.0f} Deleted {repo}")
         except audbackend.BackendError:
             raise RuntimeError(


### PR DESCRIPTION
To avoid a deprecation warning when running:

```bash
$ python tests/misc/cleanup_artifactory.py
```

we use the new way of deleting repositories in `tests/misc/cleanup_artifactory.py`.