### PR TITLE
TST: remove lower limit for pytest version

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
-pytest<8.1.0  # required by doctestplus
+pytest
 pytest-cov
 pytest-doctestplus


### PR DESCRIPTION
Allow again higher versions of `pytest` as the bug is fixed in the `doctestplus` plugin.