### PR TITLE
CI: update publish action to Node.js 20

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,7 @@ jobs:
         python -m sphinx docs/ docs/_build/ -b html
 
     - name: Deploy documentation to Github pages
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs/_build


### PR DESCRIPTION
As can be seen at 

![image](https://github.com/audeering/audbackend/assets/173624/a8693471-f7c6-4023-a66e-05235a8b7561)

I forgot to update the `peaceiris/actions-gh-pages` action in https://github.com/audeering/audbackend/pull/201