### PR TITLE
TST: catch Artifactory error during tear down

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import getpass
 import os
 
+import dohq_artifactory
 import pytest
 
 import audeer
@@ -94,7 +95,17 @@ def interface(tmpdir_factory, request):
         yield interface
 
         if artifactory:
-            backend._repo.delete()
+            try:
+                backend._repo.delete()
+            except dohq_artifactory.exception.ArtifactoryException:
+                # It might happen from time to time,
+                # that a repository cannot be deleted.
+                # In those cases,
+                # we don't raise an error here,
+                # but rely on the user calling the clean up script
+                # from time to time:
+                # $ python tests/misc/cleanup_artifactory.py
+                pass
 
     if not artifactory:
         backend_cls.delete(host, repository)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 import getpass
 import os
 
-import dohq_artifactory
 import pytest
 
 import audeer
@@ -95,6 +94,8 @@ def interface(tmpdir_factory, request):
         yield interface
 
         if artifactory:
+            import dohq_artifactory
+
             try:
                 backend._repo.delete()
             except dohq_artifactory.exception.ArtifactoryException:


### PR DESCRIPTION
This catches an error during the deletion of a repository on an Artifactory backend during tear down of the tests,
to avoid [errors like](https://github.com/audeering/audbackend/actions/runs/8985242819/job/24678823836?pr=224):

![image](https://github.com/audeering/audbackend/assets/173624/a62cb8c1-edfa-4abc-89fa-d3e0398d657d)
