### PR TITLE
Add audbackend.backend.Minio

### DIFF
--- a/audbackend/backend/__init__.py
+++ b/audbackend/backend/__init__.py
@@ -7,6 +7,6 @@ try:
 except ImportError:  # pragma: no cover
     pass
 try:
-    from audbackend.core.backend.minio import MinIO
+    from audbackend.core.backend.minio import Minio
 except ImportError:  # pragma: no cover
     pass

--- a/audbackend/backend/__init__.py
+++ b/audbackend/backend/__init__.py
@@ -6,3 +6,7 @@ try:
     from audbackend.core.backend.artifactory import Artifactory
 except ImportError:  # pragma: no cover
     pass
+try:
+    from audbackend.core.backend.minio import MinIO
+except ImportError:  # pragma: no cover
+    pass

--- a/audbackend/core/api.py
+++ b/audbackend/core/api.py
@@ -233,3 +233,11 @@ with warnings.catch_warnings():
         register("artifactory", Artifactory)
     except ImportError:  # pragma: no cover
         pass
+
+    # Register optional backends
+    try:
+        from audbackend.core.backend.minio import Minio
+
+        register("minio", Minio)
+    except ImportError:  # pragma: no cover
+        pass

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -180,6 +180,9 @@ class Minio(Base):
     ) -> bool:
         r"""Check if file exists on backend."""
         path = self.path(path)
+        if path == "":
+            # Return True for root
+            return True
         try:
             self._client.stat_object(self.repository, path)
         except minio.error.S3Error:

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -138,7 +138,7 @@ class Minio(Base):
         src_path = self.path(src_path)
         dst_path = self.path(dst_path)
         # `copy_object()` has a maximum size limit of 5GB.
-        if self._size(src_path) / 1024 / 1024 / 1024 > 5:
+        if self._size(src_path) / 1024 / 1024 / 1024 >= 5:
             with tempfile.TemporaryDirectory() as tmp_dir:
                 tmp_path = audeer.path(tmp_dir, os.path.basename(src_path))
                 self._get_file(src_path, tmp_path, verbose)

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -288,8 +288,8 @@ class Minio(Base):
                             dst_fp.write(data)
                             dst_size += n_data
                             pbar.update(n_data)
-            except Exception as e:  # pragma: nocover
-                raise RuntimeError(f"Error downloading file: {e}")  # pragma: nocover
+            except Exception as e:  # pragma: no cover
+                raise RuntimeError(f"Error downloading file: {e}")
             finally:
                 response.close()
                 response.release_conn()

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -30,8 +30,10 @@ class Minio(Base):
             when using TLS for the connection,
             and ``False`` otherwise,
             e.g. when using a `local MinIO server`_.
+        **kwargs: keyword arguments passed on to `minio.Minio`_
 
     .. _local MinIO server: https://min.io/docs/minio/container/index.html
+    .. _minio.Minio: https://min.io/docs/minio/linux/developers/python/API.html
 
     Examples:
         >>> host = "play.min.io"  # playground provided by https://min.io

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -1,4 +1,5 @@
 import configparser
+import mimetypes
 import os
 import tempfile
 import typing
@@ -369,7 +370,13 @@ class Minio(Base):
             )
             print(desc, end="\r")
 
-        self._client.fput_object(self.repository, dst_path, src_path)
+        content_type = mimetypes.guess_type(src_path)[0] or "application/octet-stream"
+        self._client.fput_object(
+            self.repository,
+            dst_path,
+            src_path,
+            content_type=content_type,
+        )
 
         if verbose:  # pragma: no cover
             # Clear progress line

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -1,0 +1,321 @@
+import configparser
+import os
+import typing
+
+import minio
+
+import audeer
+
+from audbackend.core import utils
+from audbackend.core.backend.base import Base
+
+
+class MinIO(Base):
+    r"""Backend for MinIO.
+
+    Args:
+        host: host address
+        repository: repository name
+        authentication: username, password / API key / access token tuple.
+            If ``None``,
+            it requests it by calling :meth:`get_authentication`
+
+    """  # noqa: E501
+
+    def __init__(
+        self,
+        host: str,
+        repository: str,
+        *,
+        authentication: typing.Tuple[str, str] = None,
+    ):
+        super().__init__(host, repository, authentication=authentication)
+
+        if authentication is None:
+            self.authentication = self.get_authentication(host)
+
+        # Open MinIO client
+        self._client = minio.MinIO(
+            host,
+            access_key=self.authentication[0],
+            secret_key=self.authentication[1],
+            secure=False,  # change later
+        )
+
+    @classmethod
+    def get_authentication(cls, host: str) -> typing.Tuple[str, str]:
+        """Username and password/access token for given host.
+
+        Returns a authentication for MinIO server
+        as tuple.
+
+        To get the authentication tuple,
+        the function looks first
+        for the two environment variables
+        ``MINIO_ACCESS_KEY`` and
+        ``MINIO_SECRET_KEY``.
+        Otherwise,
+        it tries to extract missing values
+        from a config file.
+        The default path of the config file
+        (:file:`~/.config/audbackend/minio.cfg`)
+        can be overwritten with the environment variable
+        ``MINIO_CONFIG_FILE``.
+        If no config file exists
+        or if it does not contain an
+        entry for ``access_key``,
+        the access key is set to ``"anonymous"``
+        and the secret key to an empty string.
+
+        Args:
+            host: hostname
+
+        Returns:
+            access token tuple
+
+        """
+        access_key = os.getenv("MINIO_ACCESS_KEY", None)
+        secret_key = os.getenv("MINIO_SECRET_KEY", None)
+        config_file = os.getenv("MINIO_CONFIG_FILE", "~/.config/audbackend/minio.cfg")
+        config_file = audeer.path(config_file)
+
+        if os.path.exists(config_file) and (access_key is None or secret_key is None):
+            config = configparser.ConfigParser(allow_no_value=True)
+            config.read(config_file)
+            if access_key is None:
+                access_key = config.get("minio", "access_key")
+            if secret_key is None:
+                secret_key = config.get("minio", "secret_key")
+
+        return access_key, secret_key
+
+    def _checksum(
+        self,
+        path: str,
+    ) -> str:
+        r"""MD5 checksum of file on backend."""
+        path = self.path(path)
+        checksum = self._client.stat_object(self.repository, path).etag
+        return checksum
+
+    def _close(
+        self,
+    ):
+        r"""Close connection to repository.
+
+        An error should be raised,
+        if the connection to the backend
+        cannot be closed.
+
+        """
+        # At the moment, this is automatically handled.
+
+    def _collapse(
+        self,
+        path,
+    ):
+        r"""Convert to virtual path.
+
+        <path>
+        ->
+        /<path>
+
+        """
+        path = "/" + path
+        path = path.replace("/", self.sep)
+        return path
+
+    def _copy_file(
+        self,
+        src_path: str,
+        dst_path: str,
+        verbose: bool,
+    ):
+        r"""Copy file on backend."""
+        src_path = self.path(src_path)
+        dst_path = self.path(dst_path)
+        # This has a maximum size limit of 5GB.
+        stats = self._client.stat_object(self.repository, src_path)
+        if stats.size / 1024 / 1024 / 1024 > 5:
+            # TODO: implement copying with temporary file
+            pass
+        else:
+            self._client.copy_object(
+                self.repository,
+                src_path,
+                minio.commonconfig.CopySource(self.repository, dst_path),
+            )
+
+    def _create(
+        self,
+    ):
+        r"""Create repository."""
+        if self._client.bucket_exists(self.repository):
+            utils.raise_file_exists_error(self.repository)
+        self._client.make_bucket(self.repository)
+
+    def _date(
+        self,
+        path: str,
+    ) -> str:
+        r"""Get last modification date of file on backend."""
+        path = self.path(path)
+        date = self.client.stat_object(self.repository, path).last_modified
+        date = utils.date_format(date)
+        return date
+
+    def _delete(
+        self,
+    ):
+        r"""Delete repository and all its content."""
+        self._client.remove_bucket(self.repository)
+
+    def _exists(
+        self,
+        path: str,
+    ) -> bool:
+        r"""Check if file exists on backend."""
+        path = self.path(path)
+        try:
+            self._client.stat_object(self.repository, path)
+        except minio.error.S3Error:
+            return False
+        return True
+
+    def _get_file(
+        self,
+        src_path: str,
+        dst_path: str,
+        verbose: bool,
+    ):
+        r"""Get file from backend."""
+        src_path = self.path(src_path)
+        src_size = self._client.stat_object(self.repository, src_path).size
+        chunk = (4 * 1024,)
+        with audeer.progress_bar(total=src_size, disable=not verbose) as pbar:
+            desc = audeer.format_display_message(
+                "Download {}".format(os.path.basename(str(src_path))),
+                pbar=True,
+            )
+            pbar.set_description_str(desc)
+            pbar.refresh()
+
+            dst_size = 0
+            try:
+                response = self.client.get_object(self.repository, src_path)
+                with open(dst_path, "wb") as dst_fp:
+                    while src_size > dst_size:
+                        data = response.read(chunk)
+                        n_data = len(data)
+                        if n_data > 0:
+                            dst_fp.write(data)
+                            dst_size += n_data
+                            pbar.update(n_data)
+            finally:
+                response.close()
+                response.release_conn()
+
+    def _ls(
+        self,
+        path: str,
+    ) -> typing.List[str]:
+        r"""List all files under sub-path."""
+        if not self._exists(path):
+            return []
+
+        path = self.path(path)
+        objects = self._client.list_objects(
+            self.repository,
+            prefix=path,
+            recursive=True,
+        )
+        paths = [self._collapse(obj.object_name) for obj in objects]
+
+        return paths
+
+    def _move_file(
+        self,
+        src_path: str,
+        dst_path: str,
+        verbose: bool,
+    ):
+        r"""Move file on backend."""
+        src_path = self.path(src_path)
+        dst_path = self.path(dst_path)
+        if not dst_path.parent.exists():
+            dst_path.parent.mkdir()
+        src_path.move(dst_path)
+
+    def _open(
+        self,
+    ):
+        r"""Open connection to backend."""
+        # At the moment, session management is handled automatically.
+        # If we want to manage this ourselves,
+        # we need to use the `http_client` argument of `minio.MinIO`
+        if not self._client.bucket_exists(self.repository):
+            utils.raise_file_not_found_error(self.repository)
+
+    def _owner(
+        self,
+        path: str,
+    ) -> str:
+        r"""Get owner of file on backend."""
+        path = self.path(path)
+        # TODO: owner seems to be empty,
+        # need to check if we have to manage this ourselves?
+        owner = self._client.stat_object(self.repository, path).owner_name
+        return owner
+
+    def path(
+        self,
+        path: str,
+    ) -> str:
+        r"""Convert to backend path.
+
+        This extends the relative ``path`` on the backend
+        by :attr:`host` and :attr:`repository`,
+        and returns an :class:`artifactory.ArtifactoryPath` object.
+
+        Args:
+            path: path on backend
+
+        Returns:
+            Artifactory path object
+
+        """
+        path = path.replace(self.sep, "/")
+        if path.startswith("/"):
+            # /path -> path
+            path = path[1:]
+        return path
+
+    def _put_file(
+        self,
+        src_path: str,
+        dst_path: str,
+        checksum: str,
+        verbose: bool,
+    ):
+        r"""Put file to backend."""
+        dst_path = self.path(dst_path)
+        if verbose:  # pragma: no cover
+            desc = audeer.format_display_message(
+                f"Deploy {src_path}",
+                pbar=False,
+            )
+            print(desc, end="\r")
+
+        self._client.fput_object(self.repository, dst_path, src_path)
+
+        if verbose:  # pragma: no cover
+            # Clear progress line
+            print(audeer.format_display_message(" ", pbar=False), end="\r")
+
+    def _remove_file(
+        self,
+        path: str,
+    ):
+        r"""Remove file from backend."""
+        path = self.path(path)
+        self._client.remove_object(self.repository, path)

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -40,7 +40,10 @@ class Minio(Base):
             host,
             access_key=self.authentication[0],
             secret_key=self.authentication[1],
