### PR TITLE
Release 2.2.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Version 2.2.3 (2025-12-08)
 * Added: support for Artifactory backend
   in Python 3.13
 * Fixed: require ``minio!=7.2.19``
-  to avoid install broken ``minio`` package
+  to avoid installing the broken ``minio`` package
 * Removed: support for Python 3.9
 
 


### PR DESCRIPTION
<img width="575" height="171" alt="image" src="https://github.com/user-attachments/assets/8aa6e685-91c2-4113-8c31-1ba51777abef" />

To get a release with the fix for the broken `minio` package and prepare a new `audmodel` release, I propose we do already a release of `audbackend` and do not wait for https://github.com/audeering/audbackend/pull/271

## Summary by Sourcery

Documentation:
- Update the changelog to document the changes included in the 2.2.3 release.