### PR TITLE
Add minio and s3 to the Python package keywords

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ license = {file = 'LICENSE'}
 keywords = [
     'artifactory',
     'filesystem',
+    'minio',
+    's3',
 ]
 classifiers = [
     'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Adds `minio` and `s3` to the `keywords` entry in `pyptoject.toml`.

I also added those keywords to the Github repository.

## Summary by Sourcery

Chores:
- Add 'minio' and 's3' to the keywords in pyproject.toml for better discoverability.