### PR TITLE
Release 2.2.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,18 @@ The format is based on `Keep a Changelog`_,
 and this project adheres to `Semantic Versioning`_.
 
 
+Version 2.2.2 (2025-01-23)
+--------------------------
+
+* Added: support for Python 3.13
+  (without Artifactory backend)
+* Added: support for Artifactory backend
+  in Python 3.12
+* Changed: depend on ``dohq-artifactory>=1.0.0``
+* Fixed: wrong path names
+  in Artifactory backend with ``dohq-artifactory==1.0.0``
+
+
 Version 2.2.1 (2024-11-27)
 --------------------------
 


### PR DESCRIPTION
The fix for Python 3.12 they introduced in `dohq-artifactory` 1.0.0 had some breaking changes how path names are returned (e.g. `/` at the end of an URL was removed), so I had to adjust the code here as well (done in https://github.com/audeering/audbackend/pull/260). I then enabled support for Artifactory Python 3.12 here as well (done in https://github.com/audeering/audbackend/pull/259).

![image](https://github.com/user-attachments/assets/eb268546-86e1-4346-a431-bd187e3b483f)
