### PR TITLE
TST: use sybil for doctests

### DIFF
--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -44,7 +44,7 @@ class Minio(Base):
         >>> backend = Minio(host, repository, authentication=auth)
         >>> try:
         ...     with backend:
-        ...         backend.put_file(file, "/sub/file.txt")
+        ...         backend.put_file("src.txt", "/sub/file.txt")
         ...         backend.ls()
         ... finally:
         ...     Minio.delete(host, repository, authentication=auth)

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -40,11 +40,11 @@ class Minio(Base):
         >>> auth = ("Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
         >>> repository = "my-data" + audeer.uid()
         >>> Minio.create(host, repository, authentication=auth)
-        >>> file = audeer.touch("file.txt")
+        >>> file = audeer.touch("src.txt")
         >>> backend = Minio(host, repository, authentication=auth)
         >>> try:
         ...     with backend:
-        ...         backend.put_file("src.txt", "/sub/file.txt")
+        ...         backend.put_file(file, "/sub/file.txt")
         ...         backend.ls()
         ... finally:
         ...     Minio.delete(host, repository, authentication=auth)

--- a/audbackend/core/conftest.py
+++ b/audbackend/core/conftest.py
@@ -16,7 +16,7 @@ import audbackend
 pytest_collect_file = sybil.Sybil(
     parsers=[DocTestParser(optionflags=doctest.ELLIPSIS)],
     patterns=["*.py"],
-    fixtures=["prepare_docstring_tests"],
+    fixtures=["prepare_docstring_tests", "filesystem_backend"],
 ).pytest()
 
 
@@ -34,6 +34,16 @@ class DoctestFileSystem(audbackend.backend.FileSystem):
         path: str,
     ) -> str:
         return "doctest"
+
+
+@pytest.fixture(scope="function")
+def filesystem_backend():
+    backend = audbackend.backend.FileSystem("host", "repo")
+    backend.open()
+
+    yield backend
+
+    backend.close()
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/audbackend/core/conftest.py
+++ b/audbackend/core/conftest.py
@@ -8,7 +8,6 @@ from sybil.parsers.rest import DocTestParser
 import audeer
 
 import audbackend
-from tests.conftest import filesystem  # noqa: F401
 
 
 # Collect doctests
@@ -23,6 +22,30 @@ pytest_collect_file = sybil.Sybil(
         "prepare_docstring_tests",
     ],
 ).pytest()
+
+
+@pytest.fixture(scope="function")
+def filesystem(tmpdir):
+    """Filesystem backend.
+
+    A repository with unique name is created
+    for the filesystem backend.
+    The filesystem backend is marked as opened
+    and returned.
+
+    Args:
+        tmpdir: tmpdir fixture
+
+    Returns:
+        filesystem backend object
+
+    """
+    repo = f"repo-{audeer.uid()[:8]}"
+    host = audeer.mkdir(tmpdir, "host")
+    audeer.mkdir(host, repo)
+    backend = audbackend.backend.FileSystem(host, repo)
+    backend.opened = True
+    yield backend
 
 
 @pytest.fixture(scope="function")

--- a/audbackend/core/conftest.py
+++ b/audbackend/core/conftest.py
@@ -1,7 +1,5 @@
 import datetime
 import doctest
-import os
-import tempfile
 
 import pytest
 import sybil
@@ -20,7 +18,15 @@ pytest_collect_file = sybil.Sybil(
 ).pytest()
 
 