-            secure=False,  # change later
+            # If you test on a local machine,
+            # `secure` needs to be set to `False`.
+            # We might want to read this from a config file?
+            # secure=False,
         )
 
     @classmethod

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -21,6 +21,21 @@ class Minio(Base):
             If ``None``,
             it requests it by calling :meth:`get_authentication`
 
+    Examples:
+        >>> host = "play.min.io"  # playground provided by https://min.io
+        >>> auth = ("Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
+        >>> repository = "my-data" + audeer.uid()
+        >>> Minio.create(host, repository, authentication=auth)
+        >>> file = audeer.touch("file.txt")
+        >>> backend = Minio(host, repository, authentication=auth)
+        >>> try:
+        ...     with backend:
+        ...         backend.put_file(file, "/sub/file.txt")
+        ...         backend.ls()
+        ... finally:
+        ...     Minio.delete(host, repository, authentication=auth)
+        ['/sub/file.txt']
+
     """  # noqa: E501
 
     def __init__(

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -334,11 +334,8 @@ class Minio(Base):
         # NOTE:
         # we use a custom metadata entry to track the owner
         # as stats.owner_name is always empty.
-        owner = ""
-        stats = self._client.stat_object(self.repository, path)
-        if "x-amz-meta-owner" in stats.metadata:
-            owner = stats.metadata["x-amz-meta-owner"]
-        return owner
+        meta = self._client.stat_object(self.repository, path).metadata
+        return meta["x-amz-meta-owner"] if "x-amz-meta-owner" in meta else ""
 
     def path(
         self,

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -20,6 +20,17 @@ class Minio(Base):
         authentication: username, password / access key, secret key token tuple.
             If ``None``,
             it requests it by calling :meth:`get_authentication`
+        secure: if ``None``,
+            it looks in the config file for it,
+            compare :meth:`get_config`.
+            If it cannot find a matching entry,
+            it defaults to ``True``.
+            Needs to be ``True``
+            when using TLS for the connection,
+            and ``False`` otherwise,
+            e.g. when using a `local MinIO server`_.
+
+    .. _local MinIO server: https://min.io/docs/minio/container/index.html
 
     Examples:
         >>> host = "play.min.io"  # playground provided by https://min.io
@@ -44,20 +55,23 @@ class Minio(Base):
         repository: str,
         *,
         authentication: typing.Tuple[str, str] = None,
+        secure: bool = None,
     ):
         super().__init__(host, repository, authentication=authentication)
 
         if authentication is None:
             self.authentication = self.get_authentication(host)
 
-        config = self.get_config(host)
+        if secure is None:
+            config = self.get_config(host)
+            secure = config.get("secure", True)
 
         # Open MinIO client
         self._client = minio.Minio(
             host,
             access_key=self.authentication[0],
             secret_key=self.authentication[1],
-            secure=config.get("secure", True),
+            secure=secure,
         )
 
     @classmethod

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -288,6 +288,8 @@ class Minio(Base):
                             dst_fp.write(data)
                             dst_size += n_data
                             pbar.update(n_data)
+            except Exception as e:
+                raise RuntimeError(f"Error downloading file: {e}")
             finally:
                 response.close()
                 response.release_conn()

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -56,6 +56,7 @@ class Minio(Base):
         *,
         authentication: typing.Tuple[str, str] = None,
         secure: bool = None,
+        **kwargs,
     ):
         super().__init__(host, repository, authentication=authentication)
 
@@ -72,6 +73,7 @@ class Minio(Base):
             access_key=self.authentication[0],
             secret_key=self.authentication[1],
             secure=secure,
+            **kwargs,
         )
 
     @classmethod

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -288,7 +288,7 @@ class Minio(Base):
                             dst_fp.write(data)
                             dst_size += n_data
                             pbar.update(n_data)
-            except Exception as e:
+            except Exception as e:  # pragma: nocover
                 raise RuntimeError(f"Error downloading file: {e}")
             finally:
                 response.close()

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -227,9 +227,6 @@ class Minio(Base):
         path: str,
     ) -> typing.List[str]:
         r"""List all files under sub-path."""
-        if not self._exists(path):
-            return []
-
         path = self.path(path)
         objects = self._client.list_objects(
             self.repository,

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -109,8 +109,8 @@ class Minio(Base):
 
         """
         config = cls.get_config(host)
-        access_key = os.getenv("MINIO_ACCESS_KEY", config.get("access_key", None))
-        secret_key = os.getenv("MINIO_SECRET_KEY", config.get("secret_key", None))
+        access_key = os.getenv("MINIO_ACCESS_KEY", config.get("access_key"))
+        secret_key = os.getenv("MINIO_SECRET_KEY", config.get("secret_key"))
 
         return access_key, secret_key
 

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -399,6 +399,8 @@ class Minio(Base):
     ):
         r"""Remove file from backend."""
         path = self.path(path)
