### PR TITLE
Add support for owner()

### DIFF
--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -335,8 +335,10 @@ class Minio(Base):
         # NOTE:
         # we use a custom metadata entry to track the owner
         # as stats.owner_name is always empty.
+        owner = ""
         stats = self._client.stat_object(self.repository, path)
-        owner = stats.metadata["x-amz-meta-owner"]
+        if "x-amz-meta-owner" in stats.metadata:
+            owner = stats.metadata["x-amz-meta-owner"]
         return owner
 
     def path(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,11 +77,6 @@ def owner(request):
     ):
         host_wo_https = pytest.HOSTS["artifactory"][8:]
         owner = backend_cls.get_authentication(host_wo_https)[0]
-    elif (
-        hasattr(audbackend.backend, "Minio") and backend_cls == audbackend.backend.Minio
-    ):
-        # There seems to be a MinIO bug here
-        owner = None
     else:
         if os.name == "nt":
             owner = "Administrators"


### PR DESCRIPTION
This is not based on `main`, but expands the `minio` branch.

MinIO seems not directly to support the concept of a file owner. At least if you call their `stats_object()` method and look at its attribute `owner_name` it is always empty for me.

This pull request adds a workaround, by setting the owner explicitly as a metadata entry, every time a file is uploaded or copied to the server. The owner can then be extracted with `stats_object().metadata`. I benchmarked, and the proposed changes have no affect on the execution time of `put_file()`.

---

We should ask ourselves, if we really want to have this feature or not. If we later switch to `fsspec` for backends (https://github.com/audeering/audbackend/pull/233), we will again have the problem, that `owner` is not supported, and we will most likely not be able to add a workaround that is independent from the backend. So maybe we should just drop it?

The challenge is that it provides very meaningful information, e.g. who published a given model or data, which means if we drop it from `audbackend`, we will most likely need to store those information inside other metadata, e.g. in the header of a dataset.