### PR TITLE
Make open a backend mandatory

### DIFF
--- a/audbackend/core/backend/artifactory.py
+++ b/audbackend/core/backend/artifactory.py
@@ -208,9 +208,8 @@ class Artifactory(Base):
         self,
     ):
         r"""Delete repository and all its content."""
-        self.open()
-        self._repo.delete()
-        self.close()
+        with self:
+            self._repo.delete()
 
     def _exists(
         self,

--- a/audbackend/core/backend/artifactory.py
+++ b/audbackend/core/backend/artifactory.py
@@ -142,14 +142,6 @@ class Artifactory(Base):
     ):
         super().__init__(host, repository)
 
-        self._username, self._api_key = _authentication(host)
-        path = _artifactory_path(
-            self.host,
-            self._username,
-            self._api_key,
-        )
-        self._repo = path.find_repository_local(self.repository)
-
     def _checksum(
         self,
         path: str,
@@ -191,20 +183,16 @@ class Artifactory(Base):
         self,
     ):
         r"""Access existing repository."""
-        if self._repo is not None:
-            utils.raise_file_exists_error(str(self._repo.path))
-
-        path = _artifactory_path(
-            self.host,
-            self._username,
-            self._api_key,
-        )
-        self._repo = dohq_artifactory.RepositoryLocal(
+        username, api_key = _authentication(self.host)
+        path = _artifactory_path(self.host, username, api_key)
+        repo = dohq_artifactory.RepositoryLocal(
             path,
             self.repository,
             package_type=dohq_artifactory.RepositoryLocal.GENERIC,
         )
-        self._repo.create()
+        if repo.path.exists():
+            utils.raise_file_exists_error(str(repo.path))
+        repo.create()
 
     def _date(
         self,
@@ -220,7 +208,9 @@ class Artifactory(Base):
         self,
     ):
         r"""Delete repository and all its content."""
+        self.open()
         self._repo.delete()
+        self.close()
 
     def _exists(
         self,
@@ -288,8 +278,15 @@ class Artifactory(Base):
         self,
     ):
         r"""Open connection to backend."""
+        self._username, self._api_key = _authentication(self.host)
+        path = _artifactory_path(
+            self.host,
+            self._username,
+            self._api_key,
+        )
+        self._repo = path.find_repository_local(self.repository)
         if self._repo is None:
-            utils.raise_file_not_found_error(str(self._repo.path))
+            utils.raise_file_not_found_error(self.repository)
 
     def _owner(
         self,

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -31,7 +31,7 @@ class Base:
         self.repository = repository
         r"""Repository name."""
         self.opened = False
-        r"""If backend is opened."""
+        r"""If a connection to the repository has been established."""
 
     def __enter__(self):
         r"""Open connection via context manager."""

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -818,8 +818,9 @@ class Base:
         .. _with: https://docs.python.org/3/reference/compound_stmts.html#with
 
         """
-        utils.call_function_on_backend(self._open)
-        self.opened = True
+        if not self.opened:
+            utils.call_function_on_backend(self._open)
+            self.opened = True
 
     def _owner(
         self,

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -129,7 +129,13 @@ class Base:
     def _close(
         self,
     ):  # pragma: no cover
-        r"""Close connection to repository."""
+        r"""Close connection to repository.
+
+        An error should be raised,
+        if the connection to the backend
+        cannot be closed.
+
+        """
         pass
 
     def close(
@@ -787,7 +793,9 @@ class Base:
     ):  # pragma: no cover
         r"""Open connection to backend.
 
-        * If repository does not exist an error should be raised
+        If repository does not exist,
+        or the backend cannot be opened,
+        an error should be raised.
 
         """
         pass

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -108,12 +108,12 @@ class Base:
             MD5 checksum
 
         Raises:
-            BackendError: if backend was not opened,
-                or an error is raised on the backend,
+            BackendError: if an error is raised on the backend,
                 e.g. ``path`` does not exist
             ValueError: if ``path`` does not start with ``'/'``,
                 ends on ``'/'``,
                 or does not match ``'[A-Za-z0-9/._-]+'``
+            RuntimeError: if backend was not opened
 
         """
         if not self.opened:
@@ -194,13 +194,13 @@ class Base:
             verbose: show debug messages
 
         Raises:
-            BackendError: if backend was not opened,
-                or an error is raised on the backend
+            BackendError: if an error is raised on the backend
             InterruptedError: if validation fails
             ValueError: if ``src_path`` or ``dst_path``
                 does not start with ``'/'``,
                 ends on ``'/'``,
                 or does not match ``'[A-Za-z0-9/._-]+'``
+            RuntimeError: if backend was not opened
 
         """
         if not self.opened:
@@ -291,12 +291,12 @@ class Base:
             date in format ``'yyyy-mm-dd'``
 
         Raises:
-            BackendError: if backend was not opened,
-                or an error is raised on the backend,
+            BackendError: if an error is raised on the backend,
                 e.g. ``path`` does not exist
             ValueError: if ``path`` does not start with ``'/'``,
                 ends on ``'/'``,
                 or does not match ``'[A-Za-z0-9/._-]+'``
+            RuntimeError: if backend was not opened
 
         """
         if not self.opened:
@@ -362,7 +362,6 @@ class Base:
             ``True`` if file exists
 
         Raises:
-            BackendError: if backend was not opened
             BackendError: if ``suppress_backend_errors`` is ``False``
                 and an error is raised on the backend,
                 e.g. due to a connection timeout
@@ -371,6 +370,7 @@ class Base:
                 or does not match ``'[A-Za-z0-9/._-]+'``
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
+            RuntimeError: if backend was not opened
 
         """
         if not self.opened:
@@ -421,8 +421,7 @@ class Base:
             extracted files
 
         Raises:
-            BackendError: if backend was not opened,
-                or an error is raised on the backend,
+            BackendError: if an error is raised on the backend,
                 e.g. ``src_path`` does not exist
             FileNotFoundError: if ``tmp_root`` does not exist
             InterruptedError: if validation fails
@@ -434,10 +433,11 @@ class Base:
             ValueError: if ``src_path`` does not start with ``'/'``,
                 ends on ``'/'``,
                 or does not match ``'[A-Za-z0-9/._-]+'``
+            RuntimeError: if backend was not opened
 
         """
         if not self.opened:
-            raise BackendError(backend_not_opened_error)
+            raise RuntimeError(backend_not_opened_error)
 
         src_path = utils.check_path(src_path)
 
@@ -508,8 +508,7 @@ class Base:
             full path to local file
 
         Raises:
-            BackendError: if backend was not opened,
-                or an error is raised on the backend,
+            BackendError: if an error is raised on the backend,
                 e.g. ``src_path`` does not exist
             InterruptedError: if validation fails
             IsADirectoryError: if ``dst_path`` points to an existing folder
@@ -518,6 +517,7 @@ class Base:
             ValueError: if ``src_path`` does not start with ``'/'``,
                 ends on ``'/'``,
                 or does not match ``'[A-Za-z0-9/._-]+'``
+            RuntimeError: if backend was not opened
 
         """
         if not self.opened:
@@ -643,12 +643,12 @@ class Base:
             list of tuples (path, version)
 
         Raises:
-            BackendError: if backend was not opened
             BackendError: if ``suppress_backend_errors`` is ``False``
                 and an error is raised on the backend,
                 e.g. ``path`` does not exist
             ValueError: if ``path`` does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
+            RuntimeError: if backend was not opened
 
         """
         if not self.opened:
@@ -741,13 +741,13 @@ class Base:
             verbose: show debug messages
 
         Raises:
-            BackendError: if backend was not opened,
-                or an error is raised on the backend
+            BackendError: if an error is raised on the backend
             InterruptedError: if validation fails
             ValueError: if ``src_path`` or ``dst_path``
                 does not start with ``'/'``,
                 ends on ``'/'``,
                 or does not match ``'[A-Za-z0-9/._-]+'``
+            RuntimeError: if backend was not opened
 
         """
         if not self.opened:
@@ -847,12 +847,12 @@ class Base:
             owner
 
         Raises:
-            BackendError: if backend was not opened,
-                or an error is raised on the backend,
+            BackendError: if an error is raised on the backend,
                 e.g. ``path`` does not exist
             ValueError: if ``path`` does not start with ``'/'``,
                 ends on ``'/'``,
                 or does not match ``'[A-Za-z0-9/._-]+'``
+            RuntimeError: if backend was not opened
 
         """
         if not self.opened:
@@ -906,8 +906,7 @@ class Base:
             verbose: show debug messages
 
         Raises:
-            BackendError: if backend was not opened,
-                or an error is raised on the backend
+            BackendError: if an error is raised on the backend
             FileNotFoundError: if ``src_root``,
                 ``tmp_root``,
                 or one or more ``files`` do not exist
@@ -919,6 +918,7 @@ class Base:
             ValueError: if ``dst_path`` does not start with ``'/'``,
                 ends on ``'/'``,
                 or does not match ``'[A-Za-z0-9/._-]+'``
+            RuntimeError: if backend was not opened
 
         """
         if not self.opened:
@@ -988,14 +988,14 @@ class Base:
             verbose: show debug messages
 
         Raises:
-            BackendError: if backend was not opened,
-                or an error is raised on the backend
+            BackendError: if an error is raised on the backend
             FileNotFoundError: if ``src_path`` does not exist
             InterruptedError: if validation fails
             IsADirectoryError: if ``src_path`` is a folder
             ValueError: if ``dst_path`` does not start with ``'/'``,
                 ends on ``'/'``,
                 or does not match ``'[A-Za-z0-9/._-]+'``
+            RuntimeError: if backend was not opened
 
         """
         if not self.opened:
@@ -1044,12 +1044,12 @@ class Base:
             path: path to file on backend
 
         Raises:
-            BackendError: if backend was not opened,
-                or an error is raised on the backend,
+            BackendError: if an error is raised on the backend,
                 e.g. ``path`` does not exist
             ValueError: if ``path`` does not start with ``'/'``,
                 ends on ``'/'``,
                 or does not match ``'[A-Za-z0-9/._-]+'``
+            RuntimeError: if backend was not opened
 
         """
         if not self.opened:

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -9,7 +9,9 @@ from audbackend.core import utils
 from audbackend.core.errors import BackendError
 
 
-backend_not_opened_error = "'Backend.open()' needs to be run first."
+backend_not_opened_error = (
+    "Call 'Backend.open()' to establish a connection to the repository first."
+)
 
 
 class Base:

--- a/audbackend/core/errors.py
+++ b/audbackend/core/errors.py
@@ -8,10 +8,11 @@ class BackendError(Exception):
 
         >>> import audeer
         >>> audeer.rmdir("host", "repo")
-        >>> _ = audeer.mkdir("host")
+        >>> _ = audeer.mkdir("host", "repo")
 
     Examples:
         >>> backend = audbackend.backend.FileSystem("host", "repo")
+        >>> backend.open()
         >>> try:
         ...     interface = audbackend.interface.Unversioned(backend)
         ...     interface.checksum("/does/not/exist")

--- a/audbackend/core/interface/maven.py
+++ b/audbackend/core/interface/maven.py
@@ -66,6 +66,7 @@ class Maven(Versioned):
     Examples:
         >>> file = "src.txt"
         >>> backend = audbackend.backend.FileSystem("host", "repo")
+        >>> backend.open()
         >>> interface = Maven(backend)
         >>> interface.put_archive(".", "/sub/archive.zip", "1.0.0", files=[file])
         >>> for version in ["1.0.0", "2.0.0"]:
@@ -138,6 +139,7 @@ class Maven(Versioned):
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> backend.open()
             >>> interface = Maven(backend)
 
         Examples:

--- a/audbackend/core/interface/maven.py
+++ b/audbackend/core/interface/maven.py
@@ -136,6 +136,7 @@ class Maven(Versioned):
                 e.g. ``path`` does not exist
             ValueError: if ``path`` does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
+            RuntimeError: if backend was not opened
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")

--- a/audbackend/core/interface/unversioned.py
+++ b/audbackend/core/interface/unversioned.py
@@ -16,6 +16,7 @@ class Unversioned(Base):
     Examples:
         >>> file = "src.txt"
         >>> backend = audbackend.backend.FileSystem("host", "repo")
+        >>> backend.open()
         >>> interface = Unversioned(backend)
         >>> interface.put_file(file, "/file.txt")
         >>> interface.put_archive(".", "/sub/archive.zip", files=[file])
@@ -47,6 +48,7 @@ class Unversioned(Base):
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> backend.open()
             >>> interface = Unversioned(backend)
 
         Examples:
@@ -101,6 +103,7 @@ class Unversioned(Base):
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> backend.open()
             >>> interface = Unversioned(backend)
 
         Examples:
@@ -144,6 +147,7 @@ class Unversioned(Base):
 
         ..
             >>> backend = DoctestFileSystem("host", "repo")
+            >>> backend.open()
             >>> interface = Unversioned(backend)
 
         Examples:
@@ -184,6 +188,7 @@ class Unversioned(Base):
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> backend.open()
             >>> interface = Unversioned(backend)
 
         Examples:
@@ -253,6 +258,7 @@ class Unversioned(Base):
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> backend.open()
             >>> interface = Unversioned(backend)
 
         Examples:
@@ -322,6 +328,7 @@ class Unversioned(Base):
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> backend.open()
             >>> interface = Unversioned(backend)
 
         Examples:
@@ -388,6 +395,7 @@ class Unversioned(Base):
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> backend.open()
             >>> interface = Unversioned(backend)
 
         Examples:
@@ -456,6 +464,7 @@ class Unversioned(Base):
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> backend.open()
             >>> interface = Unversioned(backend)
 
         Examples:
@@ -502,6 +511,7 @@ class Unversioned(Base):
 
         ..
             >>> backend = DoctestFileSystem("host", "repo")
+            >>> backend.open()
             >>> interface = Unversioned(backend)
 
         Examples:
@@ -571,6 +581,7 @@ class Unversioned(Base):
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> backend.open()
             >>> interface = Unversioned(backend)
 
         Examples:
@@ -631,6 +642,7 @@ class Unversioned(Base):
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> backend.open()
             >>> interface = Unversioned(backend)
 
         Examples:
@@ -667,6 +679,7 @@ class Unversioned(Base):
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> backend.open()
             >>> interface = Unversioned(backend)
 
         Examples:

--- a/audbackend/core/interface/unversioned.py
+++ b/audbackend/core/interface/unversioned.py
@@ -45,6 +45,7 @@ class Unversioned(Base):
             ValueError: if ``path`` does not start with ``'/'``,
                 ends on ``'/'``,
                 or does not match ``'[A-Za-z0-9/._-]+'``
+            RuntimeError: if backend was not opened
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
@@ -100,6 +101,7 @@ class Unversioned(Base):
                 does not start with ``'/'``,
                 ends on ``'/'``,
                 or does not match ``'[A-Za-z0-9/._-]+'``
+            RuntimeError: if backend was not opened
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
@@ -144,6 +146,7 @@ class Unversioned(Base):
             ValueError: if ``path`` does not start with ``'/'``,
                 ends on ``'/'``,
                 or does not match ``'[A-Za-z0-9/._-]+'``
+            RuntimeError: if backend was not opened
 
         ..
             >>> backend = DoctestFileSystem("host", "repo")
@@ -185,6 +188,7 @@ class Unversioned(Base):
                 or does not match ``'[A-Za-z0-9/._-]+'``
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
+            RuntimeError: if backend was not opened
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
@@ -255,6 +259,7 @@ class Unversioned(Base):
             ValueError: if ``src_path`` does not start with ``'/'``,
                 ends on ``'/'``,
                 or does not match ``'[A-Za-z0-9/._-]+'``
+            RuntimeError: if backend was not opened
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
@@ -325,6 +330,7 @@ class Unversioned(Base):
             ValueError: if ``src_path`` does not start with ``'/'``,
                 ends on ``'/'``,
                 or does not match ``'[A-Za-z0-9/._-]+'``
+            RuntimeError: if backend was not opened
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
@@ -392,6 +398,7 @@ class Unversioned(Base):
                 e.g. ``path`` does not exist
             ValueError: if ``path`` does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
+            RuntimeError: if backend was not opened
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
@@ -461,6 +468,7 @@ class Unversioned(Base):
                 does not start with ``'/'``,
                 ends on ``'/'``,
                 or does not match ``'[A-Za-z0-9/._-]+'``
+            RuntimeError: if backend was not opened
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
@@ -508,6 +516,7 @@ class Unversioned(Base):
             ValueError: if ``path`` does not start with ``'/'``,
                 ends on ``'/'``,
                 or does not match ``'[A-Za-z0-9/._-]+'``
+            RuntimeError: if backend was not opened
 
         ..
             >>> backend = DoctestFileSystem("host", "repo")
@@ -578,6 +587,7 @@ class Unversioned(Base):
             ValueError: if ``dst_path`` does not start with ``'/'``,
                 ends on ``'/'``,
                 or does not match ``'[A-Za-z0-9/._-]+'``
+            RuntimeError: if backend was not opened
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
@@ -639,6 +649,7 @@ class Unversioned(Base):
             ValueError: if ``dst_path`` does not start with ``'/'``,
                 ends on ``'/'``,
                 or does not match ``'[A-Za-z0-9/._-]+'``
+            RuntimeError: if backend was not opened
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -24,6 +24,7 @@ class Versioned(Base):
     Examples:
         >>> file = "src.txt"
         >>> backend = audbackend.backend.FileSystem("host", "repo")
+        >>> backend.open()
         >>> interface = Versioned(backend)
         >>> interface.put_archive(".", "/sub/archive.zip", "1.0.0", files=[file])
         >>> for version in ["1.0.0", "2.0.0"]:
@@ -67,6 +68,7 @@ class Versioned(Base):
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> backend.open()
             >>> interface = Versioned(backend)
 
         Examples:
@@ -130,6 +132,7 @@ class Versioned(Base):
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> backend.open()
             >>> interface = Versioned(backend)
 
         Examples:
@@ -185,6 +188,7 @@ class Versioned(Base):
 
         ..
             >>> backend = DoctestFileSystem("host", "repo")
+            >>> backend.open()
             >>> interface = Versioned(backend)
 
         Examples:
@@ -228,6 +232,7 @@ class Versioned(Base):
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> backend.open()
             >>> interface = Versioned(backend)
 
         Examples:
@@ -302,6 +307,7 @@ class Versioned(Base):
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> backend.open()
             >>> interface = Versioned(backend)
 
         Examples:
@@ -376,6 +382,7 @@ class Versioned(Base):
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> backend.open()
             >>> interface = Versioned(backend)
 
         Examples:
@@ -417,6 +424,7 @@ class Versioned(Base):
 
          ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> backend.open()
             >>> interface = Versioned(backend)
 
         Examples:
@@ -480,6 +488,7 @@ class Versioned(Base):
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> backend.open()
             >>> interface = Versioned(backend)
 
         Examples:
@@ -620,6 +629,7 @@ class Versioned(Base):
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> backend.open()
             >>> interface = Versioned(backend)
 
         Examples:
@@ -678,6 +688,7 @@ class Versioned(Base):
 
         ..
             >>> backend = DoctestFileSystem("host", "repo")
+            >>> backend.open()
             >>> interface = Versioned(backend)
 
         Examples:
@@ -752,6 +763,7 @@ class Versioned(Base):
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> backend.open()
             >>> interface = Versioned(backend)
 
         Examples:
@@ -820,6 +832,7 @@ class Versioned(Base):
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> backend.open()
             >>> interface = Versioned(backend)
 
         Examples:
@@ -861,6 +874,7 @@ class Versioned(Base):
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> backend.open()
             >>> interface = Versioned(backend)
 
         Examples:
@@ -903,6 +917,7 @@ class Versioned(Base):
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> backend.open()
             >>> interface = Versioned(backend)
 
         Examples:

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -65,6 +65,7 @@ class Versioned(Base):
                 or does not match ``'[A-Za-z0-9/._-]+'``
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
+            RuntimeError: if backend was not opened
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
@@ -129,6 +130,7 @@ class Versioned(Base):
                 or does not match ``'[A-Za-z0-9/._-]+'``
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
+            RuntimeError: if backend was not opened
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
@@ -185,6 +187,7 @@ class Versioned(Base):
                 or does not match ``'[A-Za-z0-9/._-]+'``
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
+            RuntimeError: if backend was not opened
 
         ..
             >>> backend = DoctestFileSystem("host", "repo")
@@ -229,6 +232,7 @@ class Versioned(Base):
                 or does not match ``'[A-Za-z0-9/._-]+'``
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
+            RuntimeError: if backend was not opened
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
@@ -304,6 +308,7 @@ class Versioned(Base):
                 or does not match ``'[A-Za-z0-9/._-]+'``
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
+            RuntimeError: if backend was not opened
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
@@ -379,6 +384,7 @@ class Versioned(Base):
                 or does not match ``'[A-Za-z0-9/._-]+'``
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
+            RuntimeError: if backend was not opened
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
@@ -421,6 +427,7 @@ class Versioned(Base):
             ValueError: if ``path`` does not start with ``'/'``,
                 ends on ``'/'``,
                 or does not match ``'[A-Za-z0-9/._-]+'``
+            RuntimeError: if backend was not opened
 
          ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
@@ -485,6 +492,7 @@ class Versioned(Base):
                 e.g. ``path`` does not exist
             ValueError: if ``path`` does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
+            RuntimeError: if backend was not opened
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
@@ -626,6 +634,7 @@ class Versioned(Base):
                 or does not match ``'[A-Za-z0-9/._-]+'``
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
+            RuntimeError: if backend was not opened
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
@@ -685,6 +694,7 @@ class Versioned(Base):
                 or does not match ``'[A-Za-z0-9/._-]+'``
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
+            RuntimeError: if backend was not opened
 
         ..
             >>> backend = DoctestFileSystem("host", "repo")
@@ -760,6 +770,7 @@ class Versioned(Base):
                 or does not match ``'[A-Za-z0-9/._-]+'``
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
+            RuntimeError: if backend was not opened
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
@@ -829,6 +840,7 @@ class Versioned(Base):
                 or does not match ``'[A-Za-z0-9/._-]+'``
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
+            RuntimeError: if backend was not opened
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
@@ -871,6 +883,7 @@ class Versioned(Base):
                 or does not match ``'[A-Za-z0-9/._-]+'``
             ValueError: if ``version`` is empty or
                 does not match ``'[A-Za-z0-9._-]+'``
+            RuntimeError: if backend was not opened
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")
@@ -914,6 +927,7 @@ class Versioned(Base):
             ValueError: if ``path`` does not start with ``'/'``,
                 ends on ``'/'``,
                 or does not match ``'[A-Za-z0-9/._-]+'``
+            RuntimeError: if backend was not opened
 
         ..
             >>> backend = audbackend.backend.FileSystem("host", "repo")

--- a/docs/developer-guide.rst
+++ b/docs/developer-guide.rst
@@ -128,6 +128,7 @@ and upload a file:
 
     audbackend.backend.FileSystem.create("./host", "repo")
     backend = audbackend.backend.FileSystem("./host", "repo")
+    backend.open()
     interface = UserContent(backend)
 
     interface.add_user("audeering", "pa$$word")

--- a/docs/developer-guide.rst
+++ b/docs/developer-guide.rst
@@ -141,6 +141,7 @@ At the end we clean up and delete our repo.
 
 .. jupyter-execute::
 
+    backend.close()
     audbackend.backend.FileSystem.delete("./host", "repo")
 
 

--- a/docs/legacy.rst
+++ b/docs/legacy.rst
@@ -50,6 +50,7 @@ you have to list those extensions explicitly.
 
     audbackend.backend.FileSystem.create("./host", "repo")
     backend = audbackend.backend.FileSystem("./host", "repo")
+    backend.open()
     interface = audbackend.interface.Maven(backend, extensions=["tar.gz"])
 
 Afterwards we upload an TAR.GZ archive

--- a/tests/test_backend_artifactory.py
+++ b/tests/test_backend_artifactory.py
@@ -39,25 +39,25 @@ def test_authentication(tmpdir, hosts, hide_credentials):
 
     # config file does not exist
 
-    backend = audbackend.backend.Artifactory(host, "repository")
-    assert backend._username == "anonymous"
-    assert backend._api_key == ""
+    username, api_key = audbackend.core.backend.artifactory._authentication(host)
+    assert username == "anonymous"
+    assert api_key == ""
 
     # config file is empty
 
     audeer.touch(config_path)
-    backend = audbackend.backend.Artifactory(host, "repository")
-    assert backend._username == "anonymous"
-    assert backend._api_key == ""
+    username, api_key = audbackend.core.backend.artifactory._authentication(host)
+    assert username == "anonymous"
+    assert api_key == ""
 
     # config file entry without username and password
 
     with open(config_path, "w") as fp:
         fp.write(f"[{host}]\n")
 
-    backend = audbackend.backend.Artifactory(host, "repository")
-    assert backend._username == "anonymous"
-    assert backend._api_key == ""
+    username, api_key = audbackend.core.backend.artifactory._authentication(host)
+    assert username == "anonymous"
+    assert api_key == ""
 
     # config file entry with username and password
 
@@ -68,8 +68,9 @@ def test_authentication(tmpdir, hosts, hide_credentials):
         fp.write(f"username = {username}\n")
         fp.write(f"password = {api_key}\n")
 
-    with pytest.raises(dohq_artifactory.exception.ArtifactoryException):
-        audbackend.backend.Artifactory(host, "repository")
+    username, api_key = audbackend.core.backend.artifactory._authentication(host)
+    assert username == "bad"
+    assert api_key == "bad"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_backend_artifactory.py
+++ b/tests/test_backend_artifactory.py
@@ -1,6 +1,5 @@
 import os
 
-import dohq_artifactory
 import pytest
 
 import audeer

--- a/tests/test_backend_base.py
+++ b/tests/test_backend_base.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 import audbackend
@@ -81,3 +83,42 @@ def test_join(paths, expected, backend):
 )
 def test_split(path, expected, backend):
     assert backend.split(path) == expected
+
+
+@pytest.mark.parametrize(
+    "backend",
+    [
+        audbackend.backend.Base("host", "repository"),
+    ],
+)
+def test_errors(tmpdir, backend):
+    # Check errors when backend is not opened
+    error_msg = re.escape("'Backend.open()' needs to be run first.")
+    path = "file.txt"
+    src_path = "src.txt"
+    dst_path = "dst.txt"
+    src_root = "."
+    with pytest.raises(RuntimeError, match=error_msg):
+        backend.checksum(path)
+    with pytest.raises(RuntimeError, match=error_msg):
+        backend.copy_file(src_path, dst_path)
+    with pytest.raises(RuntimeError, match=error_msg):
+        backend.date(path)
+    with pytest.raises(RuntimeError, match=error_msg):
+        backend.exists(path)
+    with pytest.raises(RuntimeError, match=error_msg):
+        backend.get_archive(src_path, dst_path)
+    with pytest.raises(RuntimeError, match=error_msg):
+        backend.get_file(src_path, dst_path)
+    with pytest.raises(RuntimeError, match=error_msg):
+        backend.ls(path)
+    with pytest.raises(RuntimeError, match=error_msg):
+        backend.move_file(src_path, dst_path)
+    with pytest.raises(RuntimeError, match=error_msg):
+        backend.owner(path)
+    with pytest.raises(RuntimeError, match=error_msg):
+        backend.put_archive(src_root, dst_path)
+    with pytest.raises(RuntimeError, match=error_msg):
+        backend.put_file(src_path, dst_path)
+    with pytest.raises(RuntimeError, match=error_msg):
+        backend.remove_file(path)

--- a/tests/test_backend_base.py
+++ b/tests/test_backend_base.py
@@ -93,7 +93,9 @@ def test_split(path, expected, backend):
 )
 def test_errors(tmpdir, backend):
     # Check errors when backend is not opened
-    error_msg = re.escape("'Backend.open()' needs to be run first.")
+    error_msg = re.escape(
+        "Call 'Backend.open()' to establish a connection to the repository first."
+    )
     path = "file.txt"
     src_path = "src.txt"
     dst_path = "dst.txt"

--- a/tests/test_interface_unversioned.py
+++ b/tests/test_interface_unversioned.py
@@ -784,10 +784,14 @@ def test_validate(tmpdir):
     path = audeer.touch(tmpdir, "~.txt")
     error_msg = "Execution is interrupted because"
 
-    interface = audbackend.interface.Unversioned(
-        audbackend.backend.FileSystem(tmpdir, "repo")
-    )
-    interface_bad = audbackend.interface.Unversioned(BadChecksumBackend(tmpdir, "repo"))
+    audbackend.backend.FileSystem.create(tmpdir, "repo")
+    file_system_backend = audbackend.backend.FileSystem(tmpdir, "repo")
+    file_system_backend.open()
+    bad_checksum_backend = BadChecksumBackend(tmpdir, "repo")
+    bad_checksum_backend.open()
+
+    interface = audbackend.interface.Unversioned(file_system_backend)
+    interface_bad = audbackend.interface.Unversioned(bad_checksum_backend)
 
     with pytest.raises(InterruptedError, match=error_msg):
         interface_bad.put_file(path, "/remote.txt", validate=True)

--- a/tests/test_interface_versioned.py
+++ b/tests/test_interface_versioned.py
@@ -1163,10 +1163,14 @@ def test_validate(tmpdir):
     path = audeer.touch(tmpdir, "~.txt")
     error_msg = "Execution is interrupted because"
 
-    interface = audbackend.interface.Versioned(
-        audbackend.backend.FileSystem(tmpdir, "repo")
-    )
-    interface_bad = audbackend.interface.Versioned(BadChecksumBackend(tmpdir, "repo"))
+    audbackend.backend.FileSystem.create(tmpdir, "repo")
+    file_system_backend = audbackend.backend.FileSystem(tmpdir, "repo")
+    file_system_backend.open()
+    bad_checksum_backend = BadChecksumBackend(tmpdir, "repo")
+    bad_checksum_backend.open()
+
+    interface = audbackend.interface.Versioned(file_system_backend)
+    interface_bad = audbackend.interface.Versioned(bad_checksum_backend)
 
     with pytest.raises(InterruptedError, match=error_msg):
         interface_bad.put_file(path, "/remote.txt", "1.0.0", validate=True)


### PR DESCRIPTION
Closes #216 

This adds a new `opened` attribute to the backends to track if the backend is currently open or not:

![image](https://github.com/audeering/audbackend/assets/173624/b1160462-54aa-473d-b3c4-23994aacc8c1)

In addition, every backend method that needs access to the actual backend (e.g. `sep()` does not need this), now raises a `RuntimeError` if the backend is not opened.

Example "Raises" section for the new `RuntimeError` that is raised when the backend was not opened:

![image](https://github.com/audeering/audbackend/assets/173624/ff0a444f-1fe3-4f27-a6de-1fccb7c52531)

![image](https://github.com/audeering/audbackend/assets/173624/53720f1f-2976-47e3-8547-bd479278f383)