### PR TITLE
TST: use Python 3.12 as default

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ '3.10' ]
+        python-version: [ '3.12' ]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python 3.10
+    - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
 
     - name: Install pre-commit hooks
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.12'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,12 +13,12 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
-        python-version: [ '3.10' ]
+        python-version: [ '3.12' ]
         include:
           - os: ubuntu-latest
-            python-version: '3.11'
+            python-version: '3.10'
           - os: ubuntu-latest
-            python-version: '3.12'
+            python-version: '3.11'
           - os: ubuntu-latest
             python-version: '3.13'
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@
 #
 #
 default_language_version:
-  python: python3.10
+  python: python3.12
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit


### PR DESCRIPTION
Use Python 3.12 as default in tests.

## Summary by Sourcery

Use Python 3.12 as the default version across CI workflows and pre-commit configuration, and adjust the test matrix to explicitly include Python 3.10, 3.11, and 3.13.

CI:
- Bump default Python version to 3.12 in test, linter, doc, and publish GitHub Actions workflows
- Update the test workflow matrix to default on Python 3.12 and explicitly include Python 3.10, 3.11, and 3.13
- Set default_language_version to Python 3.12 in pre-commit configuration