### PR TITLE
TST: update codespell and ruff in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,13 +13,13 @@ default_language_version:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.0
+    rev: v0.13.3
     hooks:
       - id: ruff
         args: [ --fix ]
       - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
       - id: codespell
         additional_dependencies:

--- a/audbackend/core/repository.py
+++ b/audbackend/core/repository.py
@@ -43,10 +43,4 @@ class Repository:
         warnings.warn(message, category=UserWarning, stacklevel=2)
 
     def __repr__(self):  # noqa: D105
-        return (
-            f"Repository("
-            f"'{self.name}', "
-            f"'{self.host}', "
-            f"'{self.backend}'"
-            f")"
-        )
+        return f"Repository('{self.name}', '{self.host}', '{self.backend}')"

--- a/audbackend/core/utils.py
+++ b/audbackend/core/utils.py
@@ -75,8 +75,7 @@ def check_path(
         )
     if path and BACKEND_ALLOWED_CHARS_COMPILED.fullmatch(path) is None:
         raise ValueError(
-            f"Invalid backend path '{path}', "
-            f"does not match '{BACKEND_ALLOWED_CHARS}'."
+            f"Invalid backend path '{path}', does not match '{BACKEND_ALLOWED_CHARS}'."
         )
 
     # Remove immediately consecutive seps
@@ -97,8 +96,7 @@ def check_version(version: str) -> str:
         raise ValueError("Version must not be empty.")
     if VERSION_ALLOWED_CHARS_COMPILED.fullmatch(version) is None:
         raise ValueError(
-            f"Invalid version '{version}', "
-            f"does not match '{VERSION_ALLOWED_CHARS}'."
+            f"Invalid version '{version}', does not match '{VERSION_ALLOWED_CHARS}'."
         )
 
     return version

--- a/tests/test_interface_maven.py
+++ b/tests/test_interface_maven.py
@@ -42,7 +42,7 @@ def test_errors(tmpdir, interface):
     # Invalid file names / versions and error messages
     file_invalid_path = "invalid/path.txt"
     error_invalid_path = re.escape(
-        f"Invalid backend path '{file_invalid_path}', " f"must start with '/'."
+        f"Invalid backend path '{file_invalid_path}', must start with '/'."
     )
     file_invalid_char = "/invalid/char.txt?"
     error_invalid_char = re.escape(

--- a/tests/test_interface_unversioned.py
+++ b/tests/test_interface_unversioned.py
@@ -238,11 +238,11 @@ def test_errors(tmpdir, interface):
     # Invalid file names / versions and error messages
     file_invalid_path = "invalid/path.txt"
     error_invalid_path = re.escape(
-        f"Invalid backend path '{file_invalid_path}', " f"must start with '/'."
+        f"Invalid backend path '{file_invalid_path}', must start with '/'."
     )
     file_sub_path = "/sub/"
     error_sub_path = re.escape(
-        f"Invalid backend path '{file_sub_path}', " f"must not end on '/'."
+        f"Invalid backend path '{file_sub_path}', must not end on '/'."
     )
     file_invalid_char = "/invalid/char.txt?"
     error_invalid_char = re.escape(

--- a/tests/test_interface_versioned.py
+++ b/tests/test_interface_versioned.py
@@ -261,11 +261,11 @@ def test_errors(tmpdir, interface):
     # Invalid file names / versions and error messages
     file_invalid_path = "invalid/path.txt"
     error_invalid_path = re.escape(
-        f"Invalid backend path '{file_invalid_path}', " f"must start with '/'."
+        f"Invalid backend path '{file_invalid_path}', must start with '/'."
     )
     file_sub_path = "/sub/"
     error_sub_path = re.escape(
-        f"Invalid backend path '{file_sub_path}', " f"must not end on '/'."
+        f"Invalid backend path '{file_sub_path}', must not end on '/'."
     )
     file_invalid_char = "/invalid/char.txt?"
     error_invalid_char = re.escape(
@@ -284,7 +284,7 @@ def test_errors(tmpdir, interface):
     error_empty_version = "Version must not be empty."
     invalid_version = "1.0.?"
     error_invalid_version = re.escape(
-        f"Invalid version '{invalid_version}', " f"does not match '[A-Za-z0-9._-]+'."
+        f"Invalid version '{invalid_version}', does not match '[A-Za-z0-9._-]+'."
     )
     if platform.system() == "Windows":
         error_is_a_folder = "Is a directory: "


### PR DESCRIPTION
Update `codespell` and `ruff` versions used in pre-commit.

## Summary by Sourcery

Update pre-commit hook versions for ruff and codespell, refactor f-string constructions to single-line, and align tests with the new message formatting

Enhancements:
- Bump ruff to v0.13.3 and codespell to v2.4.1 in pre-commit configuration
- Collapse multi-line f-strings into single-line formatting for repository repr and utils error messages

Tests:
- Adjust expected error message patterns in tests to match the new single-line formatting