+        # Enforce error if path does not exist
+        self._client.stat_object(self.repository, path)
         self._client.remove_object(self.repository, path)
 
     def _size(

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -406,7 +406,7 @@ class Minio(Base):
     def _size(
         self,
         path: str,
-    ) -> str:
+    ) -> int:
         r"""Get size of file on backend."""
         path = self.path(path)
         size = self._client.stat_object(self.repository, path).size

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -159,6 +159,19 @@ class Minio(Base):
 
         return config
 
+    def close(
+        self,
+    ):
+        r"""Close connection to backend.
+
+        This will only change the status of
+        :attr:`audbackend.backend.Minio.opened`
+        as Minio handles closing the session itself.
+
+        """
+        if self.opened:
+            self.opened = False
+
     def _checksum(
         self,
         path: str,
@@ -167,18 +180,6 @@ class Minio(Base):
         path = self.path(path)
         checksum = self._client.stat_object(self.repository, path).etag
         return checksum
-
-    def _close(
-        self,
-    ):
-        r"""Close connection to repository.
-
-        An error should be raised,
-        if the connection to the backend
-        cannot be closed.
-
-        """
-        # At the moment, this is automatically handled.
 
     def _collapse(
         self,

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -178,8 +178,7 @@ class Minio(Base):
     ) -> str:
         r"""MD5 checksum of file on backend."""
         path = self.path(path)
-        checksum = self._client.stat_object(self.repository, path).etag
-        return checksum
+        return self._client.stat_object(self.repository, path).etag
 
     def _collapse(
         self,
@@ -192,9 +191,8 @@ class Minio(Base):
         /<path>
 
         """
-        path = "/" + path
-        path = path.replace("/", self.sep)
-        return path
+        path = f"/{path}"
+        return path.replace("/", self.sep)
 
     def _copy_file(
         self,
@@ -274,8 +272,7 @@ class Minio(Base):
         chunk = 4 * 1024
         with audeer.progress_bar(total=src_size, disable=not verbose) as pbar:
             desc = audeer.format_display_message(
-                "Download {}".format(os.path.basename(str(src_path))),
-                pbar=True,
+                f"Download {os.path.basename(str(src_path))}", pbar=True
             )
             pbar.set_description_str(desc)
             pbar.refresh()
@@ -306,9 +303,7 @@ class Minio(Base):
             prefix=path,
             recursive=True,
         )
-        paths = [self._collapse(obj.object_name) for obj in objects]
-
-        return paths
+        return [self._collapse(obj.object_name) for obj in objects]
 
     def _move_file(
         self,

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -111,9 +111,9 @@ class Minio(Base):
         expects one section per host,
         e.g.
 
-        .. code-block:: config
+        .. code-block:: ini
 
-            ["play.min.io"]
+            [play.min.io]
             access_key = "Q3AM3UQ867SPQQA43P2F"
             secret_key = "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG"
 

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -206,7 +206,8 @@ class Minio(Base):
         src_path = self.path(src_path)
         dst_path = self.path(dst_path)
         # `copy_object()` has a maximum size limit of 5GB.
-        if self._size(src_path) / 1024 / 1024 / 1024 >= 5:
+        # We use 4.9GB to have some headroom
+        if self._size(src_path) / 1024 / 1024 / 1024 >= 4.9:
             with tempfile.TemporaryDirectory() as tmp_dir:
                 tmp_path = audeer.path(tmp_dir, os.path.basename(src_path))
                 self._get_file(src_path, tmp_path, verbose)

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -17,7 +17,7 @@ class Minio(Base):
     Args:
         host: host address
         repository: repository name
-        authentication: username, password / API key / access token tuple.
+        authentication: username, password / access key, secret key token tuple.
             If ``None``,
             it requests it by calling :meth:`get_authentication`
 
@@ -45,7 +45,7 @@ class Minio(Base):
 
     @classmethod
     def get_authentication(cls, host: str) -> typing.Tuple[str, str]:
-        """Username and password/access token for given host.
+        """Access and secret tokens for given host.
 
         Returns a authentication for MinIO server
         as tuple.
@@ -274,15 +274,11 @@ class Minio(Base):
     ) -> str:
         r"""Convert to backend path.
 
-        This extends the relative ``path`` on the backend
-        by :attr:`host` and :attr:`repository`,
-        and returns an :class:`artifactory.ArtifactoryPath` object.
-
         Args:
             path: path on backend
 
         Returns:
-            Artifactory path object
+            path
 
         """
         path = path.replace(self.sep, "/")

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -10,7 +10,7 @@ from audbackend.core import utils
 from audbackend.core.backend.base import Base
 
 
-class MinIO(Base):
+class Minio(Base):
     r"""Backend for MinIO.
 
     Args:
@@ -35,7 +35,7 @@ class MinIO(Base):
             self.authentication = self.get_authentication(host)
 
         # Open MinIO client
-        self._client = minio.MinIO(
+        self._client = minio.Minio(
             host,
             access_key=self.authentication[0],
             secret_key=self.authentication[1],
@@ -62,10 +62,9 @@ class MinIO(Base):
         can be overwritten with the environment variable
         ``MINIO_CONFIG_FILE``.
         If no config file exists
-        or if it does not contain an
-        entry for ``access_key``,
-        the access key is set to ``"anonymous"``
-        and the secret key to an empty string.
+        or if it has missing entries,
+        ``None`` is returned
+        for the missing entries.
 
         Args:
             host: hostname
@@ -83,9 +82,9 @@ class MinIO(Base):
             config = configparser.ConfigParser(allow_no_value=True)
             config.read(config_file)
             if access_key is None:
-                access_key = config.get("minio", "access_key")
+                access_key = config.get(host, "access_key", fallback=None)
             if secret_key is None:
-                secret_key = config.get("minio", "secret_key")
+                secret_key = config.get(host, "secret_key", fallback=None)
 
         return access_key, secret_key
 
@@ -252,7 +251,7 @@ class MinIO(Base):
         r"""Open connection to backend."""
         # At the moment, session management is handled automatically.
         # If we want to manage this ourselves,
-        # we need to use the `http_client` argument of `minio.MinIO`
+        # we need to use the `http_client` argument of `minio.Minio`
         if not self._client.bucket_exists(self.repository):
             utils.raise_file_not_found_error(self.repository)
 

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -289,7 +289,7 @@ class Minio(Base):
                             dst_size += n_data
                             pbar.update(n_data)
             except Exception as e:  # pragma: nocover
-                raise RuntimeError(f"Error downloading file: {e}")
+                raise RuntimeError(f"Error downloading file: {e}")  # pragma: nocover
             finally:
                 response.close()
                 response.release_conn()

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -1,4 +1,5 @@
 import configparser
+import getpass
 import mimetypes
 import os
 import tempfile
@@ -215,6 +216,7 @@ class Minio(Base):
                 self.repository,
                 dst_path,
                 minio.commonconfig.CopySource(self.repository, src_path),
+                metadata=_metadata(),
             )
 
     def _create(
@@ -332,9 +334,13 @@ class Minio(Base):
     ) -> str:
         r"""Get owner of file on backend."""
         path = self.path(path)
-        # TODO: owner seems to be empty,
-        # need to check if we have to manage this ourselves?
-        owner = self._client.stat_object(self.repository, path).owner_name
+        # NOTE:
+        # we use a custom metadata entry to track the owner
+        # as stats.owner_name is always empty.
+        owner = ""
+        stats = self._client.stat_object(self.repository, path)
+        if "x-amz-meta-owner" in stats.metadata:
+            owner = stats.metadata["x-amz-meta-owner"]
         return owner
 
     def path(
@@ -378,6 +384,7 @@ class Minio(Base):
             dst_path,
             src_path,
             content_type=content_type,
+            metadata=_metadata(),
         )
 
         if verbose:  # pragma: no cover
@@ -400,3 +407,13 @@ class Minio(Base):
         path = self.path(path)
         size = self._client.stat_object(self.repository, path).size
         return size
+
+
+def _metadata():
+    """Dictionary with owner entry.
+
+    When uploaded as metadata to MinIO,
+    it can be accessed under ``stat_object(...).metadata["x-amz-meta-owner"]``.
+
+    """
+    return {"owner": getpass.getuser()}

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -167,6 +167,11 @@ class Minio(Base):
         self,
     ):
         r"""Delete repository and all its content."""
+        # Delete all objects in bucket
+        objects = self._client.list_objects(self.repository, recursive=True)
+        for obj in objects:
+            self._client.remove_object(self.repository, obj.object_name)
+        # Delete bucket
         self._client.remove_bucket(self.repository)
 
     def _exists(

--- a/docs/api-src/audbackend.backend.rst
+++ b/docs/api-src/audbackend.backend.rst
@@ -14,7 +14,7 @@ backends are supported:
 
     Artifactory
     FileSystem
-    MinIO
+    Minio
 
 Users can implement their own
 backend by deriving from

--- a/docs/api-src/audbackend.backend.rst
+++ b/docs/api-src/audbackend.backend.rst
@@ -14,6 +14,7 @@ backends are supported:
 
     Artifactory
     FileSystem
+    MinIO
 
 Users can implement their own
 backend by deriving from

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,12 @@ dynamic = ['version']
 artifactory = [
     'dohq-artifactory >=0.10.0',
 ]
+minio = [
+    'minio',
+]
 all = [
     'dohq-artifactory >=0.10.0',
+    'minio',
 ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,11 @@ def owner(request):
         and backend_cls == audbackend.backend.Artifactory
     ):
         owner = backend_cls.get_authentication("audeering.jfrog.io/artifactory")[0]
+    elif (
+        hasattr(audbackend.backend, "Minio") and backend_cls == audbackend.backend.Minio
+    ):
+        # There seems to be a MinIO bug here
+        owner = None
     else:
         if os.name == "nt":
             owner = "Administrators"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,11 +77,6 @@ def owner(request):
     ):
         host_wo_https = pytest.HOSTS["artifactory"][8:]
         owner = backend_cls.get_authentication(host_wo_https)[0]
-    elif (
-        hasattr(audbackend.backend, "Minio") and backend_cls == audbackend.backend.Minio
-    ):
-        # There seems to be a MinIO bug here
-        owner = None
     else:
         if os.name == "nt":
             owner = "Administrators"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,7 +79,7 @@ def owner(request):
         owner = backend_cls.get_authentication(host_wo_https)[0]
     else:
         if os.name == "nt":
-            owner = "runneradmin"
+            owner = "Administrators"
         else:
             owner = getpass.getuser()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,7 +79,7 @@ def owner(request):
         owner = backend_cls.get_authentication(host_wo_https)[0]
     else:
         if os.name == "nt":
-            owner = "Administrators"
+            owner = "runneradmin"
         else:
             owner = getpass.getuser()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,12 @@ from singlefolder import SingleFolder
 # unittest-<session-uid>-<repository-uid>
 pytest.UID = audeer.uid()[:8]
 
+# Define static hosts
+pytest.HOSTS = {
+    "artifactory": "https://audeering.jfrog.io/artifactory",
+    "minio": "localhost:9000",
+}
+
 
 @pytest.fixture(scope="package", autouse=True)
 def register_single_folder():
@@ -31,9 +37,9 @@ def hosts(tmpdir_factory):
     return {
         # For tests based on backend names (deprecated),
         # like audbackend.access()
-        "artifactory": "https://audeering.jfrog.io/artifactory",
+        "artifactory": pytest.HOSTS["artifactory"],
         "file-system": str(tmpdir_factory.mktemp("host")),
-        "minio": "localhost:9000",
+        "minio": pytest.HOSTS["minio"],
         "single-folder": str(tmpdir_factory.mktemp("host")),
     }
 
@@ -46,7 +52,8 @@ def owner(request):
         hasattr(audbackend.backend, "Artifactory")
         and backend_cls == audbackend.backend.Artifactory
     ):
-        owner = backend_cls.get_authentication("audeering.jfrog.io/artifactory")[0]
+        host_wo_https = pytest.HOSTS["artifactory"][8:]
+        owner = backend_cls.get_authentication(host_wo_https)[0]
     elif (
         hasattr(audbackend.backend, "Minio") and backend_cls == audbackend.backend.Minio
     ):
@@ -88,11 +95,11 @@ def interface(tmpdir_factory, request):
         and backend_cls == audbackend.backend.Artifactory
     ):
         artifactory = True
