### PR TITLE
Remove support for Python 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,6 @@ jobs:
         python-version: [ '3.10' ]
         include:
           - os: ubuntu-latest
-            python-version: '3.8'
-          - os: ubuntu-latest
             python-version: '3.9'
           - os: ubuntu-latest
             python-version: '3.11'

--- a/audbackend/core/api.py
+++ b/audbackend/core/api.py
@@ -1,4 +1,3 @@
-import typing
 import warnings
 
 import audeer
@@ -53,7 +52,7 @@ def access(
     host: str,
     repository: str,
     *,
-    interface: typing.Type[Interface] = Versioned,
+    interface: type[Interface] = Versioned,
     interface_kwargs: dict = None,
 ) -> Interface:
     r"""Access repository.
@@ -198,7 +197,7 @@ def delete(
 @audeer.deprecated(removal_version="2.2.0", alternative="backend classes directly")
 def register(
     name: str,
-    cls: typing.Type[Base],
+    cls: type[Base],
 ):
     r"""Register backend class.
 

--- a/audbackend/core/backend/artifactory.py
+++ b/audbackend/core/backend/artifactory.py
@@ -1,5 +1,4 @@
 import os
-import typing
 
 import artifactory
 import dohq_artifactory
@@ -84,7 +83,7 @@ class Artifactory(Base):
         host: str,
         repository: str,
         *,
-        authentication: typing.Tuple[str, str] = None,
+        authentication: tuple[str, str] = None,
     ):
         super().__init__(host, repository, authentication=authentication)
 
@@ -99,7 +98,7 @@ class Artifactory(Base):
         self._session = None
 
     @classmethod
-    def get_authentication(cls, host: str) -> typing.Tuple[str, str]:
+    def get_authentication(cls, host: str) -> tuple[str, str]:
         """Username and password/access token for given host.
 
         Returns a username
@@ -271,7 +270,7 @@ class Artifactory(Base):
     def _ls(
         self,
         path: str,
-    ) -> typing.List[str]:
+    ) -> list[str]:
         r"""List all files under sub-path."""
         path = self.path(path)
         if not path.exists():

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
 import fnmatch
 import inspect
 import os
 import tempfile
-import typing
 
 import audeer
 
@@ -27,7 +29,7 @@ class Base:
         host: str,
         repository: str,
         *,
-        authentication: typing.Any = None,
+        authentication: object = None,
     ):
         self.host = host
         r"""Host path."""
@@ -257,7 +259,7 @@ class Base:
         host: str,
         repository: str,
         *,
-        authentication: typing.Any = None,
+        authentication: object = None,
     ):
         r"""Create repository.
 
@@ -340,7 +342,7 @@ class Base:
         host: str,
         repository: str,
         *,
-        authentication: typing.Any = None,
+        authentication: object = None,
     ):
         r"""Delete repository.
 
@@ -421,7 +423,7 @@ class Base:
         tmp_root: str = None,
         validate: bool = False,
         verbose: bool = False,
-    ) -> typing.List[str]:
+    ) -> list[str]:
         r"""Get archive from backend and extract.
 
         The archive type is derived from the extension of ``src_path``.
@@ -625,7 +627,7 @@ class Base:
     def _ls(
         self,
         path: str,
-    ) -> typing.List[str]:  # pragma: no cover
+    ) -> list[str]:  # pragma: no cover
         r"""List all files under sub-path.
 
         If ``path`` does not exist
@@ -640,7 +642,7 @@ class Base:
         *,
         pattern: str = None,
         suppress_backend_errors: bool = False,
-    ) -> typing.List[str]:
+    ) -> list[str]:
         r"""List files on backend.
 
         Returns a sorted list of tuples
@@ -901,7 +903,7 @@ class Base:
         src_root: str,
         dst_path: str,
         *,
-        files: typing.Union[str, typing.Sequence[str]] = None,
+        files: str | Sequence[str] = None,
         tmp_root: str = None,
         validate: bool = False,
         verbose: bool = False,
@@ -1105,7 +1107,7 @@ class Base:
     def split(
         self,
         path: str,
-    ) -> typing.Tuple[str, str]:
+    ) -> tuple[str, str]:
         r"""Split path on backend into sub-path and basename.
 
         Args:

--- a/audbackend/core/backend/filesystem.py
+++ b/audbackend/core/backend/filesystem.py
@@ -1,7 +1,6 @@
 import datetime
 import os
 import shutil
-import typing
 
 import audeer
 
@@ -126,7 +125,7 @@ class FileSystem(Base):
     def _ls(
         self,
         path: str,
-    ) -> typing.List[str]:
+    ) -> list[str]:
         r"""List all files under sub-path."""
         path = self._expand(path)
         if not os.path.exists(path):

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -3,7 +3,6 @@ import getpass
 import mimetypes
 import os
 import tempfile
-import typing
 
 import minio
 
@@ -58,7 +57,7 @@ class Minio(Base):
         host: str,
         repository: str,
         *,
-        authentication: typing.Tuple[str, str] = None,
+        authentication: tuple[str, str] = None,
         secure: bool = None,
         **kwargs,
     ):
@@ -81,7 +80,7 @@ class Minio(Base):
         )
 
     @classmethod
-    def get_authentication(cls, host: str) -> typing.Tuple[str, str]:
+    def get_authentication(cls, host: str) -> tuple[str, str]:
         """Access and secret tokens for given host.
 
         Returns a authentication for MinIO server
@@ -115,7 +114,7 @@ class Minio(Base):
         return access_key, secret_key
 
     @classmethod
