### PR TITLE
CI: fix coverage upload action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,4 +68,4 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
-      if: matrix.os == 'ubuntu-latest' and matrix.python-version != '3.12'
+      if: ${{ (matrix.os == 'ubuntu-latest') && (matrix.python-version != '3.12') }}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -22,8 +22,8 @@ import audbackend
             f"unittest-{audeer.uid()[:8]}",
             "audbackend.backend.Artifactory",
             marks=pytest.mark.skipif(
-                sys.version_info > (3, 11),
-                reason="Requires Python 3.11 or lower",
+                sys.version_info >= (3, 12),
+                reason="Requires Python<3.12",
             ),
         ),
         (


### PR DESCRIPTION
There was a bug in the CI section uploading the coverage introduced in #236, which is fixed here.

## Summary by Sourcery

CI:
- Fix the conditional expression for the coverage upload action in the CI workflow to ensure proper execution.