-        host = "https://audeering.jfrog.io/artifactory"
+        host = pytest.HOSTS["artifactory"]
     elif (
         hasattr(audbackend.backend, "Minio") and backend_cls == audbackend.backend.Minio
     ):
-        host = "localhost:9000"
+        host = pytest.HOSTS["minio"]
     else:
         host = str(tmpdir_factory.mktemp("host"))
     repository = f"unittest-{pytest.UID}-{audeer.uid()[:8]}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,9 @@ def authentication():
         ]:
             defaults[key] = os.environ.get(key, None)
 
+        # MinIO credentials for the public read/write server
+        # at play.min.io, see
+        # https://min.io/docs/minio/linux/developers/python/minio-py.html
         os.environ["MINIO_ACCESS_KEY"] = "Q3AM3UQ867SPQQA43P2F"
         os.environ["MINIO_SECRET_KEY"] = "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,8 +18,31 @@ pytest.UID = audeer.uid()[:8]
 # Define static hosts
 pytest.HOSTS = {
     "artifactory": "https://audeering.jfrog.io/artifactory",
-    "minio": "localhost:9000",
+    "minio": "play.min.io",
 }
+
+
+@pytest.fixture(scope="package", autouse=True)
+def authentication():
+    """Provide authentication tokens for supported backends."""
+    if pytest.HOSTS["minio"] == "play.min.io":
+        defaults = {}
+        for key in [
+            "MINIO_ACCESS_KEY",
+            "MINIO_SECRET_KEY",
+        ]:
+            defaults[key] = os.environ.get(key, None)
+
+        os.environ["MINIO_ACCESS_KEY"] = "Q3AM3UQ867SPQQA43P2F"
+        os.environ["MINIO_SECRET_KEY"] = "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG"
+
+        yield
+
+        for key, value in defaults.items():
+            if value is not None:
+                os.environ[key] = value
+            elif key in os.environ:
+                del os.environ[key]
 
 
 @pytest.fixture(scope="package", autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,7 @@ def hosts(tmpdir_factory):
         # like audbackend.access()
         "artifactory": "https://audeering.jfrog.io/artifactory",
         "file-system": str(tmpdir_factory.mktemp("host")),
+        "minio": "localhost:9000",
         "single-folder": str(tmpdir_factory.mktemp("host")),
     }
 
