### PR TITLE
Add audbackend.checksum()

### DIFF
--- a/audbackend/__init__.py
+++ b/audbackend/__init__.py
@@ -7,6 +7,7 @@ from audbackend.core.api import register
 from audbackend.core.backend.base import Base as Backend  # legacy
 from audbackend.core.backend.filesystem import FileSystem  # legacy
 from audbackend.core.errors import BackendError
+from audbackend.core.utils import checksum
 from audbackend.core.repository import Repository
 
 # Import optional backends (legacy)

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -69,12 +69,12 @@ class Base:
 
         """
         if path_is_local:
-            checksum = audeer.md5(path)
+            checksum = utils.checksum(path)
         else:
             checksum = self.checksum(path)
 
         if path_ref_is_local:
-            checksum_ref = audeer.md5(path_ref)
+            checksum_ref = utils.checksum(path_ref)
         else:
             checksum_ref = self.checksum(path_ref)
 
@@ -569,7 +569,7 @@ class Base:
             msg = f"Permission denied: '{dst_path}'"
             raise PermissionError(msg)
 
-        if not os.path.exists(dst_path) or audeer.md5(dst_path) != self.checksum(
+        if not os.path.exists(dst_path) or utils.checksum(dst_path) != self.checksum(
             src_path
         ):
             # get file to a temporary directory first,
@@ -1042,7 +1042,7 @@ class Base:
         elif os.path.isdir(src_path):
             raise utils.raise_is_a_directory(src_path)
 
-        checksum = audeer.md5(src_path)
+        checksum = utils.checksum(src_path)
 
         # skip if file with same checksum already exists
         if not self.exists(dst_path) or self.checksum(dst_path) != checksum:

--- a/audbackend/core/backend/filesystem.py
+++ b/audbackend/core/backend/filesystem.py
@@ -32,7 +32,7 @@ class FileSystem(Base):
     ) -> str:
         r"""MD5 checksum of file on backend."""
         path = self._expand(path)
-        return audeer.md5(path)
+        return utils.checksum(path)
 
     def _collapse(
         self,

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -77,7 +77,7 @@ class Versioned(Base):
         Examples:
             >>> file = "src.txt"
             >>> import audeer
-            >>> audeer.md5(file)
+            >>> audbackend.checksum(file)
             'd41d8cd98f00b204e9800998ecf8427e'
             >>> interface.put_file(file, "/file.txt", "1.0.0")
             >>> interface.checksum("/file.txt", "1.0.0")

--- a/audbackend/core/utils.py
+++ b/audbackend/core/utils.py
@@ -106,6 +106,9 @@ def checksum(file: str) -> str:
     Returns:
         MD5 checksum of file
 
+    Raises:
+        FileNotFoundError: if ``file`` does not exist
+
     Examples:
         >>> checksum("src.txt")
         'd41d8cd98f00b204e9800998ecf8427e'

--- a/audbackend/core/utils.py
+++ b/audbackend/core/utils.py
@@ -98,13 +98,30 @@ def checksum(file: str) -> str:
     or pyarrow_ is not installed,
     its MD5 sum is calculated instead.
 
+    .. _pyarrow: https://arrow.apache.org/docs/python/index.html
+
     Args:
         file: file path with extension
 
     Returns:
         MD5 checksum of file
 
-    .. _pyarrow: https://arrow.apache.org/docs/python/index.html
+    Examples:
+        >>> checksum("src.txt")
+        'd41d8cd98f00b204e9800998ecf8427e'
+        >>> import audformat
+        >>> import pandas as pd
+        >>> import pyarrow as pa
+        >>> import pyarrow.parquet as pq
+        >>> df = pd.DataFrame([0, 1], columns=["a"])
+        >>> hash = audformat.utils.hash(df, strict=True)
+        >>> hash
+        '9021a9b6e1e696ba9de4fe29346319b2'
+        >>> table = pa.Table.from_pandas(df)
+        >>> table = table.replace_schema_metadata({"hash": hash})
+        >>> pq.write_table(table, "file.parquet", compression="snappy")
+        >>> checksum("file.parquet")
+        '9021a9b6e1e696ba9de4fe29346319b2'
 
     """
     ext = audeer.file_extension(file)

