### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
         python -m pytest --cov-config=.coveragerc.${{ runner.os }}
       if: ${{ (matrix.python-version != '3.12') && (matrix.python-version != '3.13') }}
 
-    - name: Test with pytest for Python 3.12 and 3.12
+    - name: Test with pytest for Python >=3.12
       run: |
         python -m pytest --cov-config=.coveragerc.python3.12 --ignore=audbackend/core/backend/artifactory.py --ignore=tests/test_backend_artifactory.py
       if: ${{ (matrix.python-version == '3.12') || (matrix.python-version == '3.13') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
             python-version: '3.11'
           - os: ubuntu-latest
             python-version: '3.12'
+          - os: ubuntu-latest
+            python-version: '3.13'
 
     steps:
     - uses: actions/checkout@v4
@@ -54,16 +56,16 @@ jobs:
         ARTIFACTORY_API_KEY: ${{ secrets.ARTIFACTORY_API_KEY }}
       run: |
         python -m pytest --cov-config=.coveragerc.${{ runner.os }}
-      if: matrix.python-version != '3.12'
+      if: ${{ (matrix.python-version != '3.12') && (matrix.python-version != '3.13') }}
 
-    - name: Test with pytest for Python 3.12
+    - name: Test with pytest for Python 3.12 and 3.12
       run: |
         python -m pytest --cov-config=.coveragerc.python3.12 --ignore=audbackend/core/backend/artifactory.py --ignore=tests/test_backend_artifactory.py
-      if: matrix.python-version == '3.12'
+      if: ${{ (matrix.python-version == '3.12') || (matrix.python-version == '3.13') }}
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
-      if: ${{ (matrix.os == 'ubuntu-latest') && (matrix.python-version != '3.12') }}
+      if: ${{ (matrix.os == 'ubuntu-latest') && (matrix.python-version != '3.12') && (matrix.python-version != '3.13') }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Topic :: Scientific/Engineering',
 ]
 requires-python = '>=3.9'


### PR DESCRIPTION
Adds tests for Python 3.13 and adds it to the list of supported versions in the Python package.

## Summary by Sourcery

Add support for Python 3.13 by updating the CI workflow and project configuration to include it as a supported version.

New Features:
- Add support for Python 3.13 in the project.

CI:
- Update CI workflow to include testing for Python 3.13.