@@ -76,14 +77,18 @@ def interface(tmpdir_factory, request):
 
     """
     backend_cls, interface_cls = request.param
+    artifactory = False
     if (
         hasattr(audbackend.backend, "Artifactory")
         and backend_cls == audbackend.backend.Artifactory
     ):
         artifactory = True
         host = "https://audeering.jfrog.io/artifactory"
+    elif (
+        hasattr(audbackend.backend, "Minio") and backend_cls == audbackend.backend.Minio
+    ):
+        host = "localhost:9000"
     else:
-        artifactory = False
         host = str(tmpdir_factory.mktemp("host"))
     repository = f"unittest-{pytest.UID}-{audeer.uid()[:8]}"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,26 +26,25 @@ pytest.HOSTS = {
 def authentication():
     """Provide authentication tokens for supported backends."""
     if pytest.HOSTS["minio"] == "play.min.io":
-        defaults = {}
-        for key in [
-            "MINIO_ACCESS_KEY",
-            "MINIO_SECRET_KEY",
-        ]:
-            defaults[key] = os.environ.get(key, None)
-
+        defaults = {
+            key: os.environ.get(key, None)
+            for key in ["MINIO_ACCESS_KEY", "MINIO_SECRET_KEY"]
+        }
         # MinIO credentials for the public read/write server
         # at play.min.io, see
         # https://min.io/docs/minio/linux/developers/python/minio-py.html
         os.environ["MINIO_ACCESS_KEY"] = "Q3AM3UQ867SPQQA43P2F"
         os.environ["MINIO_SECRET_KEY"] = "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG"
+    else:
+        defaults = {}
 
-        yield
+    yield
 
-        for key, value in defaults.items():
-            if value is not None:
-                os.environ[key] = value
-            elif key in os.environ:
-                del os.environ[key]
+    for key, value in defaults.items():
+        if value is not None:
+            os.environ[key] = value
+        elif key in os.environ:
+            del os.environ[key]
 
 
 @pytest.fixture(scope="package", autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,6 +77,13 @@ def owner(request):
     ):
         host_wo_https = pytest.HOSTS["artifactory"][8:]
         owner = backend_cls.get_authentication(host_wo_https)[0]
+    elif (
+        hasattr(audbackend.backend, "Minio") and backend_cls == audbackend.backend.Minio
+    ):
+        if os.name == "nt":
+            owner = "runneradmin"
+        else:
+            owner = getpass.getuser()
     else:
         if os.name == "nt":
             owner = "Administrators"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -20,6 +20,12 @@ import audbackend
             f"unittest-{audeer.uid()[:8]}",
             audbackend.backend.Artifactory,
         ),
+        (
+            "minio",
+            "minio",
+            f"unittest-{audeer.uid()[:8]}",
+            audbackend.backend.Minio,
+        ),
         pytest.param(  # backend does not exist
             "bad-backend",
             None,

--- a/tests/test_backend_artifactory.py
+++ b/tests/test_backend_artifactory.py
@@ -70,14 +70,14 @@ def test_authentication(tmpdir, hosts, hide_credentials):
         backend.open()
 
 
-@pytest.mark.parametrize("host", ["https://audeering.jfrog.io/artifactory"])
+@pytest.mark.parametrize("host", [pytest.HOSTS["artifactory"]])
 @pytest.mark.parametrize("repository", [f"unittest-{pytest.UID}-{audeer.uid()[:8]}"])
 def test_create_delete_repositories(host, repository):
     audbackend.backend.Artifactory.create(host, repository)
     audbackend.backend.Artifactory.delete(host, repository)
 
 
-@pytest.mark.parametrize("host", ["https://audeering.jfrog.io/artifactory"])
+@pytest.mark.parametrize("host", [pytest.HOSTS["artifactory"]])
 @pytest.mark.parametrize("repository", [f"unittest-{pytest.UID}-{audeer.uid()[:8]}"])
 @pytest.mark.parametrize("authentication", [("non-existing", "non-existing")])
 def test_errors(host, repository, authentication):

--- a/tests/test_backend_minio.py
+++ b/tests/test_backend_minio.py
@@ -89,7 +89,7 @@ def test_copy_large_file(tmpdir, interface, src_path, dst_path):
 
     ``minio.Minio.copy_object()`` has a limit of 5 GB.
     We mock the ``audbackend.backend.Minio._size()`` method
-    to return a value of ``5.01``
+    to return a value equivalent to 5 GB.
     to trigger the fall back copy mechanism for large files,
     without having to create a large file.
 
@@ -102,7 +102,7 @@ def test_copy_large_file(tmpdir, interface, src_path, dst_path):
     """
     tmp_path = audeer.touch(audeer.path(tmpdir, "big.1.txt"))
     interface.put_file(tmp_path, src_path)
-    interface._backend._size = lambda x: 5.01 * 1024 * 1024 * 1024
+    interface._backend._size = lambda x: 5 * 1024 * 1024 * 1024
     interface.copy_file(src_path, dst_path)
     assert interface.exists(src_path)
     assert interface.exists(dst_path)

--- a/tests/test_backend_minio.py
+++ b/tests/test_backend_minio.py
@@ -1,0 +1,213 @@
+import os
+
+import pytest
+
+import audeer
+
+import audbackend
+
+
+@pytest.fixture(scope="function", autouse=False)
+def hide_credentials():
+    defaults = {}
+
+    for key in [
+        "MINIO_ACCESS_KEY",
+        "MINIO_SECRET_KEY",
+        "MINIO_CONFIG_FILE",
+    ]:
+        defaults[key] = os.environ.get(key, None)
+
+    for key, value in defaults.items():
+        if value is not None:
+            del os.environ[key]
+
+    yield
+
+    for key, value in defaults.items():
+        if value is not None:
+            os.environ[key] = value
+        elif key in os.environ:
+            del os.environ[key]
+
+
+def test_authentication(tmpdir, hosts, hide_credentials):
+    host = hosts["minio"]
+    config_path = audeer.path(tmpdir, "config.cfg")
+    os.environ["MINIO_CONFIG_FILE"] = config_path
+
+    # config file does not exist
+
+    backend = audbackend.backend.Minio(host, "repository")
+    assert backend.authentication == (None, None)
+
+    # config file is empty
+
+    audeer.touch(config_path)
+    backend = audbackend.backend.Minio(host, "repository")
+    assert backend.authentication == (None, None)
+
+    # config file entry without username and password
+
+    with open(config_path, "w") as fp:
+        fp.write(f"[{host}]\n")
+
+    backend = audbackend.backend.Minio(host, "repository")
+    assert backend.authentication == (None, None)
+
+    # config file entry with username and password
+
+    access_key = "bad"
+    secret_key = "bad"
+    with open(config_path, "w") as fp:
+        fp.write(f"[{host}]\n")
+        fp.write(f"access_key = {access_key}\n")
+        fp.write(f"secret_key = {secret_key}\n")
+
+    backend = audbackend.backend.Minio(host, "repository")
+    assert backend.authentication == ("bad", "bad")
+    with pytest.raises(audbackend.BackendError):
+        backend.open()
+
+
+@pytest.mark.parametrize("host", ["localhost:9000"])
+@pytest.mark.parametrize("repository", [f"unittest-{pytest.UID}-{audeer.uid()[:8]}"])
+def test_create_delete_repositories(host, repository):
+    audbackend.backend.Minio.create(host, repository)
+    audbackend.backend.Minio.delete(host, repository)
+
+
+@pytest.mark.parametrize("host", ["localhost:9000"])
+@pytest.mark.parametrize("repository", [f"unittest-{pytest.UID}-{audeer.uid()[:8]}"])
+@pytest.mark.parametrize("authentication", [("bad-access", "bad-secret")])
+def test_errors(host, repository, authentication):
+    backend = audbackend.backend.Minio(host, repository, authentication=authentication)
+    with pytest.raises(audbackend.BackendError):
+        backend.open()
+
+
+@pytest.mark.parametrize(
+    "interface",
+    [(audbackend.backend.Minio, audbackend.interface.Maven)],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "file, version, extensions, regex, expected",
+    [
+        (
+            "/file.tar.gz",
+            "1.0.0",
+            [],
+            False,
+            "/file.tar/1.0.0/file.tar-1.0.0.gz",
+        ),
+        (
+            "/file.tar.gz",
+            "1.0.0",
+            ["tar.gz"],
+            False,
+            "/file/1.0.0/file-1.0.0.tar.gz",
+        ),
+        (
+            "/.tar.gz",
+            "1.0.0",
+            ["tar.gz"],
+            False,
+            "/.tar/1.0.0/.tar-1.0.0.gz",
+        ),
+        (
+            "/tar.gz",
+            "1.0.0",
+            ["tar.gz"],
+            False,
+            "/tar/1.0.0/tar-1.0.0.gz",
+        ),
+        (
+            "/.tar.gz",
+            "1.0.0",
+            [],
+            False,
+            "/.tar/1.0.0/.tar-1.0.0.gz",
+        ),
+        (
+            "/.tar",
+            "1.0.0",
+            [],
+            False,
+            "/.tar/1.0.0/.tar-1.0.0",
+        ),
+        (
+            "/tar",
+            "1.0.0",
+            [],
+            False,
+            "/tar/1.0.0/tar-1.0.0",
+        ),
+        # test regex
+        (
+            "/file.0.tar.gz",
+            "1.0.0",
+            [r"\d+.tar.gz"],
+            False,
+            "/file.0.tar/1.0.0/file.0.tar-1.0.0.gz",
+        ),
+        (
+            "/file.0.tar.gz",
+            "1.0.0",
+            [r"\d+.tar.gz"],
+            True,
+            "/file/1.0.0/file-1.0.0.0.tar.gz",
+        ),
+        (
+            "/file.99.tar.gz",
+            "1.0.0",
+            [r"\d+.tar.gz"],
+            True,
+            "/file/1.0.0/file-1.0.0.99.tar.gz",
+        ),
+        (
+            "/file.prediction.99.tar.gz",
+            "1.0.0",
+            [r"prediction.\d+.tar.gz", r"truth.tar.gz"],
+            True,
+            "/file/1.0.0/file-1.0.0.prediction.99.tar.gz",
+        ),
+        (
+            "/file.truth.tar.gz",
+            "1.0.0",
+            [r"prediction.\d+.tar.gz", r"truth.tar.gz"],
+            True,
+            "/file/1.0.0/file-1.0.0.truth.tar.gz",
+        ),
+        (
+            "/file.99.tar.gz",
+            "1.0.0",
+            [r"(\d+.)?tar.gz"],
+            True,
+            "/file/1.0.0/file-1.0.0.99.tar.gz",
+        ),
+        (
+            "/file.tar.gz",
+            "1.0.0",
+            [r"(\d+.)?tar.gz"],
+            True,
+            "/file/1.0.0/file-1.0.0.tar.gz",
+        ),
+    ],
+)
+def test_maven_file_structure(
+    tmpdir, interface, file, version, extensions, regex, expected
+):
+    interface.extensions = extensions
+    interface.regex = regex
+
+    src_path = audeer.touch(audeer.path(tmpdir, "tmp"))
+    interface.put_file(src_path, file, version)
+
+    url = str(interface.backend.path(expected))
+    url_expected = str(
+        interface.backend.path(interface._path_with_version(file, version))
+    )
+    assert url_expected == url
+    assert interface.ls(file) == [(file, version)]
+    assert interface.ls() == [(file, version)]

