### PR TITLE
Deprecate audbackend.Repository

### DIFF
--- a/audbackend/core/repository.py
+++ b/audbackend/core/repository.py
@@ -1,3 +1,9 @@
+import audeer
+
+
+@audeer.deprecated(
+    removal_version="2.2.0",
+)
 class Repository:
     r"""Repository object.
 
@@ -7,14 +13,19 @@ class Repository:
     host,
     and backend.
 
+    .. Warning::
+
+        ``audbackend.Repository`` is deprecated
+        and will be removed in version 2.2.0.
+        If an application requires
+        repository objects,
+        that assign string names to backends,
+        they should be provided by the application.
+
     Args:
         name: repository name
         host: repository host
         backend: repository backend
-
-    Examples:
-        >>> Repository("data-local", "/data", "file-system")
-        Repository('data-local', '/data', 'file-system')
 
     """
 

--- a/audbackend/core/repository.py
+++ b/audbackend/core/repository.py
@@ -39,10 +39,7 @@ class Repository:
         self.backend = backend
         r"""Repository backend."""
 
-        message = (
-            "audbackend.Repository is deprecated and will be removed "
-            "with version 2.2.0."
-        )
+        message = "Repository is deprecated and will be removed with version 2.2.0."
         warnings.warn(message, category=UserWarning, stacklevel=2)
 
     def __repr__(self):  # noqa: D105

--- a/audbackend/core/repository.py
+++ b/audbackend/core/repository.py
@@ -1,9 +1,6 @@
-import audeer
+import warnings
 
 
-@audeer.deprecated(
-    removal_version="2.2.0",
-)
 class Repository:
     r"""Repository object.
 
@@ -41,6 +38,12 @@ class Repository:
         r"""Repository host."""
         self.backend = backend
         r"""Repository backend."""
+
+        message = (
+            "audbackend.Repository is deprecated and will be removed "
+            "with version 2.2.0."
+        )
+        warnings.warn(message, category=UserWarning, stacklevel=2)
 
     def __repr__(self):  # noqa: D105
         return (

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -13,3 +13,4 @@ def test_repository():
     assert repo.name == name
     assert repo.host == host
     assert repo.backend == backend
+    assert repo.__repr__() == f"Repository('{name}', '{host}', '{backend}')"

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,0 +1,15 @@
+import pytest
+
+import audbackend
+
+
+def test_repository():
+    name = "name"
+    host = "host"
+    backend = "backend"
+    msg = "Repository is deprecated and will be removed with version 2.2.0."
+    with pytest.warns(UserWarning, match=msg):
+        repo = audbackend.Repository(name, host, backend)
+    assert repo.name == name
+    assert repo.host == host
+    assert repo.backend == backend


### PR DESCRIPTION
Deprecates `audbackend.Repository` as we have deprecated the usage of string names for backends as well.
If an application needs this feature it should be implemented by the application, see https://github.com/audeering/audb/pull/386 for an example.

Due to https://github.com/audeering/audeer/issues/145, I don't use `audeer.deprecated()` to mark the class as deprecated.

![image](https://github.com/audeering/audbackend/assets/173624/e5164cf1-7994-4f40-9472-195a3327588c)
