### PR TITLE
Add support for Python 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
             python-version: '3.11'
           - os: ubuntu-latest
             python-version: '3.13'
+          - os: ubuntu-latest
+            python-version: '3.14'
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
     'Topic :: Scientific/Engineering',
 ]
 requires-python = '>=3.10'


### PR DESCRIPTION
Add support and tests for Python 3.14

## Summary by Sourcery

Add support for Python 3.14 by updating the CI test matrix and project metadata

CI:
- Include Python 3.14 in the GitHub Actions test workflow

Documentation:
- Add Python :: 3.14 classifier to project metadata in pyproject.toml