### PR TITLE
Implement Artifactory._close()

### DIFF
--- a/audbackend/core/backend/artifactory.py
+++ b/audbackend/core/backend/artifactory.py
@@ -178,7 +178,7 @@ class Artifactory(Base):
 
     def _close(
         self,
-    ):  # pragma: no cover
+    ):
         r"""Close connection to repository.
 
         An error should be raised,

--- a/audbackend/core/backend/artifactory.py
+++ b/audbackend/core/backend/artifactory.py
@@ -3,6 +3,7 @@ import typing
 
 import artifactory
 import dohq_artifactory
+import requests
 
 import audeer
 
@@ -94,6 +95,9 @@ class Artifactory(Base):
         # when opening the backend.
         self._repo = None
 
+        # Store request.Session as handed to ArtifactoryPath
+        self._session = None
+
     @classmethod
     def get_authentication(cls, host: str) -> typing.Tuple[str, str]:
         """Username and password/access token for given host.
@@ -172,6 +176,19 @@ class Artifactory(Base):
         checksum = artifactory.ArtifactoryPath.stat(path).md5
         return checksum
 
+    def _close(
+        self,
+    ):  # pragma: no cover
+        r"""Close connection to repository.
+
+        An error should be raised,
+        if the connection to the backend
+        cannot be closed.
+
+        """
+        if self._session is not None:
+            self._session.close()
+
     def _collapse(
         self,
         path,
@@ -204,7 +221,9 @@ class Artifactory(Base):
         self,
     ):
         r"""Access existing repository."""
-        path = artifactory.ArtifactoryPath(self.host, auth=self.authentication)
+        session = requests.Session()
+        session.auth = self.authentication
+        path = artifactory.ArtifactoryPath(self.host, session=session)
         repo = dohq_artifactory.RepositoryLocal(
             path,
             self.repository,
@@ -213,6 +232,7 @@ class Artifactory(Base):
         if repo.path.exists():
             utils.raise_file_exists_error(str(repo.path))
         repo.create()
+        session.close()
 
     def _date(
         self,
@@ -280,7 +300,9 @@ class Artifactory(Base):
         self,
     ):
         r"""Open connection to backend."""
-        path = artifactory.ArtifactoryPath(self.host, auth=self.authentication)
+        self._session = requests.Session()
+        self._session.auth = self.authentication
+        path = artifactory.ArtifactoryPath(self.host, session=self._session)
         self._repo = path.find_repository(self.repository)
         if self._repo is None:
             utils.raise_file_not_found_error(self.repository)

--- a/audbackend/core/backend/artifactory.py
+++ b/audbackend/core/backend/artifactory.py
@@ -221,18 +221,17 @@ class Artifactory(Base):
         self,
     ):
         r"""Access existing repository."""
-        session = requests.Session()
-        session.auth = self.authentication
-        path = artifactory.ArtifactoryPath(self.host, session=session)
-        repo = dohq_artifactory.RepositoryLocal(
-            path,
-            self.repository,
-            package_type=dohq_artifactory.RepositoryLocal.GENERIC,
-        )
-        if repo.path.exists():
-            utils.raise_file_exists_error(str(repo.path))
-        repo.create()
-        session.close()
+        with requests.Session() as session:
+            session.auth = self.authentication
+            path = artifactory.ArtifactoryPath(self.host, session=session)
+            repo = dohq_artifactory.RepositoryLocal(
+                path,
+                self.repository,
+                package_type=dohq_artifactory.RepositoryLocal.GENERIC,
+            )
+            if repo.path.exists():
+                utils.raise_file_exists_error(str(repo.path))
+            repo.create()
 
     def _date(
         self,


### PR DESCRIPTION
In https://github.com/audeering/audbackend/pull/204 we introduced the backend methods `open()` and `close()` that can be used to establish a connection to a backend. Those are of course also good candidates for handling authentication, if needed by a backend, which we added for `audbackend.backend.Artifactory` in https://github.com/audeering/audbackend/pull/215.

In `audbackend.backend.Artifactory.open()` we store an `artifactory.ArtifactoryPath` object as `audbackend.backend.Artifactory._repo`, which is an opened connection to the repository. But `artifactory.ArtifactoryPath` does not provide a method to close the connection (maybe this is also not needed?).
In the corresponding documentation it is stated that the connection can also be handled by a `requests.Session`, see https://github.com/devopshq/artifactory?tab=readme-ov-file#session, which has the advantage that it provides a `close()` method.

In this pull request, I make use of `requests.Session.close()` and add `audbackend.backend.Artifactory._close()` that calls it to terminate the connection to the Artifactory repository. The session object is stored as `audbackend.backend.Artifactory._session`. I benchmarked the changes when loading emodb as in https://github.com/audeering/audb/issues/387#issuecomment-2071636778, and found no difference in performance.

/cc @frankenjoe 