### PR TITLE
Retry if call function on backend fails

### DIFF
--- a/audbackend/core/utils.py
+++ b/audbackend/core/utils.py
@@ -55,10 +55,9 @@ def call_function_on_backend(
         except Exception as ex:
             if suppress_backend_errors:
                 return fallback_return_value
-            else:
-                if retry + 1 == retries:
-                    raise BackendError(ex)
-                time.sleep(0.05)
+            if retry + 1 == retries:
+                raise BackendError(ex) from ex
+            time.sleep(0.05)
 
 
 def check_path(

--- a/audbackend/core/utils.py
+++ b/audbackend/core/utils.py
@@ -3,6 +3,7 @@ import datetime
 import errno
 import os
 import re
+import time
 
 import audeer
 
@@ -23,15 +24,41 @@ def call_function_on_backend(
     *args,
     suppress_backend_errors: bool = False,
     fallback_return_value: object = None,
+    retries: int = 3,
     **kwargs,
 ) -> object:
-    try:
-        return function(*args, **kwargs)
-    except Exception as ex:
-        if suppress_backend_errors:
-            return fallback_return_value
-        else:
-            raise BackendError(ex)
+    r"""Call function on backend.
+
+    Args:
+        function: function to call on backend
+        suppress_backend_errors: if ``True``
+            and ``function`` fails during execution,
+            ``fallback_return_value`` is returned
+            instead of raising an error
+        fallback_return_value: value returned
+            if ``function`` fails during execution
+            and ``suppress_backend_errors`` is ``True``
+        retries: number of times ``function``
+            is tried to execute
+            when it raises an error,
+            before raising the error
+        *args: positional args of ``function``
+        **kwargs: keyword arguments of ``function``
+
+    Returns:
+        return value(s) of ``function``
+
+    """
+    for retry in range(retries):
+        try:
+            return function(*args, **kwargs)
+        except Exception as ex:
+            if suppress_backend_errors:
+                return fallback_return_value
+            else:
+                if retry + 1 == retries:
+                    raise BackendError(ex)
+                time.sleep(0.05)
 
 
 def check_path(


### PR DESCRIPTION
When publishing large datasets that take longer than 24 hours, I encountered network related errors for both Artifactory and S3 servers. They seem to be related with loosing the connection while uploading a file, which will then raise an error, and stops the whole process. To avoid this, this pull request proposes to not directly fail, but try two times more to rerunning the requested job on the backend, with a short delay of 50 ms between the tries.

I tested it on a 27 hour job on S3, which failed three times before, and did now proceed without any error for two times.
As I don't see any unwanted consequences, I would propose to integrate the changes.

## Summary by Sourcery

Enhancements:
- Add retry mechanism to call_function_on_backend to attempt function execution multiple times before raising an error.

## Summary by Sourcery

Enhancements:
- Add a retry mechanism to the call_function_on_backend function to attempt execution multiple times before raising an error.