### PR TITLE
Update license year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 audEERING GmbH and Contributors
+Copyright (c) 2021-present audEERING GmbH and Contributors
 
 Authors:
     Johannes Wagner


### PR DESCRIPTION
To be in line with our other packages, I added `-present` to the year in the `LICENSE` file.