--- a/tests/test_backend_minio.py
+++ b/tests/test_backend_minio.py
@@ -315,6 +315,21 @@ def test_get_config(tmpdir, hosts, hide_credentials):
 def test_maven_file_structure(
     tmpdir, interface, file, version, extensions, regex, expected
 ):
+    """Test using the Maven interface with a Minio backend.
+
+    Args:
+        tmpdir: tmpdir fixture
+        interface: interface fixture,
+            which needs to be called with the Minio backend
+            and the Maven interface
+        file: file name
+        version: file version
+        extensions: extensions considered by the Maven interface
+        regex: if ``True``,
+            ``extensions`` are considered as a regex
+        expected: expected file structure on backend
+
+    """
     interface.extensions = extensions
     interface.regex = regex
 

--- a/tests/test_backend_minio.py
+++ b/tests/test_backend_minio.py
@@ -9,15 +9,14 @@ import audbackend
 
 @pytest.fixture(scope="function", autouse=False)
 def hide_credentials():
-    defaults = {}
-
-    for key in [
-        "MINIO_ACCESS_KEY",
-        "MINIO_SECRET_KEY",
-        "MINIO_CONFIG_FILE",
-    ]:
-        defaults[key] = os.environ.get(key, None)
-
+    defaults = {
+        key: os.environ.get(key, None)
+        for key in [
+            "MINIO_ACCESS_KEY",
+            "MINIO_SECRET_KEY",
+            "MINIO_CONFIG_FILE",
+        ]
+    }
     for key, value in defaults.items():
         if value is not None:
             del os.environ[key]

--- a/tests/test_backend_minio.py
+++ b/tests/test_backend_minio.py
@@ -108,14 +108,14 @@ def test_copy_large_file(tmpdir, interface, src_path, dst_path):
     assert interface.exists(dst_path)
 
 
-@pytest.mark.parametrize("host", ["localhost:9000"])
+@pytest.mark.parametrize("host", [pytest.HOSTS["minio"]])
 @pytest.mark.parametrize("repository", [f"unittest-{pytest.UID}-{audeer.uid()[:8]}"])
 def test_create_delete_repositories(host, repository):
     audbackend.backend.Minio.create(host, repository)
     audbackend.backend.Minio.delete(host, repository)
 
 
-@pytest.mark.parametrize("host", ["localhost:9000"])
+@pytest.mark.parametrize("host", [pytest.HOSTS["minio"]])
 @pytest.mark.parametrize("repository", [f"unittest-{pytest.UID}-{audeer.uid()[:8]}"])
 @pytest.mark.parametrize("authentication", [("bad-access", "bad-secret")])
 def test_errors(host, repository, authentication):