--- a/audbackend/core/utils.py
+++ b/audbackend/core/utils.py
@@ -83,20 +83,15 @@ def check_version(version: str) -> str:
 def checksum(file: str) -> str:
     r"""Checksum of file.
 
-    The checksum is given by the MD5 sum
-    as calculated with :func:`audeer.md5`.
+    This function is used by backends
+    to get the checksum of local files,
+    using :func:`audeer.md5`.
 
-    As parquet files are stored non-deterministically,
-    we allow to use them with precalculated checksums,
-    stored under the key ``b"hash"`` in its metadata.
-    To support this feature pyarrow_
-    has to be installed.
-    A deterministic checksum,
-    based on the content of the parquet file,
-    can be calculated with :func:`audformat.utils.hash`.
-    If the key is not present in the metadata of the parquet file,
-    or pyarrow_ is not installed,
-    its MD5 sum is calculated instead.
+    An exception are parquet files,
+    for which their ``"hash"`` metadata entry
+    is used as checksum,
+    if the entry is available
+    and pyarrow_ is installed.
 
     .. _pyarrow: https://arrow.apache.org/docs/python/index.html
 

--- a/docs/api-src/audbackend.rst
+++ b/docs/api-src/audbackend.rst
@@ -32,6 +32,7 @@ and functions are available.
     BackendError
     Repository
     access
+    checksum
     create
     delete
     register

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,6 +43,7 @@ napoleon_use_ivar = True  # List of class attributes
 autodoc_inherit_docstrings = False  # disable docstring inheritance
 intersphinx_mapping = {
     "audeer": ("https://audeering.github.io/audeer/", None),
+    "audformat": ("https://audeering.github.io/audformat/", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     "python": ("https://docs.python.org/3/", None),
 }

--- a/tests/bad_file_system.py
+++ b/tests/bad_file_system.py
@@ -1,5 +1,3 @@
-import audeer
-
 import audbackend
 
 
@@ -16,7 +14,7 @@ class BadFileSystem(audbackend.backend.FileSystem):
         verbose: bool = False,
     ):
         r"""Put file on backend."""
-        checksum = audeer.md5(src_path)
+        checksum = audbackend.checksum(src_path)
         audbackend.core.utils.call_function_on_backend(
             self._put_file,
             src_path,

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
+pyarrow
 pytest<8.1.0  # required by doctestplus
 pytest-cov
 pytest-doctestplus

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
-pyarrow
+audformat
 pytest<8.1.0  # required by doctestplus
 pytest-cov
 pytest-doctestplus

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -79,8 +79,8 @@ class TestChecksum:
     @pytest.mark.parametrize(
         "file, error, error_msg",
         [
-            ("non-existing.txt", FileNotFoundError, "No such file or directory"),
-            ("non-existing.parquet", FileNotFoundError, "No such file or directory"),
+            ("non-existing.txt", FileNotFoundError, "non-existing.txt"),
+            ("non-existing.parquet", FileNotFoundError, "non-existing.parquet"),
         ],
     )
     def test_errors(self, file, error, error_msg):
@@ -89,7 +89,10 @@ class TestChecksum:
         Args:
             file: file path
             error: expected error
-            error_msg: expected error message
+            error_msg: expected error message.
+                For ``FileNotFoundError``,
+                we recommend to use only the file name
+                as the rest of the error message differs under Windows
 
         """
         with pytest.raises(error, match=error_msg):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -62,3 +62,21 @@ class TestChecksum:
         assert audbackend.checksum(path) == expected_checksum_function(path)
         if not pyarrow_installed:
             del sys.modules["pyarrow"]