-    def get_config(cls, host: str) -> typing.Dict:
+    def get_config(cls, host: str) -> dict:
         """Configuration of MinIO server.
 
         The default path of the config file is
@@ -297,7 +296,7 @@ class Minio(Base):
     def _ls(
         self,
         path: str,
-    ) -> typing.List[str]:
+    ) -> list[str]:
         r"""List all files under sub-path."""
         path = self.path(path)
         objects = self._client.list_objects(

--- a/audbackend/core/interface/base.py
+++ b/audbackend/core/interface/base.py
@@ -1,5 +1,3 @@
-import typing
-
 from audbackend.core.backend.base import Base as Backend
 
 
@@ -138,7 +136,7 @@ class Base:
     def split(
         self,
         path: str,
-    ) -> typing.Tuple[str, str]:
+    ) -> tuple[str, str]:
         r"""Split path on backend into sub-path and basename.
 
         Args:

--- a/audbackend/core/interface/maven.py
+++ b/audbackend/core/interface/maven.py
@@ -1,7 +1,7 @@
+from collections.abc import Sequence
 import fnmatch
 import os
 import re
-import typing
 
 import audeer
 
@@ -82,7 +82,7 @@ class Maven(Versioned):
         self,
         backend: Backend,
         *,
-        extensions: typing.Sequence[str] = [],
+        extensions: Sequence[str] = [],
         regex: bool = False,
     ):
         super().__init__(backend)
@@ -96,7 +96,7 @@ class Maven(Versioned):
         latest_version: bool = False,
         pattern: str = None,
         suppress_backend_errors: bool = False,
-    ) -> typing.List[typing.Tuple[str, str]]:
+    ) -> list[tuple[str, str]]:
         r"""List files on backend.
 
         Returns a sorted list of tuples
@@ -250,7 +250,7 @@ class Maven(Versioned):
     def _split_ext(
         self,
         name: str,
-    ) -> typing.Tuple[str, str]:
+    ) -> tuple[str, str]:
         r"""Split name into basename and extension."""
         ext = None
         for custom_ext in self.extensions:

--- a/audbackend/core/interface/unversioned.py
+++ b/audbackend/core/interface/unversioned.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
 import os  # noqa: F401
-import typing
 
 from audbackend.core.interface.base import Base
 
@@ -217,7 +219,7 @@ class Unversioned(Base):
         tmp_root: str = None,
         validate: bool = False,
         verbose: bool = False,
-    ) -> typing.List[str]:
+    ) -> list[str]:
         r"""Get archive from backend and extract.
 
         The archive type is derived from the extension of ``src_path``.
@@ -360,7 +362,7 @@ class Unversioned(Base):
         *,
         pattern: str = None,
         suppress_backend_errors: bool = False,
-    ) -> typing.List[str]:
+    ) -> list[str]:
         r"""List files on backend.
 
         Returns a sorted list of tuples
@@ -537,7 +539,7 @@ class Unversioned(Base):
         src_root: str,
         dst_path: str,
         *,
-        files: typing.Union[str, typing.Sequence[str]] = None,
+        files: str | Sequence[str] = None,
         tmp_root: str = None,
         validate: bool = False,
         verbose: bool = False,

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
 import fnmatch
 import os
-import typing
 
 import audeer
 
@@ -263,7 +265,7 @@ class Versioned(Base):
         tmp_root: str = None,
         validate: bool = False,
         verbose: bool = False,
-    ) -> typing.List[str]:
+    ) -> list[str]:
         r"""Get archive from backend and extract.
 
         The archive type is derived from the extension of ``src_path``.
@@ -452,7 +454,7 @@ class Versioned(Base):
         latest_version: bool = False,
         pattern: str = None,
         suppress_backend_errors: bool = False,
-    ) -> typing.List[typing.Tuple[str, str]]:
+    ) -> list[tuple[str, str]]:
         r"""List files on backend.
 
         Returns a sorted list of tuples
@@ -717,7 +719,7 @@ class Versioned(Base):
         dst_path: str,
         version: str,
         *,
-        files: typing.Union[str, typing.Sequence[str]] = None,
+        files: str | Sequence[str] = None,
         tmp_root: str = None,
         validate: bool = False,
         verbose: bool = False,
@@ -908,7 +910,7 @@ class Versioned(Base):
         path: str,
         *,
         suppress_backend_errors: bool = False,
-    ) -> typing.List[str]:
+    ) -> list[str]:
         r"""Versions of a file.
 
         Args:

--- a/audbackend/core/utils.py
+++ b/audbackend/core/utils.py
@@ -1,8 +1,8 @@
+from collections.abc import Callable
 import datetime
 import errno
 import os
 import re
-import typing
 
 from audbackend.core.errors import BackendError
 
@@ -17,12 +17,12 @@ VERSION_ALLOWED_CHARS_COMPILED = re.compile(VERSION_ALLOWED_CHARS)
 
 
 def call_function_on_backend(
-    function: typing.Callable,
+    function: Callable,
     *args,
     suppress_backend_errors: bool = False,
-    fallback_return_value: typing.Any = None,
+    fallback_return_value: object = None,
     **kwargs,
-) -> typing.Any:
+) -> object:
     try:
         return function(*args, **kwargs)
     except Exception as ex:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ classifiers = [
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',

--- a/tests/singlefolder.py
+++ b/tests/singlefolder.py
@@ -3,7 +3,6 @@ import os
 import pickle
 import shutil
 import threading
-import typing
 
 import audeer
 
@@ -124,7 +123,7 @@ class SingleFolder(audbackend.backend.Base):
     def _ls(
         self,
         path: str,
-    ) -> typing.List[str]:
+    ) -> list[str]:
         with self.Map(self._path, self._lock) as m:
             ls = []
 


### PR DESCRIPTION
Removes support for Python 3.8, which has reached its end of life.

It also updates the typing syntax as `typing` is no longer needed with Python 3.9.