### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.coveragerc.python3.13
+++ b/.coveragerc.python3.13
@@ -1,7 +1,0 @@
-[report]
-exclude_lines =
-    pragma: no cover
-    pragma: no Linux cover
-omit =
-    audbackend/core/api.py
-    audbackend/core/backend/artifactory.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,22 +50,16 @@ jobs:
       run: |
         pip install -r requirements.txt
 
-    - name: Test with pytest for Python <3.13
+    - name: Test with pytest
       env:
         ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
         ARTIFACTORY_API_KEY: ${{ secrets.ARTIFACTORY_API_KEY }}
       run: |
         python -m pytest --cov-config=.coveragerc.${{ runner.os }}
-      if: ${{ matrix.python-version != '3.13' }}
-
-    - name: Test with pytest for Python >=3.13
-      run: |
-        python -m pytest --cov-config=.coveragerc.python3.13 --ignore=audbackend/core/backend/artifactory.py --ignore=tests/test_backend_artifactory.py
-      if: ${{ matrix.python-version == '3.13' }}
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
-      if: ${{ (matrix.os == 'ubuntu-latest') && (matrix.python-version != '3.13') }}
+      if: ${{ (matrix.os == 'ubuntu-latest') }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,13 +42,13 @@ dynamic = ['version']
 
 [project.optional-dependencies]
 artifactory = [
-    'dohq-artifactory >=1.0.0; python_version < "3.13"',
+    'dohq-artifactory @ git+https://github.com/devopshq/artifactory@python-3-13',
 ]
 minio = [
     'minio',
 ]
 all = [
-    'dohq-artifactory >=1.0.0; python_version < "3.13"',
+    'dohq-artifactory @ git+https://github.com/devopshq/artifactory@python-3-13',
     'minio',
 ]
 


### PR DESCRIPTION
This tests the implementation of `dohq-artifactory` for Python 3.13 from https://github.com/devopshq/artifactory/issues/470.

## Summary by Sourcery

This pull request adds support for Python 3.13. It updates the CI workflow to test the implementation with Python 3.13 and modifies the project dependencies to use a specific version of `dohq-artifactory` compatible with Python 3.13.

CI:
- Consolidated the pytest execution into a single step, removing the conditional execution based on the Python version.
- Removed conditional execution for uploading coverage to Codecov based on the Python version.