### PR TITLE
Deprecate audbackend.access()

### DIFF
--- a/audbackend/core/api.py
+++ b/audbackend/core/api.py
@@ -73,7 +73,13 @@ def access(
         and will be removed in version 2.2.0.
         Repositories on backends are instead accessed
         by instantiating the corresponding backend class,
-        e.g. :meth:`audbackend.backend.FileSystem(host, repo)`.
+        and connecting to it using the ``open()`` method,
+        e.g.
+
+        .. code-block:: python
+
+            backend = audbackend.backend.FileSystem(host, repo)
+            backend.open()
 
     Args:
         name: backend alias

--- a/audbackend/core/api.py
+++ b/audbackend/core/api.py
@@ -185,7 +185,9 @@ def delete(
             has been registered
 
     """  # noqa: E501
-    interface = access(name, host, repository)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        interface = access(name, host, repository)
     utils.call_function_on_backend(interface._backend._delete)
     backends[name][host].pop(repository)
 

--- a/audbackend/core/api.py
+++ b/audbackend/core/api.py
@@ -47,6 +47,10 @@ def _backend(
     return backend
 
 
+@audeer.deprecated(
+    removal_version="2.2.0",
+    alternative="Backend.__init__() of corresponding backend",
+)
 def access(
     name: str,
     host: str,
@@ -62,6 +66,14 @@ def access(
     located at ``host``
     on the backend with alias ``name``
     (see :func:`audbackend.register`).
+
+    .. Warning::
+
+        ``audbackend.access()`` is deprecated
+        and will be removed in version 2.2.0.
+        Repositories on backends are instead accessed
+        by instantiating the corresponding backend class,
+        e.g. :meth:`audbackend.backend.FileSystem(host, repo)`.
 
     Args:
         name: backend alias

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -50,7 +50,8 @@ def test_api(hosts, name, host, repository, cls):
     error_msg = "A backend class with name 'bad' does not exist."
 
     with pytest.raises(ValueError, match=error_msg):
-        audbackend.access("bad", host, repository)
+        with pytest.warns(UserWarning, match=warning):
+            audbackend.access("bad", host, repository)
 
     error_msg = (
         "An exception was raised by the backend, "
@@ -58,7 +59,8 @@ def test_api(hosts, name, host, repository, cls):
     )
 
     with pytest.raises(audbackend.BackendError, match=error_msg):
-        audbackend.access(name, host, repository)
+        with pytest.warns(UserWarning, match=warning):
+            audbackend.access(name, host, repository)
 
     # returns versioned interface for legacy reasons
     warning = (
@@ -74,7 +76,8 @@ def test_api(hosts, name, host, repository, cls):
         with pytest.warns(UserWarning, match=warning):
             audbackend.create(name, host, repository)
 
-    interface = audbackend.access(name, host, repository)
+    with pytest.warns(UserWarning, match=warning):
+        interface = audbackend.access(name, host, repository)
     assert isinstance(interface.backend, cls)
 
     warning = (
@@ -85,4 +88,5 @@ def test_api(hosts, name, host, repository, cls):
         audbackend.delete(name, host, repository)
 
     with pytest.raises(audbackend.BackendError, match=error_msg):
-        audbackend.access(name, host, repository)
+        with pytest.warns(UserWarning, match=warning):
+            audbackend.access(name, host, repository)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,4 @@
 import pytest
-import warning
 
 import audeer
 
@@ -48,10 +47,22 @@ def test_api(hosts, name, host, repository, cls):
     if host is not None and host in hosts:
         host = hosts[name]
 
-    error_msg = "A backend class with name 'bad' does not exist."
+    access_warning = (
+        "access is deprecated and will be removed with version 2.2.0. "
+        r"Use Backend.__init__\(\) of corresponding backend instead."
+    )
+    create_warning = (
+        "create is deprecated and will be removed with version 2.2.0. "
+        r"Use class method Backend.create\(\) of corresponding backend instead."
+    )
+    delete_warning = (
+        "delete is deprecated and will be removed with version 2.2.0. "
+        r"Use class method Backend.delete\(\) of corresponding backend instead."
+    )
 
+    error_msg = "A backend class with name 'bad' does not exist."
     with pytest.raises(ValueError, match=error_msg):
-        with pytest.warns(UserWarning, match=warning):
+        with pytest.warns(UserWarning, match=access_warning):
             audbackend.access("bad", host, repository)
 
     error_msg = (
@@ -60,34 +71,26 @@ def test_api(hosts, name, host, repository, cls):
     )
 
     with pytest.raises(audbackend.BackendError, match=error_msg):
-        with pytest.warns(UserWarning, match=warning):
+        with pytest.warns(UserWarning, match=access_warning):
             audbackend.access(name, host, repository)
 
     # returns versioned interface for legacy reasons
-    warning = (
-        "create is deprecated and will be removed with version 2.2.0. "
-        r"Use class method Backend.create\(\) of corresponding backend instead."
-    )
-    with pytest.warns(UserWarning, match=warning):
+    with pytest.warns(UserWarning, match=create_warning):
         interface = audbackend.create(name, host, repository)
     assert isinstance(interface, audbackend.interface.Versioned)
     assert isinstance(interface.backend, cls)
 
     with pytest.raises(audbackend.BackendError, match=error_msg):
-        with pytest.warns(UserWarning, match=warning):
+        with pytest.warns(UserWarning, match=create_warning):
             audbackend.create(name, host, repository)
 
-    with pytest.warns(UserWarning, match=warning):
+    with pytest.warns(UserWarning, match=access_warning):
         interface = audbackend.access(name, host, repository)
     assert isinstance(interface.backend, cls)
 
-    warning = (
-        "delete is deprecated and will be removed with version 2.2.0. "
-        r"Use class method Backend.delete\(\) of corresponding backend instead."
-    )
-    with pytest.warns(UserWarning, match=warning):
+    with pytest.warns(UserWarning, match=delete_warning):
         audbackend.delete(name, host, repository)
 
     with pytest.raises(audbackend.BackendError, match=error_msg):
-        with pytest.warns(UserWarning, match=warning):
+        with pytest.warns(UserWarning, match=access_warning):
             audbackend.access(name, host, repository)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
 import pytest
+import warning
 
 import audeer
 


### PR DESCRIPTION
Closes #211 

This deprecates `audbackend.access()`.

![image](https://github.com/audeering/audbackend/assets/173624/fb60cf5a-5865-4cbf-8708-55670fe3e4ba)