### PR TITLE
Speedup audbackend.interface.Maven.ls()

### DIFF
--- a/audbackend/core/interface/maven.py
+++ b/audbackend/core/interface/maven.py
@@ -170,7 +170,7 @@ class Maven(Versioned):
                 suppress_backend_errors=suppress_backend_errors,
             )
             # Files are also stored as sub-folder,
-            # e.g. `/<name>/<version>/<name>-<version><ext>`,
+            # e.g. `.../<name>/<version>/<name>-<version><ext>`,
             # so we need to skip those
             sub_paths = len(path.split("/")) - 2
             if sub_paths > 0:
@@ -183,15 +183,15 @@ class Maven(Versioned):
             name, ext = self._split_ext(file)
 
             # Use unversioned backend interface
-            # to limit search to the single folder `/<root>/<name>/`.
+            # to limit search to the single folder `<root>/<name>/`.
             # It will return entries in the form
-            # `/<root>/<name>/<version>/<name>-<version><ext>`
+            # `<root>/<name>/<version>/<name>-<version><ext>`
             paths = self._unversioned.ls(
                 self._unversioned.join(root, name, self.sep),
                 suppress_backend_errors=suppress_backend_errors,
             )
 
-            # filter for '/<root>/<name>/<version>/<name>-x.x.x<ext>'
+            # filter for '<root>/<name>/<version>/<name>-x.x.x<ext>'
             depth = root.count("/") + 2
             match = re.compile(rf"{name}-\d+\.\d+.\d+{ext}")
             paths = [

--- a/audbackend/core/interface/maven.py
+++ b/audbackend/core/interface/maven.py
@@ -8,7 +8,6 @@ import audeer
 from audbackend.core import utils
 from audbackend.core.backend.base import Base as Backend
 from audbackend.core.errors import BackendError
-from audbackend.core.interface.unversioned import Unversioned
 from audbackend.core.interface.versioned import Versioned
 
 
@@ -89,7 +88,6 @@ class Maven(Versioned):
         super().__init__(backend)
         self.extensions = extensions
         self.regex = regex
-        self._unversioned = Unversioned(backend)
 
     def ls(
         self,
@@ -182,12 +180,12 @@ class Maven(Versioned):
             root, file = self.split(path)
             name, ext = self._split_ext(file)
 
-            # Use unversioned backend interface
-            # to limit search to the single folder `<root>/<name>/`.
+            # Look inside `<root>/<name>/`
+            # for available versions.
             # It will return entries in the form
             # `<root>/<name>/<version>/<name>-<version><ext>`
-            paths = self._unversioned.ls(
-                self._unversioned.join(root, name, self.sep),
+            paths = self.backend.ls(
+                self.backend.join(root, name, self.sep),
                 suppress_backend_errors=suppress_backend_errors,
             )
 


### PR DESCRIPTION
In its current implementation, the execution time of `audbackend.interface.Maven.ls()` **scales with the content of the repository / sub-folder**, as it first collects all files given under root or a sub-folder, and limits the results only afterwards for the requested file.

As all versioned belonging to a file are stored in the the sub-folder `<root>/<name>/` there is no need for this. In this pull request, I use `ls()` of the underlying backend object to inspect the content of that folder and hence speed up the execution time.