+
+    @pytest.mark.parametrize(
+        "file, error, error_msg",
+        [
+            ("non-existing.txt", FileNotFoundError, "No such file or directory"),
+        ],
+    )
+    def test_errors(self, file, error, error_msg):
+        """Test expected errors.
+
+        Args:
+            file: file path
+            error: expected error
+            error_msg: expected error message
+
+        """
+        with pytest.raises(error, match=error_msg):
+            audbackend.checksum(file)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,64 @@
+import sys
+
+import pyarrow
+import pyarrow.parquet as parquet
+import pytest
+
+import audeer
+
+import audbackend
+
+
+class TestChecksum:
+    """Test local checksum calculation."""
+
+    @classmethod
+    @pytest.fixture(autouse=True)
+    def setup(cls, tmpdir):
+        """Prepare files for tests."""
+        cls.files = {}
+
+        file = "file.txt"
+        cls.files[file] = audeer.path(tmpdir, file)
+        with open(cls.files[file], "w") as fp:
+            fp.write("hello\n")
+
+        file = "file.parquet"
+        cls.files[file] = audeer.path(tmpdir, file)
+        table = pyarrow.Table.from_pylist([{"a": 0, "b": 1}])
+        parquet.write_table(table, cls.files[file], compression="snappy")
+
+        file = "file-metadata.parquet"
+        cls.files[file] = audeer.path(tmpdir, file)
+        metadata = {"hash": "my-hash"}
+        table = table.replace_schema_metadata(metadata)
+        parquet.write_table(table, cls.files[file], compression="snappy")
+
+    @pytest.mark.parametrize(
+        "file, pyarrow_installed, expected_checksum_function",
+        [
+            ("file.txt", True, audeer.md5),
+            ("file.parquet", True, audeer.md5),
+            ("file-metadata.parquet", True, lambda x: "my-hash"),
+            ("file.txt", False, audeer.md5),
+            ("file.parquet", False, audeer.md5),
+            ("file-metadata.parquet", False, audeer.md5),
+        ],
+    )
+    def test_checksum(self, file, pyarrow_installed, expected_checksum_function):
+        """Test checksum of local file.
+
+        Args:
+            file: file name, see ``setup()``
+            pyarrow_installed: if ``False,
+                it hides the ``pyarrow`` module
+            expected_checksum_function: function executed
+                to generate expected checksum for ``file``
+
+        """
+        path = self.files[file]
+        if not pyarrow_installed:
+            sys.modules["pyarrow"] = None
+        assert audbackend.checksum(path) == expected_checksum_function(path)
+        if not pyarrow_installed:
+            del sys.modules["pyarrow"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -53,10 +53,13 @@ class TestChecksum:
         table = table.replace_schema_metadata(metadata)
         parquet.write_table(table, cls.files[file], compression="snappy")
 
+        file = "folder"
+        cls.files[file] = audeer.mkdir(tmpdir, file)
+
     @pytest.mark.parametrize("pyarrow_installed", [True, False], indirect=True)
     @pytest.mark.parametrize(
         "file",
-        ["file.txt", "file.parquet", "file-metadata.parquet"],
+        ["file.txt", "file.parquet", "file-metadata.parquet", "folder"],
     )
     def test_checksum(self, file, pyarrow_installed):
         """Test checksum of local file.
@@ -90,6 +93,7 @@ class TestChecksum:
 
         """
         with pytest.raises(error, match=error_msg):
+            file = self.files.get(file, file)
             audbackend.checksum(file)
 
     def determine_expected_checksum(self, file, pyarrow_installed):


### PR DESCRIPTION
Tackles part of https://github.com/audeering/audb/issues/459

This copies the checksum handling for parquet files from `audb.core.utils.md5()` into the new function `audbackend.checksum()`. Inside `audbackend`, it replaces the usage of `audeer.md5()` by it, to make sure we are getting the correct checksum for local parquet files, which we use for example inside `audbackend.backend.Base.get_file()` to decide if the file exists already locally.

The checksum for parquet is given by its `"hash"` metadata entry, or if not available by `audeer.md5()`.
As `pyarrow` is not a dependency of `audbackend`, and should also not be, I decided to also use `audeer.md5()` if `pyarrow` is not installed and we can hence not access the metadata of the parquet file (or is there a way to access it with pure Python functions?).

![image](https://github.com/user-attachments/assets/5c944204-153b-47ee-bace-85221a7ead13)



## Summary by Sourcery

Add a new checksum function to the audbackend module, replacing the existing MD5 checksum method with support for deterministic checksums for parquet files using metadata. Update documentation and tests accordingly.

New Features:
- Introduce a new function audbackend.checksum() to calculate checksums for files, including support for deterministic checksums for parquet files using metadata.

Enhancements:
- Replace the usage of audeer.md5() with the new audbackend.checksum() function across the codebase for improved checksum handling.

Documentation:
- Update documentation to include the new audbackend.checksum() function and its usage.

Tests:
- Add new tests for the audbackend.checksum() function to ensure correct checksum calculation for different file types, including parquet files with and without metadata.

## Summary by Sourcery

Add a new checksum function to the audbackend module, replacing the existing MD5 checksum method with support for deterministic checksums for parquet files using metadata. Update documentation and tests accordingly.

New Features:
- Introduce a new function audbackend.checksum() to calculate checksums for files, including support for deterministic checksums for parquet files using metadata.

Enhancements:
- Replace the usage of audeer.md5() with the new audbackend.checksum() function across the codebase for improved checksum handling.

Documentation:
- Update documentation to include the new audbackend.checksum() function and its usage.

Tests:
- Add new tests for the audbackend.checksum() function to ensure correct checksum calculation for different file types, including parquet files with and without metadata.