-class DoctestFileSystem(audbackend.backend.FileSystem):
+class FileSystem(audbackend.backend.FileSystem):
+    def __init__(
+        self,
+        host: str,
+        repository: str,
+    ):
+        super().__init__(host, repository)
+        self.opened = True
+
     def _date(
         self,
         path: str,
@@ -38,34 +44,44 @@ class DoctestFileSystem(audbackend.backend.FileSystem):
 
 @pytest.fixture(scope="function")
 def filesystem_backend():
-    backend = audbackend.backend.FileSystem("host", "repo")
-    backend.open()
-
-    yield backend
-
-    backend.close()
+    yield FileSystem("host", "repo")
 
 
 @pytest.fixture(scope="function", autouse=True)
-def prepare_docstring_tests(doctest_namespace):
-    with tempfile.TemporaryDirectory() as tmp:
-        # Change to tmp dir
-        current_dir = os.getcwd()
-        os.chdir(tmp)
-        # Prepare backend
-        audeer.mkdir("host")
-        audbackend.backend.FileSystem.create("host", "repo")
-        # Provide example file `src.txt`
-        audeer.touch("src.txt")
-        # Provide DoctestFileSystem as FileSystem,
-        # and audbackend
-        # in docstring examples
-        doctest_namespace["DoctestFileSystem"] = DoctestFileSystem
-        doctest_namespace["audbackend"] = audbackend
+def prepare_docstring_tests(tmpdir, monkeypatch):
+    r"""Code to be run before each doctest."""
+    # Change to tmp dir
+    monkeypatch.chdir(tmpdir)
 
-        yield
+    # Provide example file `src.txt`
+    audeer.touch("src.txt")
 
-        # Remove backend
-        audbackend.backend.FileSystem.delete("host", "repo")
-        # Change back to current dir
-        os.chdir(current_dir)
+    # Prepare backend
+    audeer.mkdir("host", "repo")
+
+    yield
+
+
+# @pytest.fixture(scope="function", autouse=True)
+# def prepare_docstring_tests(doctest_namespace):
+#     with tempfile.TemporaryDirectory() as tmp:
+#         # Change to tmp dir
+#         current_dir = os.getcwd()
+#         os.chdir(tmp)
+#         # Prepare backend
+#         audeer.mkdir("host")
+#         audbackend.backend.FileSystem.create("host", "repo")
+#         # Provide example file `src.txt`
+#         audeer.touch("src.txt")
+#         # Provide DoctestFileSystem as FileSystem,
+#         # and audbackend
+#         # in docstring examples
+#         doctest_namespace["DoctestFileSystem"] = DoctestFileSystem
+#         doctest_namespace["audbackend"] = audbackend
+#
+#         yield
+#
+#         # Remove backend
+#         audbackend.backend.FileSystem.delete("host", "repo")
+#         # Change back to current dir
+#         os.chdir(current_dir)

--- a/audbackend/core/conftest.py
+++ b/audbackend/core/conftest.py
@@ -1,12 +1,22 @@
 import datetime
+import doctest
 import os
 import tempfile
 
 import pytest
+import sybil
+from sybil.parsers.rest import DocTestParser
 
 import audeer
 
 import audbackend
+
+
+# Collect doctests
+pytest_collect_file = sybil.Sybil(
+    parsers=[DocTestParser(optionflags=doctest.ELLIPSIS)],
+    patterns=["*.py"],
+).pytest()
 
 
 class DoctestFileSystem(audbackend.backend.FileSystem):

--- a/audbackend/core/conftest.py
+++ b/audbackend/core/conftest.py
@@ -16,6 +16,7 @@ import audbackend
 pytest_collect_file = sybil.Sybil(
     parsers=[DocTestParser(optionflags=doctest.ELLIPSIS)],
     patterns=["*.py"],
+    fixtures=["prepare_docstring_tests"],
 ).pytest()
 
 

--- a/audbackend/core/errors.py
+++ b/audbackend/core/errors.py
@@ -7,8 +7,7 @@ class BackendError(Exception):
     .. Prepare backend and interface for docstring examples
 
         >>> import audeer
-        >>> audeer.rmdir("host", "repo")
-        >>> _ = audeer.mkdir("host", "repo")
+        >>> import audbackend
 
     Examples:
         >>> backend = audbackend.backend.FileSystem("host", "repo")

--- a/audbackend/core/errors.py
+++ b/audbackend/core/errors.py
@@ -8,10 +8,11 @@ class BackendError(Exception):
 
         >>> import audeer
         >>> import audbackend
-        >>> _ = audeer.mkdir("host", "repo")
 
     Examples:
-        >>> backend = audbackend.backend.FileSystem("host", "repo")
+        >>> host = audeer.mkdir("host")
+        >>> audbackend.backend.FileSystem.create(host, "repo")
+        >>> backend = audbackend.backend.FileSystem(host, "repo")
         >>> backend.open()
         >>> try:
         ...     interface = audbackend.interface.Unversioned(backend)

--- a/audbackend/core/errors.py
+++ b/audbackend/core/errors.py
@@ -8,6 +8,7 @@ class BackendError(Exception):
 
         >>> import audeer
         >>> import audbackend
+        >>> _ = audeer.mkdir("host", "repo")
 
     Examples:
         >>> backend = audbackend.backend.FileSystem("host", "repo")

--- a/audbackend/core/interface/base.py
+++ b/audbackend/core/interface/base.py
@@ -36,8 +36,7 @@ class Base:
             backend object
 
         ..
-            >>> backend = audbackend.backend.FileSystem("host", "repo")
-            >>> interface = Base(backend)
+            >>> interface = Base(filesystem_backend)
 
         Examples:
             >>> interface.backend
@@ -53,8 +52,7 @@ class Base:
         Returns: host path
 
         ..
-            >>> backend = audbackend.backend.FileSystem("host", "repo")
-            >>> interface = Base(backend)
+            >>> interface = Base(filesystem_backend)
 
         Examples:
             >>> interface.host
@@ -83,8 +81,7 @@ class Base:
                 or if joined path contains invalid character
 
         ..
-            >>> backend = audbackend.backend.FileSystem("host", "repo")
-            >>> interface = Base(backend)
+            >>> interface = Base(filesystem_backend)
 
         Examples:
             >>> interface.join("/", "file.txt")
@@ -105,8 +102,7 @@ class Base:
             repository name
 
         ..
-            >>> backend = audbackend.backend.FileSystem("host", "repo")
-            >>> interface = Base(backend)
+            >>> interface = Base(filesystem_backend)
 
         Examples:
             >>> interface.repository
@@ -123,8 +119,7 @@ class Base:
             file separator
 
         ..
-            >>> backend = audbackend.backend.FileSystem("host", "repo")
-            >>> interface = Base(backend)
+            >>> interface = Base(filesystem_backend)
 
         Examples:
             >>> interface.sep
@@ -150,8 +145,7 @@ class Base:
                 does not match ``'[A-Za-z0-9/._-]+'``
 
         ..
-            >>> backend = audbackend.backend.FileSystem("host", "repo")
-            >>> interface = Base(backend)
+            >>> interface = Base(filesystem_backend)
 
         Examples:
             >>> interface.split("/")

--- a/audbackend/core/interface/base.py
+++ b/audbackend/core/interface/base.py
@@ -36,7 +36,9 @@ class Base:
             backend object
 
         ..
-            >>> interface = Base(filesystem_backend)
+            >>> import audbackend
+            >>> backend = audbackend.backend.FileSystem("host", "repo")
+            >>> interface = Base(backend)
 
         Examples:
             >>> interface.backend
@@ -50,9 +52,6 @@ class Base:
         r"""Host path.
 
         Returns: host path
-
-        ..
-            >>> interface = Base(filesystem_backend)
 
         Examples:
             >>> interface.host
@@ -80,9 +79,6 @@ class Base:
                 or does not start with ``'/'``,
                 or if joined path contains invalid character
 
-        ..
-            >>> interface = Base(filesystem_backend)
-
         Examples:
             >>> interface.join("/", "file.txt")
             '/file.txt'
@@ -101,9 +97,6 @@ class Base:
         Returns:
             repository name
 
-        ..
-            >>> interface = Base(filesystem_backend)
-
         Examples:
             >>> interface.repository
             'repo'
@@ -117,9 +110,6 @@ class Base:
 
         Returns:
             file separator
-
-        ..
-            >>> interface = Base(filesystem_backend)
 
         Examples:
             >>> interface.sep
@@ -143,9 +133,6 @@ class Base:
         Raises:
             ValueError: if ``path`` does not start with ``'/'`` or
                 does not match ``'[A-Za-z0-9/._-]+'``
-
-        ..
-            >>> interface = Base(filesystem_backend)
 
         Examples:
             >>> interface.split("/")

--- a/audbackend/core/interface/maven.py
+++ b/audbackend/core/interface/maven.py
@@ -68,10 +68,12 @@ class Maven(Versioned):
         >>> import audeer
 
     Examples:
-        >>> file = "src.txt"
-        >>> backend = audbackend.backend.FileSystem("host", "repo")
+        >>> host = audeer.mkdir("host")
+        >>> audbackend.backend.FileSystem.create(host, "repo")
+        >>> backend = audbackend.backend.FileSystem(host, "repo")
         >>> backend.open()
         >>> interface = Maven(backend)
+        >>> file = "src.txt"
         >>> interface.put_archive(".", "/sub/archive.zip", "1.0.0", files=[file])
         >>> for version in ["1.0.0", "2.0.0"]:
         ...     interface.put_file(file, "/file.txt", version)
@@ -79,9 +81,6 @@ class Maven(Versioned):
         [('/file.txt', '1.0.0'), ('/file.txt', '2.0.0'), ('/sub/archive.zip', '1.0.0')]
         >>> interface.get_file("/file.txt", "dst.txt", "2.0.0")
         '...dst.txt'
-
-    ..
-        >>> clear()
 
     """  # noqa: E501
 
@@ -146,7 +145,7 @@ class Maven(Versioned):
             RuntimeError: if backend was not opened
 
         ..
-            >>> interface = Maven(filesystem_backend)
+            >>> interface = Maven(filesystem)
 
         Examples:
             >>> file = "src.txt"
@@ -165,9 +164,6 @@ class Maven(Versioned):
             [('/sub/archive.zip', '1.0.0')]
             >>> interface.ls("/sub/")
             [('/sub/archive.zip', '1.0.0')]
-
-        ..
-            >>> clear()
 
         """  # noqa: E501
         if path.endswith("/"):  # find files under sub-path

--- a/audbackend/core/interface/maven.py
+++ b/audbackend/core/interface/maven.py
@@ -63,6 +63,9 @@ class Maven(Versioned):
             ...
             as extensions
 
+    ..
+        >>> import audbackend
+
     Examples:
         >>> file = "src.txt"
         >>> backend = audbackend.backend.FileSystem("host", "repo")
@@ -139,9 +142,7 @@ class Maven(Versioned):
             RuntimeError: if backend was not opened
 
         ..
-            >>> backend = audbackend.backend.FileSystem("host", "repo")
-            >>> backend.open()
-            >>> interface = Maven(backend)
+            >>> interface = Maven(filesystem_backend)
 
         Examples:
             >>> file = "src.txt"

--- a/audbackend/core/interface/maven.py
+++ b/audbackend/core/interface/maven.py
@@ -65,6 +65,7 @@ class Maven(Versioned):
 
     ..
         >>> import audbackend
+        >>> import audeer
 
     Examples:
         >>> file = "src.txt"
@@ -78,6 +79,9 @@ class Maven(Versioned):
         [('/file.txt', '1.0.0'), ('/file.txt', '2.0.0'), ('/sub/archive.zip', '1.0.0')]
         >>> interface.get_file("/file.txt", "dst.txt", "2.0.0")
         '...dst.txt'
+
+    ..
+        >>> clear()
 
     """  # noqa: E501
 
@@ -161,6 +165,9 @@ class Maven(Versioned):
             [('/sub/archive.zip', '1.0.0')]
             >>> interface.ls("/sub/")
             [('/sub/archive.zip', '1.0.0')]
+
+        ..
+            >>> clear()
 
         """  # noqa: E501
         if path.endswith("/"):  # find files under sub-path

--- a/audbackend/core/interface/unversioned.py
+++ b/audbackend/core/interface/unversioned.py
@@ -17,6 +17,17 @@ class Unversioned(Base):
 
     ..
         >>> import audbackend
+        >>> import audeer
+
+    ..    >>> def clear():
+    ..    ...    # Clear backend
+    ..    ...    audeer.rmdir("host", "repo")
+    ..    ...    audeer.mkdir("host", "repo")
+    ..    ...    # Clear local files
+    ..    ...    files = audeer.list_file_names(".", basenames=True)
+    ..    ...    files = [file for file in files if not file == "src.txt"]
+    ..    ...    for file in files:
+    ..    ...        os.remove(file)
 
     Examples:
         >>> file = "src.txt"
@@ -29,6 +40,9 @@ class Unversioned(Base):
         ['/file.txt', '/sub/archive.zip']
         >>> interface.get_file("/file.txt", "dst.txt")
         '...dst.txt'
+
+    ..
+        >>> clear()
 
     """
 
@@ -63,6 +77,9 @@ class Unversioned(Base):
             >>> interface.put_file(file, "/file.txt")
             >>> interface.checksum("/file.txt")
             'd41d8cd98f00b204e9800998ecf8427e'
+
+        ..
+            >>> clear()
 
         """
         return self.backend.checksum(path)
@@ -118,6 +135,9 @@ class Unversioned(Base):
             >>> interface.exists("/copy.txt")
             True
 
+        ..
+            >>> clear()
+
         """
         self.backend.copy_file(
             src_path,
@@ -157,6 +177,9 @@ class Unversioned(Base):
             >>> interface.put_file(file, "/file.txt")
             >>> interface.date("/file.txt")
             '1991-02-20'
+
+        ..
+            >>> clear()
 
         """
         return self.backend.date(path)
@@ -199,6 +222,9 @@ class Unversioned(Base):
             >>> interface.put_file(file, "/file.txt")
             >>> interface.exists("/file.txt")
             True
+
+        ..
+            >>> clear()
 
         """
         return self.backend.exists(
@@ -267,6 +293,9 @@ class Unversioned(Base):
             >>> os.remove(file)
             >>> interface.get_archive("/sub/archive.zip", ".")
             ['src.txt']
+
+        ..
+            >>> clear()
 
         """
         return self.backend.get_archive(
@@ -338,6 +367,9 @@ class Unversioned(Base):
             >>> _ = interface.get_file("/file.txt", "dst.txt")
             >>> os.path.exists("dst.txt")
             True
+
+        ..
+            >>> clear()
 
         """
         return self.backend.get_file(
@@ -411,6 +443,9 @@ class Unversioned(Base):
             >>> interface.ls("/sub/")
             ['/sub/archive.zip']
 
+        ..
+            >>> clear()
+
         """  # noqa: E501
         return self.backend.ls(
             path,
@@ -475,6 +510,9 @@ class Unversioned(Base):
             >>> interface.exists("/file.txt")
             False
 
+        ..
+            >>> clear()
+
         """
         self.backend.move_file(
             src_path,
@@ -516,6 +554,7 @@ class Unversioned(Base):
             >>> interface.owner("/file.txt")
             'doctest'
 
+            >>> clear()
         """
         return self.backend.owner(path)
 
@@ -587,6 +626,8 @@ class Unversioned(Base):
             >>> interface.exists("/sub/archive.tar.gz")
             True
 
+            >>> clear()
+
         """
         self.backend.put_archive(
             src_root,
@@ -647,6 +688,9 @@ class Unversioned(Base):
             >>> interface.exists("/file.txt")
             True
 
+        ..
+            >>> clear()
+
         """
         self.backend.put_file(
             src_path,
@@ -682,6 +726,9 @@ class Unversioned(Base):
             >>> interface.remove_file("/file.txt")
             >>> interface.exists("/file.txt")
             False
+
+        ..
+            >>> clear()
 
         """
         self.backend.remove_file(path)

--- a/audbackend/core/interface/unversioned.py
+++ b/audbackend/core/interface/unversioned.py
@@ -151,9 +151,7 @@ class Unversioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> backend = DoctestFileSystem("host", "repo")
-            >>> backend.open()
-            >>> interface = Unversioned(backend)
+            >>> interface = Unversioned(filesystem_backend)
 
         Examples:
             >>> file = "src.txt"
@@ -521,9 +519,7 @@ class Unversioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> backend = DoctestFileSystem("host", "repo")
-            >>> backend.open()
-            >>> interface = Unversioned(backend)
+            >>> interface = Unversioned(filesystem_backend)
 
         Examples:
             >>> file = "src.txt"

--- a/audbackend/core/interface/unversioned.py
+++ b/audbackend/core/interface/unversioned.py
@@ -20,19 +20,18 @@ class Unversioned(Base):
         >>> import audeer
 
     Examples:
-        >>> file = "src.txt"
-        >>> backend = audbackend.backend.FileSystem("host", "repo")
+        >>> host = audeer.mkdir("host")
+        >>> audbackend.backend.FileSystem.create(host, "repo")
+        >>> backend = audbackend.backend.FileSystem(host, "repo")
         >>> backend.open()
         >>> interface = Unversioned(backend)
+        >>> file = "src.txt"
         >>> interface.put_file(file, "/file.txt")
         >>> interface.put_archive(".", "/sub/archive.zip", files=[file])
         >>> interface.ls()
         ['/file.txt', '/sub/archive.zip']
         >>> interface.get_file("/file.txt", "dst.txt")
         '...dst.txt'
-
-    ..
-        >>> clear()
 
     """
 
@@ -338,11 +337,8 @@ class Unversioned(Base):
         Examples:
             >>> file = "src.txt"
             >>> interface.put_file(file, "/file.txt")
-            >>> os.path.exists("dst.txt")
-            False
-            >>> _ = interface.get_file("/file.txt", "dst.txt")
-            >>> os.path.exists("dst.txt")
-            True
+            >>> interface.get_file("/file.txt", "dst.txt")
+            '...dst.txt'
 
         """
         return self.backend.get_file(

--- a/audbackend/core/interface/unversioned.py
+++ b/audbackend/core/interface/unversioned.py
@@ -15,6 +15,9 @@ class Unversioned(Base):
     Args:
         backend: backend object
 
+    ..
+        >>> import audbackend
+
     Examples:
         >>> file = "src.txt"
         >>> backend = audbackend.backend.FileSystem("host", "repo")
@@ -50,9 +53,7 @@ class Unversioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> backend = audbackend.backend.FileSystem("host", "repo")
-            >>> backend.open()
-            >>> interface = Unversioned(backend)
+            >>> interface = Unversioned(filesystem_backend)
 
         Examples:
             >>> file = "src.txt"
@@ -106,9 +107,7 @@ class Unversioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> backend = audbackend.backend.FileSystem("host", "repo")
-            >>> backend.open()
-            >>> interface = Unversioned(backend)
+            >>> interface = Unversioned(filesystem_backend)
 
         Examples:
             >>> file = "src.txt"
@@ -191,9 +190,7 @@ class Unversioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> backend = audbackend.backend.FileSystem("host", "repo")
-            >>> backend.open()
-            >>> interface = Unversioned(backend)
+            >>> interface = Unversioned(filesystem_backend)
 
         Examples:
             >>> file = "src.txt"
@@ -262,9 +259,7 @@ class Unversioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> backend = audbackend.backend.FileSystem("host", "repo")
-            >>> backend.open()
-            >>> interface = Unversioned(backend)
+            >>> interface = Unversioned(filesystem_backend)
 
         Examples:
             >>> file = "src.txt"
@@ -333,9 +328,7 @@ class Unversioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> backend = audbackend.backend.FileSystem("host", "repo")
-            >>> backend.open()
-            >>> interface = Unversioned(backend)
+            >>> interface = Unversioned(filesystem_backend)
 
         Examples:
             >>> file = "src.txt"
@@ -401,9 +394,7 @@ class Unversioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> backend = audbackend.backend.FileSystem("host", "repo")
-            >>> backend.open()
-            >>> interface = Unversioned(backend)
+            >>> interface = Unversioned(filesystem_backend)
 
         Examples:
             >>> file = "src.txt"
@@ -471,9 +462,7 @@ class Unversioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> backend = audbackend.backend.FileSystem("host", "repo")
-            >>> backend.open()
-            >>> interface = Unversioned(backend)
+            >>> interface = Unversioned(filesystem_backend)
 
         Examples:
             >>> file = "src.txt"
@@ -588,9 +577,7 @@ class Unversioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> backend = audbackend.backend.FileSystem("host", "repo")
-            >>> backend.open()
-            >>> interface = Unversioned(backend)
+            >>> interface = Unversioned(filesystem_backend)
 
         Examples:
             >>> file = "src.txt"
@@ -650,9 +637,7 @@ class Unversioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> backend = audbackend.backend.FileSystem("host", "repo")
-            >>> backend.open()
-            >>> interface = Unversioned(backend)
+            >>> interface = Unversioned(filesystem_backend)
 
         Examples:
             >>> file = "src.txt"
@@ -687,9 +672,7 @@ class Unversioned(Base):
                 or does not match ``'[A-Za-z0-9/._-]+'``
 
         ..
-            >>> backend = audbackend.backend.FileSystem("host", "repo")
-            >>> backend.open()
-            >>> interface = Unversioned(backend)
+            >>> interface = Unversioned(filesystem_backend)
 
         Examples:
             >>> file = "src.txt"

--- a/audbackend/core/interface/unversioned.py
+++ b/audbackend/core/interface/unversioned.py
@@ -19,16 +19,6 @@ class Unversioned(Base):
         >>> import audbackend
         >>> import audeer
 
-    ..    >>> def clear():
-    ..    ...    # Clear backend
-    ..    ...    audeer.rmdir("host", "repo")
-    ..    ...    audeer.mkdir("host", "repo")
-    ..    ...    # Clear local files
-    ..    ...    files = audeer.list_file_names(".", basenames=True)
-    ..    ...    files = [file for file in files if not file == "src.txt"]
-    ..    ...    for file in files:
-    ..    ...        os.remove(file)
-
     Examples:
         >>> file = "src.txt"
         >>> backend = audbackend.backend.FileSystem("host", "repo")
@@ -67,7 +57,7 @@ class Unversioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> interface = Unversioned(filesystem_backend)
+            >>> interface = Unversioned(filesystem)
 
         Examples:
             >>> file = "src.txt"
@@ -77,9 +67,6 @@ class Unversioned(Base):
             >>> interface.put_file(file, "/file.txt")
             >>> interface.checksum("/file.txt")
             'd41d8cd98f00b204e9800998ecf8427e'
-
-        ..
-            >>> clear()
 
         """
         return self.backend.checksum(path)
@@ -124,7 +111,7 @@ class Unversioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> interface = Unversioned(filesystem_backend)
+            >>> interface = Unversioned(filesystem)
 
         Examples:
             >>> file = "src.txt"
@@ -134,9 +121,6 @@ class Unversioned(Base):
             >>> interface.copy_file("/file.txt", "/copy.txt")
             >>> interface.exists("/copy.txt")
             True
-
-        ..
-            >>> clear()
 
         """
         self.backend.copy_file(
@@ -170,16 +154,14 @@ class Unversioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> interface = Unversioned(filesystem_backend)
+            >>> interface = Unversioned(filesystem)
+            >>> interface.date = mock_date
 
         Examples:
             >>> file = "src.txt"
             >>> interface.put_file(file, "/file.txt")
             >>> interface.date("/file.txt")
             '1991-02-20'
-
-        ..
-            >>> clear()
 
         """
         return self.backend.date(path)
@@ -213,7 +195,7 @@ class Unversioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> interface = Unversioned(filesystem_backend)
+            >>> interface = Unversioned(filesystem)
 
         Examples:
             >>> file = "src.txt"
@@ -222,9 +204,6 @@ class Unversioned(Base):
             >>> interface.put_file(file, "/file.txt")
             >>> interface.exists("/file.txt")
             True
-
-        ..
-            >>> clear()
 
         """
         return self.backend.exists(
@@ -285,7 +264,7 @@ class Unversioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> interface = Unversioned(filesystem_backend)
+            >>> interface = Unversioned(filesystem)
 
         Examples:
             >>> file = "src.txt"
@@ -293,9 +272,6 @@ class Unversioned(Base):
             >>> os.remove(file)
             >>> interface.get_archive("/sub/archive.zip", ".")
             ['src.txt']
-
-        ..
-            >>> clear()
 
         """
         return self.backend.get_archive(
@@ -357,7 +333,7 @@ class Unversioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> interface = Unversioned(filesystem_backend)
+            >>> interface = Unversioned(filesystem)
 
         Examples:
             >>> file = "src.txt"
@@ -367,9 +343,6 @@ class Unversioned(Base):
             >>> _ = interface.get_file("/file.txt", "dst.txt")
             >>> os.path.exists("dst.txt")
             True
-
-        ..
-            >>> clear()
 
         """
         return self.backend.get_file(
@@ -426,7 +399,7 @@ class Unversioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> interface = Unversioned(filesystem_backend)
+            >>> interface = Unversioned(filesystem)
 
         Examples:
             >>> file = "src.txt"
@@ -442,9 +415,6 @@ class Unversioned(Base):
             ['/sub/archive.zip']
             >>> interface.ls("/sub/")
             ['/sub/archive.zip']
-
-        ..
-            >>> clear()
 
         """  # noqa: E501
         return self.backend.ls(
@@ -497,7 +467,7 @@ class Unversioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> interface = Unversioned(filesystem_backend)
+            >>> interface = Unversioned(filesystem)
 
         Examples:
             >>> file = "src.txt"
@@ -509,9 +479,6 @@ class Unversioned(Base):
             True
             >>> interface.exists("/file.txt")
             False
-
-        ..
-            >>> clear()
 
         """
         self.backend.move_file(
@@ -546,7 +513,8 @@ class Unversioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> interface = Unversioned(filesystem_backend)
+            >>> interface = Unversioned(filesystem)
+            >>> interface.owner = mock_owner
 
         Examples:
             >>> file = "src.txt"
@@ -554,7 +522,6 @@ class Unversioned(Base):
             >>> interface.owner("/file.txt")
             'doctest'
 
-            >>> clear()
         """
         return self.backend.owner(path)
 
@@ -616,7 +583,7 @@ class Unversioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> interface = Unversioned(filesystem_backend)
+            >>> interface = Unversioned(filesystem)
 
         Examples:
             >>> file = "src.txt"
@@ -625,8 +592,6 @@ class Unversioned(Base):
             >>> interface.put_archive(".", "/sub/archive.tar.gz")
             >>> interface.exists("/sub/archive.tar.gz")
             True
-
-            >>> clear()
 
         """
         self.backend.put_archive(
@@ -678,7 +643,7 @@ class Unversioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> interface = Unversioned(filesystem_backend)
+            >>> interface = Unversioned(filesystem)
 
         Examples:
             >>> file = "src.txt"
@@ -687,9 +652,6 @@ class Unversioned(Base):
             >>> interface.put_file(file, "/file.txt")
             >>> interface.exists("/file.txt")
             True
-
-        ..
-            >>> clear()
 
         """
         self.backend.put_file(
@@ -716,7 +678,7 @@ class Unversioned(Base):
                 or does not match ``'[A-Za-z0-9/._-]+'``
 
         ..
-            >>> interface = Unversioned(filesystem_backend)
+            >>> interface = Unversioned(filesystem)
 
         Examples:
             >>> file = "src.txt"
@@ -726,9 +688,6 @@ class Unversioned(Base):
             >>> interface.remove_file("/file.txt")
             >>> interface.exists("/file.txt")
             False
-
-        ..
-            >>> clear()
 
         """
         self.backend.remove_file(path)

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -23,13 +23,15 @@ class Versioned(Base):
 
     ..
         >>> import audbackend
-        >>> backend = filesystem
+        >>> import audeer
 
     Examples:
+        >>> host = audeer.mkdir("host")
+        >>> audbackend.backend.FileSystem.create(host, "repo")
+        >>> backend = audbackend.backend.FileSystem(host, "repo")
+        >>> backend.open()
+        >>> interface = Versioned(backend)
         >>> file = "src.txt"
-        >>> # backend = audbackend.backend.FileSystem("host", "repo")
-        >>> # backend.open()
-        >>> interface = Versioned(filesystem)
         >>> interface.put_archive(".", "/sub/archive.zip", "1.0.0", files=[file])
         >>> for version in ["1.0.0", "2.0.0"]:
         ...     interface.put_file(file, "/file.txt", version)
@@ -384,14 +386,10 @@ class Versioned(Base):
             >>> interface = Versioned(filesystem)
 
         Examples:
-            >>> src_file = "src.txt"
-            >>> dst_file = "dst.txt"
-            >>> interface.put_file(src_file, "/file.txt", "1.0.0")
-            >>> os.path.exists(dst_file)
-            False
-            >>> dst_file = interface.get_file("/file.txt", dst_file, "1.0.0")
-            >>> os.path.exists(dst_file)
-            True
+            >>> file = "src.txt"
+            >>> interface.put_file(file, "/file.txt", "1.0.0")
+            >>> interface.get_file("/file.txt", "dst.txt", "1.0.0")
+            '...dst.txt'
 
         """
         src_path_with_version = self._path_with_version(src_path, version)

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -21,7 +21,8 @@ class Versioned(Base):
     Args:
         backend: backend object
 
-    .. Prepare backend and interface for docstring examples
+    ..
+        >>> import audbackend
 
     Examples:
         >>> file = "src.txt"

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -23,12 +23,13 @@ class Versioned(Base):
 
     ..
         >>> import audbackend
+        >>> backend = filesystem
 
     Examples:
         >>> file = "src.txt"
-        >>> backend = audbackend.backend.FileSystem("host", "repo")
-        >>> backend.open()
-        >>> interface = Versioned(backend)
+        >>> # backend = audbackend.backend.FileSystem("host", "repo")
+        >>> # backend.open()
+        >>> interface = Versioned(filesystem)
         >>> interface.put_archive(".", "/sub/archive.zip", "1.0.0", files=[file])
         >>> for version in ["1.0.0", "2.0.0"]:
         ...     interface.put_file(file, "/file.txt", version)
@@ -36,9 +37,6 @@ class Versioned(Base):
         [('/file.txt', '1.0.0'), ('/file.txt', '2.0.0'), ('/sub/archive.zip', '1.0.0')]
         >>> interface.get_file("/file.txt", "dst.txt", "2.0.0")
         '...dst.txt'
-
-    ..
-        >>> clear()
 
     """
 
@@ -73,7 +71,7 @@ class Versioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> interface = Versioned(filesystem_backend)
+            >>> interface = Versioned(filesystem)
 
         Examples:
             >>> file = "src.txt"
@@ -83,9 +81,6 @@ class Versioned(Base):
             >>> interface.put_file(file, "/file.txt", "1.0.0")
             >>> interface.checksum("/file.txt", "1.0.0")
             'd41d8cd98f00b204e9800998ecf8427e'
-
-        ..
-            >>> clear()
 
         """
         path_with_version = self._path_with_version(path, version)
@@ -139,7 +134,7 @@ class Versioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> interface = Versioned(filesystem_backend)
+            >>> interface = Versioned(filesystem)
 
         Examples:
             >>> file = "src.txt"
@@ -149,9 +144,6 @@ class Versioned(Base):
             >>> interface.copy_file("/file.txt", "/copy.txt", version="1.0.0")
             >>> interface.exists("/copy.txt", "1.0.0")
             True
-
-        ..
-            >>> clear()
 
         """
         if version is None:
@@ -197,16 +189,14 @@ class Versioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> interface = Versioned(filesystem_backend)
+            >>> interface = Versioned(filesystem)
+            >>> interface.date = mock_date
 
         Examples:
             >>> file = "src.txt"
             >>> interface.put_file(file, "/file.txt", "1.0.0")
             >>> interface.date("/file.txt", "1.0.0")
             '1991-02-20'
-
-        ..
-            >>> clear()
 
         """
         path_with_version = self._path_with_version(path, version)
@@ -243,7 +233,7 @@ class Versioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> interface = Versioned(filesystem_backend)
+            >>> interface = Versioned(filesystem)
 
         Examples:
             >>> file = "src.txt"
@@ -252,9 +242,6 @@ class Versioned(Base):
             >>> interface.put_file(file, "/file.txt", "1.0.0")
             >>> interface.exists("/file.txt", "1.0.0")
             True
-
-        ..
-            >>> clear()
 
         """
         path_with_version = self._path_with_version(path, version)
@@ -320,7 +307,7 @@ class Versioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> interface = Versioned(filesystem_backend)
+            >>> interface = Versioned(filesystem)
 
         Examples:
             >>> file = "src.txt"
@@ -328,9 +315,6 @@ class Versioned(Base):
             >>> os.remove(file)
             >>> interface.get_archive("/sub/archive.zip", ".", "1.0.0")
             ['src.txt']
-
-        ..
-            >>> clear()
 
         """
         src_path_with_version = self._path_with_version(src_path, version)
@@ -397,19 +381,17 @@ class Versioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> interface = Versioned(filesystem_backend)
+            >>> interface = Versioned(filesystem)
 
         Examples:
-            >>> file = "src.txt"
-            >>> interface.put_file(file, "/file.txt", "1.0.0")
-            >>> os.path.exists("dst.txt")
+            >>> src_file = "src.txt"
+            >>> dst_file = "dst.txt"
+            >>> interface.put_file(src_file, "/file.txt", "1.0.0")
+            >>> os.path.exists(dst_file)
             False
-            >>> _ = interface.get_file("/file.txt", "dst.txt", "1.0.0")
-            >>> os.path.exists("dst.txt")
+            >>> dst_file = interface.get_file("/file.txt", dst_file, "1.0.0")
+            >>> os.path.exists(dst_file)
             True
-
-        ..
-            >>> clear()
 
         """
         src_path_with_version = self._path_with_version(src_path, version)
@@ -441,7 +423,7 @@ class Versioned(Base):
             RuntimeError: if backend was not opened
 
          ..
-            >>> interface = Versioned(filesystem_backend)
+            >>> interface = Versioned(filesystem)
 
         Examples:
             >>> file = "src.txt"
@@ -449,9 +431,6 @@ class Versioned(Base):
             >>> interface.put_file(file, "/file.txt", "2.0.0")
             >>> interface.latest_version("/file.txt")
             '2.0.0'
-
-        ..
-            >>> clear()
 
         """
         vs = self.versions(path)
@@ -507,7 +486,7 @@ class Versioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> interface = Versioned(filesystem_backend)
+            >>> interface = Versioned(filesystem)
 
         Examples:
             >>> file = "src.txt"
@@ -526,9 +505,6 @@ class Versioned(Base):
             [('/sub/archive.zip', '1.0.0')]
             >>> interface.ls("/sub/")
             [('/sub/archive.zip', '1.0.0')]
-
-        ..
-            >>> clear()
 
         """  # noqa: E501
         if path.endswith("/"):  # find files under sub-path
@@ -650,7 +626,7 @@ class Versioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> interface = Versioned(filesystem_backend)
+            >>> interface = Versioned(filesystem)
 
         Examples:
             >>> file = "src.txt"
@@ -662,9 +638,6 @@ class Versioned(Base):
             True
             >>> interface.exists("/file.txt", "1.0.0")
             False
-
-        ..
-            >>> clear()
 
         """
         if version is None:
@@ -711,16 +684,14 @@ class Versioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> interface = Versioned(filesystem_backend)
+            >>> interface = Versioned(filesystem)
+            >>> interface.owner = mock_owner
 
         Examples:
             >>> file = "src.txt"
             >>> interface.put_file(file, "/file.txt", "1.0.0")
             >>> interface.owner("/file.txt", "1.0.0")
             'doctest'
-
-        ..
-            >>> clear()
 
         """
         path_with_version = self._path_with_version(path, version)
@@ -788,7 +759,7 @@ class Versioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> interface = Versioned(filesystem_backend)
+            >>> interface = Versioned(filesystem)
 
         Examples:
             >>> file = "src.txt"
@@ -797,9 +768,6 @@ class Versioned(Base):
             >>> interface.put_archive(".", "/sub/archive.tar.gz", "1.0.0")
             >>> interface.exists("/sub/archive.tar.gz", "1.0.0")
             True
-
-        ..
-            >>> clear()
 
         """
         dst_path_with_version = self._path_with_version(dst_path, version)
@@ -859,7 +827,7 @@ class Versioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> interface = Versioned(filesystem_backend)
+            >>> interface = Versioned(filesystem)
 
         Examples:
             >>> file = "src.txt"
@@ -868,9 +836,6 @@ class Versioned(Base):
             >>> interface.put_file(file, "/file.txt", "3.0.0")
             >>> interface.exists("/file.txt", "3.0.0")
             True
-
-        ..
-            >>> clear()
 
         """
         dst_path_with_version = self._path_with_version(dst_path, version)
@@ -903,7 +868,7 @@ class Versioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> interface = Versioned(filesystem_backend)
+            >>> interface = Versioned(filesystem)
 
         Examples:
             >>> file = "src.txt"
@@ -913,9 +878,6 @@ class Versioned(Base):
             >>> interface.remove_file("/file.txt", "1.0.0")
             >>> interface.exists("/file.txt", "1.0.0")
             False
-
-        ..
-            >>> clear()
 
         """
         path_with_version = self._path_with_version(path, version)
@@ -948,7 +910,7 @@ class Versioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> interface = Versioned(filesystem_backend)
+            >>> interface = Versioned(filesystem)
 
         Examples:
             >>> file = "src.txt"
@@ -956,9 +918,6 @@ class Versioned(Base):
             >>> interface.put_file(file, "/file.txt", "2.0.0")
             >>> interface.versions("/file.txt")
             ['1.0.0', '2.0.0']
-
-        ..
-            >>> clear()
 
         """
         utils.check_path(path)

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -37,6 +37,8 @@ class Versioned(Base):
         >>> interface.get_file("/file.txt", "dst.txt", "2.0.0")
         '...dst.txt'
 
+    ..
+        >>> clear()
 
     """
 
@@ -71,9 +73,7 @@ class Versioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> backend = audbackend.backend.FileSystem("host", "repo")
-            >>> backend.open()
-            >>> interface = Versioned(backend)
+            >>> interface = Versioned(filesystem_backend)
 
         Examples:
             >>> file = "src.txt"
@@ -83,6 +83,9 @@ class Versioned(Base):
             >>> interface.put_file(file, "/file.txt", "1.0.0")
             >>> interface.checksum("/file.txt", "1.0.0")
             'd41d8cd98f00b204e9800998ecf8427e'
+
+        ..
+            >>> clear()
 
         """
         path_with_version = self._path_with_version(path, version)
@@ -136,9 +139,7 @@ class Versioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> backend = audbackend.backend.FileSystem("host", "repo")
-            >>> backend.open()
-            >>> interface = Versioned(backend)
+            >>> interface = Versioned(filesystem_backend)
 
         Examples:
             >>> file = "src.txt"
@@ -148,6 +149,9 @@ class Versioned(Base):
             >>> interface.copy_file("/file.txt", "/copy.txt", version="1.0.0")
             >>> interface.exists("/copy.txt", "1.0.0")
             True
+
+        ..
+            >>> clear()
 
         """
         if version is None:
@@ -201,6 +205,9 @@ class Versioned(Base):
             >>> interface.date("/file.txt", "1.0.0")
             '1991-02-20'
 
+        ..
+            >>> clear()
+
         """
         path_with_version = self._path_with_version(path, version)
         return self.backend.date(path_with_version)
@@ -236,9 +243,7 @@ class Versioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> backend = audbackend.backend.FileSystem("host", "repo")
-            >>> backend.open()
-            >>> interface = Versioned(backend)
+            >>> interface = Versioned(filesystem_backend)
 
         Examples:
             >>> file = "src.txt"
@@ -247,6 +252,9 @@ class Versioned(Base):
             >>> interface.put_file(file, "/file.txt", "1.0.0")
             >>> interface.exists("/file.txt", "1.0.0")
             True
+
+        ..
+            >>> clear()
 
         """
         path_with_version = self._path_with_version(path, version)
@@ -312,9 +320,7 @@ class Versioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> backend = audbackend.backend.FileSystem("host", "repo")
-            >>> backend.open()
-            >>> interface = Versioned(backend)
+            >>> interface = Versioned(filesystem_backend)
 
         Examples:
             >>> file = "src.txt"
@@ -322,6 +328,9 @@ class Versioned(Base):
             >>> os.remove(file)
             >>> interface.get_archive("/sub/archive.zip", ".", "1.0.0")
             ['src.txt']
+
+        ..
+            >>> clear()
 
         """
         src_path_with_version = self._path_with_version(src_path, version)
@@ -388,9 +397,7 @@ class Versioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> backend = audbackend.backend.FileSystem("host", "repo")
-            >>> backend.open()
-            >>> interface = Versioned(backend)
+            >>> interface = Versioned(filesystem_backend)
 
         Examples:
             >>> file = "src.txt"
@@ -400,6 +407,9 @@ class Versioned(Base):
             >>> _ = interface.get_file("/file.txt", "dst.txt", "1.0.0")
             >>> os.path.exists("dst.txt")
             True
+
+        ..
+            >>> clear()
 
         """
         src_path_with_version = self._path_with_version(src_path, version)
@@ -431,9 +441,7 @@ class Versioned(Base):
             RuntimeError: if backend was not opened
 
          ..
-            >>> backend = audbackend.backend.FileSystem("host", "repo")
-            >>> backend.open()
-            >>> interface = Versioned(backend)
+            >>> interface = Versioned(filesystem_backend)
 
         Examples:
             >>> file = "src.txt"
@@ -441,6 +449,9 @@ class Versioned(Base):
             >>> interface.put_file(file, "/file.txt", "2.0.0")
             >>> interface.latest_version("/file.txt")
             '2.0.0'
+
+        ..
+            >>> clear()
 
         """
         vs = self.versions(path)
@@ -496,9 +507,7 @@ class Versioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> backend = audbackend.backend.FileSystem("host", "repo")
-            >>> backend.open()
-            >>> interface = Versioned(backend)
+            >>> interface = Versioned(filesystem_backend)
 
         Examples:
             >>> file = "src.txt"
@@ -517,6 +526,9 @@ class Versioned(Base):
             [('/sub/archive.zip', '1.0.0')]
             >>> interface.ls("/sub/")
             [('/sub/archive.zip', '1.0.0')]
+
+        ..
+            >>> clear()
 
         """  # noqa: E501
         if path.endswith("/"):  # find files under sub-path
@@ -638,9 +650,7 @@ class Versioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> backend = audbackend.backend.FileSystem("host", "repo")
-            >>> backend.open()
-            >>> interface = Versioned(backend)
+            >>> interface = Versioned(filesystem_backend)
 
         Examples:
             >>> file = "src.txt"
@@ -652,6 +662,9 @@ class Versioned(Base):
             True
             >>> interface.exists("/file.txt", "1.0.0")
             False
+
+        ..
+            >>> clear()
 
         """
         if version is None:
@@ -705,6 +718,9 @@ class Versioned(Base):
             >>> interface.put_file(file, "/file.txt", "1.0.0")
             >>> interface.owner("/file.txt", "1.0.0")
             'doctest'
+
+        ..
+            >>> clear()
 
         """
         path_with_version = self._path_with_version(path, version)
@@ -772,9 +788,7 @@ class Versioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> backend = audbackend.backend.FileSystem("host", "repo")
-            >>> backend.open()
-            >>> interface = Versioned(backend)
+            >>> interface = Versioned(filesystem_backend)
 
         Examples:
             >>> file = "src.txt"
@@ -783,6 +797,9 @@ class Versioned(Base):
             >>> interface.put_archive(".", "/sub/archive.tar.gz", "1.0.0")
             >>> interface.exists("/sub/archive.tar.gz", "1.0.0")
             True
+
+        ..
+            >>> clear()
 
         """
         dst_path_with_version = self._path_with_version(dst_path, version)
@@ -842,9 +859,7 @@ class Versioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> backend = audbackend.backend.FileSystem("host", "repo")
-            >>> backend.open()
-            >>> interface = Versioned(backend)
+            >>> interface = Versioned(filesystem_backend)
 
         Examples:
             >>> file = "src.txt"
@@ -853,6 +868,9 @@ class Versioned(Base):
             >>> interface.put_file(file, "/file.txt", "3.0.0")
             >>> interface.exists("/file.txt", "3.0.0")
             True
+
+        ..
+            >>> clear()
 
         """
         dst_path_with_version = self._path_with_version(dst_path, version)
@@ -885,9 +903,7 @@ class Versioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> backend = audbackend.backend.FileSystem("host", "repo")
-            >>> backend.open()
-            >>> interface = Versioned(backend)
+            >>> interface = Versioned(filesystem_backend)
 
         Examples:
             >>> file = "src.txt"
@@ -897,6 +913,9 @@ class Versioned(Base):
             >>> interface.remove_file("/file.txt", "1.0.0")
             >>> interface.exists("/file.txt", "1.0.0")
             False
+
+        ..
+            >>> clear()
 
         """
         path_with_version = self._path_with_version(path, version)
@@ -929,9 +948,7 @@ class Versioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> backend = audbackend.backend.FileSystem("host", "repo")
-            >>> backend.open()
-            >>> interface = Versioned(backend)
+            >>> interface = Versioned(filesystem_backend)
 
         Examples:
             >>> file = "src.txt"
@@ -939,6 +956,9 @@ class Versioned(Base):
             >>> interface.put_file(file, "/file.txt", "2.0.0")
             >>> interface.versions("/file.txt")
             ['1.0.0', '2.0.0']
+
+        ..
+            >>> clear()
 
         """
         utils.check_path(path)

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -192,9 +192,7 @@ class Versioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> backend = DoctestFileSystem("host", "repo")
-            >>> backend.open()
-            >>> interface = Versioned(backend)
+            >>> interface = Versioned(filesystem_backend)
 
         Examples:
             >>> file = "src.txt"
@@ -699,9 +697,7 @@ class Versioned(Base):
             RuntimeError: if backend was not opened
 
         ..
-            >>> backend = DoctestFileSystem("host", "repo")
-            >>> backend.open()
-            >>> interface = Versioned(backend)
+            >>> interface = Versioned(filesystem_backend)
 
         Examples:
             >>> file = "src.txt"

--- a/audbackend/core/utils.py
+++ b/audbackend/core/utils.py
@@ -115,10 +115,11 @@ def checksum(file: str) -> str:
         >>> hash = audformat.utils.hash(df, strict=True)
         >>> hash
         '9021a9b6e1e696ba9de4fe29346319b2'
+        >>> parquet_file = audeer.path("file.parquet")
         >>> table = pa.Table.from_pandas(df)
         >>> table = table.replace_schema_metadata({"hash": hash})
-        >>> pq.write_table(table, "file.parquet", compression="snappy")
-        >>> checksum("file.parquet")
+        >>> pq.write_table(table, parquet_file, compression="snappy")
+        >>> checksum(parquet_file)
         '9021a9b6e1e696ba9de4fe29346319b2'
 
     """

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,6 @@ exclude_patterns = [
 ]
 pygments_style = None
 extensions = [
-    "jupyter_sphinx",
     "sphinx.ext.napoleon",
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,0 +1,16 @@
+from doctest import ELLIPSIS
+
+from sybil import Sybil
+from sybil.parsers.rest import DocTestParser
+from sybil.parsers.rest import PythonCodeBlockParser
+
+from audbackend.core.conftest import mock_date  # noqa: F401
+from audbackend.core.conftest import mock_owner  # noqa: F401
+from audbackend.core.conftest import prepare_docstring_tests  # noqa: F401
+
+
+pytest_collect_file = Sybil(
+    parsers=[DocTestParser(optionflags=ELLIPSIS), PythonCodeBlockParser()],
+    pattern="*.rst",
+    fixtures=["mock_date", "mock_owner", "prepare_docstring_tests"],
+).pytest()

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -3,6 +3,7 @@ from doctest import ELLIPSIS
 from sybil import Sybil
 from sybil.parsers.rest import DocTestParser
 from sybil.parsers.rest import PythonCodeBlockParser
+from sybil.parsers.rest import SkipParser
 
 from audbackend.core.conftest import mock_date  # noqa: F401
 from audbackend.core.conftest import mock_owner  # noqa: F401
@@ -10,7 +11,11 @@ from audbackend.core.conftest import prepare_docstring_tests  # noqa: F401
 
 
 pytest_collect_file = Sybil(
-    parsers=[DocTestParser(optionflags=ELLIPSIS), PythonCodeBlockParser()],
+    parsers=[
+        DocTestParser(optionflags=ELLIPSIS),
+        PythonCodeBlockParser(),
+        SkipParser(),
+    ],
     pattern="*.rst",
     fixtures=["mock_date", "mock_owner", "prepare_docstring_tests"],
 ).pytest()

--- a/docs/developer-guide.rst
+++ b/docs/developer-guide.rst
@@ -502,7 +502,7 @@ from the backend.
 
 Which we then use to download the file.
 
->>> interface.get_file("/file.txt", "local.txt", "1.0.0")
+>>> interface.get_file("/file.txt", audeer.path("local.txt"), "1.0.0")
 '...local.txt'
 
 To inspect the files

--- a/docs/developer-guide.rst
+++ b/docs/developer-guide.rst
@@ -70,7 +70,7 @@ helper class.
             self.remote_file = "/.db.pkl"
             self.local_file = audeer.path(".db.pkl")
 
-        def __enter__(self) -> shelve.Shelf:
+        def __enter__(self) -> dict:
             if self.backend.exists(self.remote_file):
                 self.backend.get_file(self.remote_file, self.local_file)
             if os.path.exists(self.local_file):

--- a/docs/legacy.rst
+++ b/docs/legacy.rst
@@ -37,6 +37,7 @@ you have to list those extensions explicitly.
     import audbackend
     import audeer
 
+
     host = audeer.mkdir("host")
     audbackend.backend.FileSystem.create(host, "repo")
     backend = audbackend.backend.FileSystem(host, "repo")
@@ -48,6 +49,7 @@ Afterwards we upload an TAR.GZ archive.
 .. code-block:: python
 
     import tempfile
+
 
     with tempfile.TemporaryDirectory() as tmp:
         audeer.touch(audeer.path(tmp, "file.txt"))

--- a/docs/legacy.rst
+++ b/docs/legacy.rst
@@ -57,5 +57,10 @@ Afterwards we upload an TAR.GZ archive.
 
 And check that it is stored as expected.
 
+..
+    >>> import platform
+
+.. skip: next if(platform.system() == "Windows")
+
 >>> audeer.list_file_names(host, recursive=True, basenames=True)
 ['repo/file/1.0.0/file-1.0.0.tar.gz']

--- a/docs/legacy.rst
+++ b/docs/legacy.rst
@@ -1,15 +1,3 @@
-.. set temporal working directory
-.. jupyter-execute::
-    :hide-code:
-
-    import os
-    import audeer
-
-    _cwd_root = os.getcwd()
-    _tmp_root = audeer.mkdir(os.path.join("docs", "tmp"))
-    os.chdir(_tmp_root)
-
-
 .. _legacy-backends:
 
 Legacy backends
@@ -44,34 +32,28 @@ that contain a dot
 in its file extension,
 you have to list those extensions explicitly.
 
-.. jupyter-execute::
+.. code-block:: python
 
     import audbackend
+    import audeer
 
-    audbackend.backend.FileSystem.create("./host", "repo")
-    backend = audbackend.backend.FileSystem("./host", "repo")
+    host = audeer.mkdir("host")
+    audbackend.backend.FileSystem.create(host, "repo")
+    backend = audbackend.backend.FileSystem(host, "repo")
     backend.open()
     interface = audbackend.interface.Maven(backend, extensions=["tar.gz"])
 
-Afterwards we upload an TAR.GZ archive
-and check that it is stored as expected.
+Afterwards we upload an TAR.GZ archive.
 
-.. jupyter-execute::
+.. code-block:: python
 
-    import audeer
     import tempfile
 
     with tempfile.TemporaryDirectory() as tmp:
         audeer.touch(audeer.path(tmp, "file.txt"))
         interface.put_archive(tmp, "/file.tar.gz", "1.0.0")
 
-    audeer.list_file_names("./host", recursive=True, basenames=True)
+And check that it is stored as expected.
 
-
-.. reset working directory and clean up
-.. jupyter-execute::
-    :hide-code:
-
-    import shutil
-    os.chdir(_cwd_root)
-    shutil.rmtree(_tmp_root)
+>>> audeer.list_file_names(host, recursive=True, basenames=True)
+['repo/file/1.0.0/file-1.0.0.tar.gz']

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,3 @@
-ipykernel
-jupyter-sphinx
 sphinx
 sphinx-apipages
 sphinx-audeering-theme >=1.2.1

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -110,7 +110,9 @@ We move it to a new location.
 We download the file
 and store it as ``local.txt``.
 
->>> file = interface.get_file("/file.txt", "local.txt")
+>>> file = audeer.path("local.txt")
+>>> interface.get_file("/file.txt", file)
+'...local.txt'
 
 It is possible to upload
 one or more files
@@ -251,7 +253,7 @@ We move them to a new location.
 When downloading a file,
 we can select the desired version.
 
->>> path = interface.get_file("/file.txt", "local.txt", "1.0.0")
+>>> path = interface.get_file("/file.txt", audeer.path("local.txt"), "1.0.0")
 >>> with open(path, "r") as file:
 ...     print(file.read())
 Content v1.0.0

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -232,7 +232,7 @@ for a file.
 >>> interface.versions("/file.txt")
 ['1.0.0', '2.0.0']
 
-Or request it's latest version.
+Or request its latest version.
 
 >>> interface.latest_version("/file.txt")
 '2.0.0'

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -177,6 +177,11 @@ we will get an error
 for all backend classes
 as it depends on the implementation).
 
+..
+    >>> import platform
+
+.. skip: next if(platform.system() == "Windows")
+
 >>> try:
 ...     backend.open()
 ... except audbackend.BackendError as ex:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,6 @@ skip = './audbackend.egg-info,./build,.docs/api,./docs/_templates'
 cache_dir = '.cache/pytest'
 xfail_strict = true
 addopts = '''
-    --doctest-plus
     --cov=audbackend
     --cov-fail-under=100
     --cov-report term-missing

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,33 +45,6 @@ def authentication():
             del os.environ[key]
 
 
-@pytest.fixture(scope="function")
-def filesystem(tmpdir):
-    repo = f"unittest-{pytest.UID}-{audeer.uid()[:8]}"
-    host = audeer.mkdir(tmpdir, "host")
-    audeer.mkdir(host, repo)
-    backend = audbackend.backend.FileSystem(host, repo)
-    backend.opened = True
-    yield backend
-
-
-# @pytest.fixture(scope="function")
-# def filesystem(tmpdir):
-#     repo = f"unittest-{pytest.UID}-{audeer.uid()[:8]}"
-#     host = audeer.mkdir(tmpdir, "host")
-#     audeer.mkdir(host, repo)
-#     backend = audbackend.backend.Filesystem(host, repo)
-#
-#     root = audeer.mkdir(tmpdir, f"unittest-{pytest.UID}-{audeer.uid()[:8]}")
-#     # Wrap "local" filesystem in "dir" filesystem
-#     # to return paths relatiove to root
-#     yield fsspec.filesystem(
-#         "dir",
-#         path=root,
-#         fs=fsspec.filesystem("local"),
-#     )
-
-
 @pytest.fixture(scope="package", autouse=False)
 def hosts(tmpdir_factory):
     return {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,33 @@ def authentication():
             del os.environ[key]
 
 
+@pytest.fixture(scope="function")
+def filesystem(tmpdir):
+    repo = f"unittest-{pytest.UID}-{audeer.uid()[:8]}"
+    host = audeer.mkdir(tmpdir, "host")
+    audeer.mkdir(host, repo)
+    backend = audbackend.backend.FileSystem(host, repo)
+    backend.opened = True
+    yield backend
+
+
+# @pytest.fixture(scope="function")
+# def filesystem(tmpdir):
+#     repo = f"unittest-{pytest.UID}-{audeer.uid()[:8]}"
+#     host = audeer.mkdir(tmpdir, "host")
+#     audeer.mkdir(host, repo)
+#     backend = audbackend.backend.Filesystem(host, repo)
+#
+#     root = audeer.mkdir(tmpdir, f"unittest-{pytest.UID}-{audeer.uid()[:8]}")
+#     # Wrap "local" filesystem in "dir" filesystem
+#     # to return paths relatiove to root
+#     yield fsspec.filesystem(
+#         "dir",
+#         path=root,
+#         fs=fsspec.filesystem("local"),
+#     )
+
+
 @pytest.fixture(scope="package", autouse=False)
 def hosts(tmpdir_factory):
     return {

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
 audformat
 pytest
 pytest-cov
-pytest-doctestplus
+sybil

--- a/tests/test_interface_unversioned.py
+++ b/tests/test_interface_unversioned.py
@@ -788,11 +788,12 @@ def test_validate(tmpdir):
     interface.put_file(path, "/remote.txt", validate=True)
     assert interface.exists("/remote.txt")
 
+    local_file = audeer.path(tmpdir, "local.txt")
     with pytest.raises(InterruptedError, match=error_msg):
-        interface_bad.get_file("/remote.txt", "local.txt", validate=True)
-    assert not os.path.exists("local.txt")
-    interface.get_file("/remote.txt", "local.txt", validate=True)
-    assert os.path.exists("local.txt")
+        interface_bad.get_file("/remote.txt", local_file, validate=True)
+    assert not os.path.exists(local_file)
+    interface.get_file("/remote.txt", local_file, validate=True)
+    assert os.path.exists(local_file)
 
     with pytest.raises(InterruptedError, match=error_msg):
         interface_bad.copy_file("/remote.txt", "/copy.txt", validate=True)

--- a/tests/test_interface_versioned.py
+++ b/tests/test_interface_versioned.py
@@ -1158,21 +1158,12 @@ def test_validate(tmpdir):
     interface.put_file(path, "/remote.txt", "1.0.0", validate=True)
     assert interface.exists("/remote.txt", "1.0.0")
 
+    local_file = audeer.path(tmpdir, "local.txt")
     with pytest.raises(InterruptedError, match=error_msg):
-        interface_bad.get_file(
-            "/remote.txt",
-            "local.txt",
-            "1.0.0",
-            validate=True,
-        )
-    assert not os.path.exists("local.txt")
-    interface.get_file(
-        "/remote.txt",
-        "local.txt",
-        "1.0.0",
-        validate=True,
-    )
-    assert os.path.exists("local.txt")
+        interface_bad.get_file("/remote.txt", local_file, "1.0.0", validate=True)
+    assert not os.path.exists(local_file)
+    interface.get_file("/remote.txt", local_file, "1.0.0", validate=True)
+    assert os.path.exists(local_file)
 
     with pytest.raises(InterruptedError, match=error_msg):
         interface_bad.copy_file(


### PR DESCRIPTION
Similar to https://github.com/audeering/audinterface/pull/178 we switch to use `sybil` for doctests.

This has several motivations:

* separate testing and building the documentation
* remove dependency on `jupyter-sphinx` (large dependencies, not well maintained)
* remove dependency on `pytest-doctestplus` (slow in adopting to newer `pytest` versions)
* write expected results of code blocks as part of the usage documentation
* allow to use `pytest` fixtures inside doctests

<details><summary>Update "Usage" section</summary>

![image](https://github.com/user-attachments/assets/865e4fe7-8695-421d-ae7f-d2494de04083)

</details>

<details><summary> Updated "Developer guide" section</summary>

![image](https://github.com/user-attachments/assets/23fe91e0-9a42-449a-811b-b0025632dd88)

</details>

<details><summary> Updated "Legacy backends" section</summary>

![image](https://github.com/user-attachments/assets/cb02e0c1-d70b-4daa-a565-e45d8af26398)

</details>

In the developer guide, I replaced the usage of `shelve` by `pickle` as the previous implementation worked under Linux, but not under MacOS (where it was not tested before).

## Summary by Sourcery

Switch to sybil for doctests to separate testing from documentation building, remove large and outdated dependencies, and enhance testing capabilities with pytest fixtures.

Enhancements:
- Allow the use of pytest fixtures inside doctests.

Documentation:
- Update the 'Usage', 'Developer guide', and 'Legacy backends' sections to reflect the new testing approach and remove outdated references.

Tests:
- Switch to using sybil for collecting and running doctests, replacing pytest-doctestplus.

Chores:
- Remove dependencies on jupyter-sphinx and pytest-doctestplus due to maintenance and compatibility issues.