--- a/tests/test_backend_minio.py
+++ b/tests/test_backend_minio.py
@@ -76,6 +76,33 @@ def test_authentication(tmpdir, hosts, hide_credentials):
     indirect=True,
 )
 @pytest.mark.parametrize(
+    "path, expected,",
+    [
+        ("/text.txt", "text/plain"),
+    ],
+)
+def test_content_type(tmpdir, interface, path, expected):
+    r"""Test setting of content type.
+
+    Args:
+        tmpdir: tmpdir fixture
+        interface: interface fixture
+        path: path of file on backend
+        expected: expected content type
+
+    """
+    tmp_path = audeer.touch(audeer.path(tmpdir, path[1:]))
+    interface.put_file(tmp_path, path)
+    stats = interface._backend._client.stat_object(interface.repository, path)
+    assert stats.content_type == expected
+
+
+@pytest.mark.parametrize(
+    "interface",
+    [(audbackend.backend.Minio, audbackend.interface.Unversioned)],
+    indirect=True,
+)
+@pytest.mark.parametrize(
     "src_path, dst_path,",
     [
         (

--- a/tests/test_backend_minio.py
+++ b/tests/test_backend_minio.py
@@ -152,6 +152,17 @@ def test_errors(host, repository, authentication):
 
 
 def test_get_config(tmpdir, hosts, hide_credentials):
+    r"""Test parsing of configuration.
+
+    The `get_config()` class method is responsible
+    for parsing a Minio backend config file.
+
+    Args:
+        tmpdir: tmpdir fixture
+        hosts: hosts fixture
+        hide_credentials: hide_credentials fixture
+
+    """
     host = hosts["minio"]
     config_path = audeer.path(tmpdir, "config.cfg")
     os.environ["MINIO_CONFIG_FILE"] = config_path

--- a/tests/test_interface_maven.py
+++ b/tests/test_interface_maven.py
@@ -13,8 +13,8 @@ from singlefolder import SingleFolder
 
 # Backend-interface combinations to use in all tests
 backend_interface_combinations = [
-    (audbackend.backend.FileSystem, audbackend.interface.Unversioned),
-    (SingleFolder, audbackend.interface.Unversioned),
+    (audbackend.backend.FileSystem, audbackend.interface.Maven),
+    (SingleFolder, audbackend.interface.Maven),
 ]
 
 

--- a/tests/test_interface_maven.py
+++ b/tests/test_interface_maven.py
@@ -11,12 +11,16 @@ import audbackend
 from singlefolder import SingleFolder
 
 
+# Backend-interface combinations to use in all tests
+backend_interface_combinations = [
+    (audbackend.backend.FileSystem, audbackend.interface.Unversioned),
+    (SingleFolder, audbackend.interface.Unversioned),
+]
+
+
 @pytest.mark.parametrize(
     "interface",
-    [
-        (audbackend.backend.FileSystem, audbackend.interface.Maven),
-        (SingleFolder, audbackend.interface.Maven),
-    ],
+    backend_interface_combinations,
     indirect=True,
 )
 def test_errors(tmpdir, interface):
@@ -75,10 +79,7 @@ def test_errors(tmpdir, interface):
 
 @pytest.mark.parametrize(
     "interface",
-    [
-        (audbackend.backend.FileSystem, audbackend.interface.Maven),
-        (SingleFolder, audbackend.interface.Maven),
-    ],
+    backend_interface_combinations,
     indirect=True,
 )
 @pytest.mark.parametrize(

--- a/tests/test_interface_unversioned.py
+++ b/tests/test_interface_unversioned.py
@@ -603,6 +603,17 @@ def test_file(tmpdir, src_path, dst_path, owner, interface):
     interface.put_file(src_path, dst_path)
     assert interface.exists(dst_path)
 
+    # Download with already existing src_path
+    interface.get_file(dst_path, src_path)
+    assert os.path.exists(src_path)
+    assert interface.checksum(dst_path) == audeer.md5(src_path)
+    assert interface.owner(dst_path) == owner
+    date = datetime.datetime.today().strftime("%Y-%m-%d")
+    assert interface.date(dst_path) == date
+
+    # Repeat, but remove src_path first
+    os.remove(src_path)
+    assert not os.path.exists(src_path)
     interface.get_file(dst_path, src_path)
     assert os.path.exists(src_path)
     assert interface.checksum(dst_path) == audeer.md5(src_path)

--- a/tests/test_interface_unversioned.py
+++ b/tests/test_interface_unversioned.py
@@ -217,6 +217,7 @@ def test_copy(tmpdir, src_path, dst_path, interface):
     [
         (audbackend.backend.Artifactory, audbackend.interface.Unversioned),
         (audbackend.backend.FileSystem, audbackend.interface.Unversioned),
+        (audbackend.backend.Minio, audbackend.interface.Unversioned),
         (SingleFolder, audbackend.interface.Unversioned),
     ],
     indirect=True,

--- a/tests/test_interface_unversioned.py
+++ b/tests/test_interface_unversioned.py
@@ -91,6 +91,7 @@ def tree(tmpdir, request):
     [
         (audbackend.backend.Artifactory, audbackend.interface.Unversioned),
         (audbackend.backend.FileSystem, audbackend.interface.Unversioned),
+        (audbackend.backend.Minio, audbackend.interface.Unversioned),
         (SingleFolder, audbackend.interface.Unversioned),
     ],
     indirect=True,
@@ -172,6 +173,7 @@ def test_archive(tmpdir, tree, archive, files, tmp_root, interface, expected):
     [
         (audbackend.backend.Artifactory, audbackend.interface.Unversioned),
         (audbackend.backend.FileSystem, audbackend.interface.Unversioned),
+        (audbackend.backend.Minio, audbackend.interface.Unversioned),
         (SingleFolder, audbackend.interface.Unversioned),
     ],
     indirect=True,
@@ -557,6 +559,7 @@ def test_errors(tmpdir, interface):
     [
         (audbackend.backend.Artifactory, audbackend.interface.Unversioned),
         (audbackend.backend.FileSystem, audbackend.interface.Unversioned),
+        (audbackend.backend.Minio, audbackend.interface.Unversioned),
         (SingleFolder, audbackend.interface.Unversioned),
     ],
     indirect=True,
@@ -603,6 +606,10 @@ def test_exists(tmpdir, path, interface):
             audbackend.backend.FileSystem,
         ),
         (
+            (audbackend.backend.Minio, audbackend.interface.Unversioned),
+            audbackend.backend.Minio,
+        ),
+        (
             (SingleFolder, audbackend.interface.Unversioned),
             SingleFolder,
         ),
@@ -636,6 +643,7 @@ def test_file(tmpdir, src_path, dst_path, owner, interface):
     [
         (audbackend.backend.Artifactory, audbackend.interface.Unversioned),
         (audbackend.backend.FileSystem, audbackend.interface.Unversioned),
+        (audbackend.backend.Minio, audbackend.interface.Unversioned),
         (SingleFolder, audbackend.interface.Unversioned),
     ],
     indirect=True,
@@ -710,6 +718,7 @@ def test_ls(tmpdir, interface):
     [
         (audbackend.backend.Artifactory, audbackend.interface.Unversioned),
         (audbackend.backend.FileSystem, audbackend.interface.Unversioned),
+        (audbackend.backend.Minio, audbackend.interface.Unversioned),
         (SingleFolder, audbackend.interface.Unversioned),
     ],
     indirect=True,

--- a/tests/test_interface_unversioned.py
+++ b/tests/test_interface_unversioned.py
@@ -15,6 +15,15 @@ import audbackend
 from singlefolder import SingleFolder
 
 
+# Backend-interface combinations to use in all tests
+backend_interface_combinations = [
+    (audbackend.backend.Artifactory, audbackend.interface.Unversioned),
+    (audbackend.backend.FileSystem, audbackend.interface.Unversioned),
+    (audbackend.backend.Minio, audbackend.interface.Unversioned),
+    (SingleFolder, audbackend.interface.Unversioned),
+]
+
+
 @pytest.fixture(scope="function", autouse=False)
 def tree(tmpdir, request):
     r"""Create file tree."""
@@ -88,12 +97,7 @@ def tree(tmpdir, request):
 )
 @pytest.mark.parametrize(
     "interface",
-    [
-        (audbackend.backend.Artifactory, audbackend.interface.Unversioned),
-        (audbackend.backend.FileSystem, audbackend.interface.Unversioned),
-        (audbackend.backend.Minio, audbackend.interface.Unversioned),
-        (SingleFolder, audbackend.interface.Unversioned),
-    ],
+    backend_interface_combinations,
     indirect=True,
 )
 def test_archive(tmpdir, tree, archive, files, tmp_root, interface, expected):
@@ -170,12 +174,7 @@ def test_archive(tmpdir, tree, archive, files, tmp_root, interface, expected):
 )
 @pytest.mark.parametrize(
     "interface",
-    [
-        (audbackend.backend.Artifactory, audbackend.interface.Unversioned),
-        (audbackend.backend.FileSystem, audbackend.interface.Unversioned),
-        (audbackend.backend.Minio, audbackend.interface.Unversioned),
-        (SingleFolder, audbackend.interface.Unversioned),
-    ],
+    backend_interface_combinations,
     indirect=True,
 )
 def test_copy(tmpdir, src_path, dst_path, interface):
@@ -214,12 +213,7 @@ def test_copy(tmpdir, src_path, dst_path, interface):
 
 @pytest.mark.parametrize(
     "interface",
-    [
-        (audbackend.backend.Artifactory, audbackend.interface.Unversioned),
-        (audbackend.backend.FileSystem, audbackend.interface.Unversioned),
-        (audbackend.backend.Minio, audbackend.interface.Unversioned),
-        (SingleFolder, audbackend.interface.Unversioned),
-    ],
+    backend_interface_combinations,
     indirect=True,
 )
 def test_errors(tmpdir, interface):
@@ -557,12 +551,7 @@ def test_errors(tmpdir, interface):
 )
 @pytest.mark.parametrize(
     "interface",
-    [
-        (audbackend.backend.Artifactory, audbackend.interface.Unversioned),
-        (audbackend.backend.FileSystem, audbackend.interface.Unversioned),
-        (audbackend.backend.Minio, audbackend.interface.Unversioned),
-        (SingleFolder, audbackend.interface.Unversioned),
-    ],
+    backend_interface_combinations,
     indirect=True,
 )
 def test_exists(tmpdir, path, interface):
