### PR TITLE
By explicit about required Python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     'Programming Language :: Python :: 3.12',
     'Topic :: Scientific/Engineering',
 ]
+requires-python = '>=3.9'
 dependencies = [
     'audeer >=1.20.0',
     'pywin32; sys_platform == "win32"',


### PR DESCRIPTION
As we updated the syntax in https://github.com/audeering/audbackend/pull/239 as well, I decided to also state a `requires-python = '>=3.9'` in `pyproject.toml`, so the new version of `audbackend` can no longer be installed under Python 3.8.