@@ -598,22 +587,8 @@ def test_exists(tmpdir, path, interface):
 @pytest.mark.parametrize(
     "interface, owner",
     [
-        (
-            (audbackend.backend.Artifactory, audbackend.interface.Unversioned),
-            audbackend.backend.Artifactory,
-        ),
-        (
-            (audbackend.backend.FileSystem, audbackend.interface.Unversioned),
-            audbackend.backend.FileSystem,
-        ),
-        (
-            (audbackend.backend.Minio, audbackend.interface.Unversioned),
-            audbackend.backend.Minio,
-        ),
-        (
-            (SingleFolder, audbackend.interface.Unversioned),
-            SingleFolder,
-        ),
+        ((backend, interface), backend)
+        for backend, interface in backend_interface_combinations
     ],
     indirect=True,
 )
@@ -641,12 +616,7 @@ def test_file(tmpdir, src_path, dst_path, owner, interface):
 
 @pytest.mark.parametrize(
     "interface",
-    [
-        (audbackend.backend.Artifactory, audbackend.interface.Unversioned),
-        (audbackend.backend.FileSystem, audbackend.interface.Unversioned),
-        (audbackend.backend.Minio, audbackend.interface.Unversioned),
-        (SingleFolder, audbackend.interface.Unversioned),
-    ],
+    backend_interface_combinations,
     indirect=True,
 )
 def test_ls(tmpdir, interface):
@@ -716,12 +686,7 @@ def test_ls(tmpdir, interface):
 )
 @pytest.mark.parametrize(
     "interface",
-    [
-        (audbackend.backend.Artifactory, audbackend.interface.Unversioned),
-        (audbackend.backend.FileSystem, audbackend.interface.Unversioned),
-        (audbackend.backend.Minio, audbackend.interface.Unversioned),
-        (SingleFolder, audbackend.interface.Unversioned),
-    ],
+    backend_interface_combinations,
     indirect=True,
 )
 def test_move(tmpdir, src_path, dst_path, interface):

--- a/tests/test_interface_versioned.py
+++ b/tests/test_interface_versioned.py
@@ -15,6 +15,13 @@ import audbackend
 from singlefolder import SingleFolder
 
 
+# Backend-interface combinations to use in all tests
+backend_interface_combinations = [
+    (audbackend.backend.FileSystem, audbackend.interface.Unversioned),
+    (SingleFolder, audbackend.interface.Unversioned),
+]
+
+
 @pytest.fixture(scope="function", autouse=False)
 def tree(tmpdir, request):
     r"""Create file tree."""
@@ -88,10 +95,7 @@ def tree(tmpdir, request):
 )
 @pytest.mark.parametrize(
     "interface",
-    [
-        (audbackend.backend.FileSystem, audbackend.interface.Versioned),
-        (SingleFolder, audbackend.interface.Versioned),
-    ],
+    backend_interface_combinations,
     indirect=True,
 )
 def test_archive(tmpdir, tree, archive, files, tmp_root, interface, expected):
@@ -181,10 +185,7 @@ def test_archive(tmpdir, tree, archive, files, tmp_root, interface, expected):
 )
 @pytest.mark.parametrize(
     "interface",
-    [
-        (audbackend.backend.FileSystem, audbackend.interface.Versioned),
-        (SingleFolder, audbackend.interface.Versioned),
-    ],
+    backend_interface_combinations,
     indirect=True,
 )
 def test_copy(tmpdir, src_path, src_versions, dst_path, version, interface):
@@ -237,10 +238,7 @@ def test_copy(tmpdir, src_path, src_versions, dst_path, version, interface):
 
 @pytest.mark.parametrize(
     "interface",
-    [
-        (audbackend.backend.FileSystem, audbackend.interface.Versioned),
-        (SingleFolder, audbackend.interface.Versioned),
-    ],
+    backend_interface_combinations,
     indirect=True,
 )
 def test_errors(tmpdir, interface):
@@ -678,10 +676,7 @@ def test_errors(tmpdir, interface):
 )
 @pytest.mark.parametrize(
     "interface",
-    [
-        (audbackend.backend.FileSystem, audbackend.interface.Versioned),
-        (SingleFolder, audbackend.interface.Versioned),
-    ],
+    backend_interface_combinations,
     indirect=True,
 )
 def test_exists(tmpdir, path, version, interface):
@@ -721,14 +716,8 @@ def test_exists(tmpdir, path, version, interface):
 @pytest.mark.parametrize(
     "interface, owner",
     [
-        (
-            (audbackend.backend.FileSystem, audbackend.interface.Versioned),
-            audbackend.backend.FileSystem,
-        ),
-        (
-            (SingleFolder, audbackend.interface.Versioned),
-            SingleFolder,
-        ),
+        ((backend, interface), backend)
+        for backend, interface in backend_interface_combinations
     ],
     indirect=True,
 )
@@ -756,10 +745,7 @@ def test_file(tmpdir, src_path, dst_path, version, interface, owner):
 
 @pytest.mark.parametrize(
     "interface",
-    [
-        (audbackend.backend.FileSystem, audbackend.interface.Versioned),
-        (SingleFolder, audbackend.interface.Versioned),
-    ],
+    backend_interface_combinations,
     indirect=True,
 )
 @pytest.mark.parametrize(
@@ -1035,10 +1021,7 @@ def test_ls(tmpdir, interface, files, path, latest, pattern, expected):
 )
 @pytest.mark.parametrize(
     "interface",
-    [
-        (audbackend.backend.FileSystem, audbackend.interface.Versioned),
-        (SingleFolder, audbackend.interface.Versioned),
-    ],
+    backend_interface_combinations,
     indirect=True,
 )
 def test_move(tmpdir, src_path, src_versions, dst_path, version, interface):
@@ -1110,10 +1093,7 @@ def test_repr():
 @pytest.mark.parametrize("dst_path", ["/file.ext", "/sub/file.ext"])
 @pytest.mark.parametrize(
     "interface",
-    [
-        (audbackend.backend.FileSystem, audbackend.interface.Versioned),
-        (SingleFolder, audbackend.interface.Versioned),
-    ],
+    backend_interface_combinations,
     indirect=True,
 )
 def test_versions(tmpdir, dst_path, interface):

--- a/tests/test_interface_versioned.py
+++ b/tests/test_interface_versioned.py
@@ -17,8 +17,8 @@ from singlefolder import SingleFolder
 
 # Backend-interface combinations to use in all tests
 backend_interface_combinations = [
-    (audbackend.backend.FileSystem, audbackend.interface.Unversioned),
-    (SingleFolder, audbackend.interface.Unversioned),
+    (audbackend.backend.FileSystem, audbackend.interface.Versioned),
+    (SingleFolder, audbackend.interface.Versioned),
 ]
 
 


### PR DESCRIPTION
Implements a backend for [MinIO](https://min.io).

MinIO is compatible with S3 storage, and we tested internally that this backend works with S3 storage on Hetzner and AWS. A test based on AWS is integrated in https://github.com/audeering/audb/pull/450.

I decided to handle the authentication the same way as we do for `audbackend.backend.Artifactory`, by allowing to specify the username / password inside a config file or environment variable. In addition, we have the class method `audbackend.backend.Minio.get_authentication()` to retrieve them, in order to check their values.
For local MinIO servers we also need to set the `secure` argument to `False`. I added this to the config file as well, in oder to make it part of the backend configuration, and added the class method `audbackend.backend.Minio.get_config()`, which returns all entries as dictionary.
In certain edge cases you might want to add other arguments to the underlying `minio.Minio` class. For that reason I decided to add support for `**kwargs`, but do no checks if there is any conflict with authentication as I think this is only for power users anyway.

![image](https://github.com/user-attachments/assets/d6f45537-76a8-4183-854b-2be123e3ac69)

![image](https://github.com/user-attachments/assets/80ef8740-8d9d-4663-9109-738c485939d7)

![image](https://github.com/user-attachments/assets/f8ecf07a-445e-472e-b1cf-3f5b653d3e14)

## Summary by Sourcery

Add support for MinIO as a new backend in the audbackend library, enabling storage operations with MinIO. Refactor tests to accommodate the new backend and ensure robust testing of its functionality.

New Features:
- Introduce a new backend for MinIO, allowing integration with MinIO storage systems.

Enhancements:
- Refactor test parameterization to use a centralized list of backend-interface combinations, improving test maintainability.

Tests:
- Add comprehensive tests for the new MinIO backend, including authentication, file operations, and configuration parsing.