### PR TITLE
Add num_workers and chunk_size for downloads

### DIFF
--- a/audbackend/core/backend/artifactory.py
+++ b/audbackend/core/backend/artifactory.py
@@ -209,6 +209,7 @@ class Artifactory(Base):
         self,
         src_path: str,
         dst_path: str,
+        num_workers: int,
         verbose: bool,
     ):
         r"""Copy file on backend."""
@@ -263,6 +264,7 @@ class Artifactory(Base):
         self,
         src_path: str,
         dst_path: str,
+        num_workers: int,
         verbose: bool,
     ):
         r"""Get file from backend."""
@@ -287,6 +289,7 @@ class Artifactory(Base):
         self,
         src_path: str,
         dst_path: str,
+        num_workers: int,
         verbose: bool,
     ):
         r"""Move file on backend."""

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -176,6 +176,7 @@ class Base:
         self,
         src_path: str,
         dst_path: str,
+        num_workers: int,
         verbose: bool,
     ):
         r"""Copy file on backend.
@@ -189,7 +190,12 @@ class Base:
         """
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = audeer.path(tmp, "~")
-            tmp_path = self.get_file(src_path, tmp_path, verbose=verbose)
+            tmp_path = self.get_file(
+                src_path,
+                tmp_path,
+                num_workers=num_workers,
+                verbose=verbose,
+            )
             self.put_file(tmp_path, dst_path, verbose=verbose)
 
     def copy_file(
@@ -197,6 +203,7 @@ class Base:
         src_path: str,
         dst_path: str,
         *,
+        num_workers: int = 1,
         validate: bool = False,
         verbose: bool = False,
     ):
@@ -219,6 +226,7 @@ class Base:
         Args:
             src_path: source path to file on backend
             dst_path: destination path to file on backend
+            num_workers: number of parallel jobs
             validate: verify file was successfully copied
             verbose: show debug messages
 
@@ -246,6 +254,7 @@ class Base:
                 self._copy_file,
                 src_path,
                 dst_path,
+                num_workers,
                 verbose,
             )
 
@@ -435,6 +444,7 @@ class Base:
         dst_root: str,
         *,
         tmp_root: str = None,
+        num_workers: int = 1,
         validate: bool = False,
         verbose: bool = False,
     ) -> list[str]:
@@ -459,6 +469,7 @@ class Base:
             dst_root: local destination directory
             tmp_root: directory under which archive is temporarily extracted.
                 Defaults to temporary directory of system
+            num_workers: number of parallel jobs
             validate: verify archive was successfully
                 retrieved from the backend
             verbose: show debug messages
@@ -496,6 +507,7 @@ class Base:
             self.get_file(
                 src_path,
                 local_archive,
+                num_workers=num_workers,
                 validate=validate,
                 verbose=verbose,
             )
@@ -510,6 +522,7 @@ class Base:
         self,
         src_path: str,
         dst_path: str,
+        num_workers: int,
         verbose: bool,
     ):  # pragma: no cover
         r"""Get file from backend."""
@@ -520,6 +533,7 @@ class Base:
         src_path: str,
         dst_path: str,
         *,
+        num_workers: int = 1,
         validate: bool = False,
         verbose: bool = False,
     ) -> str:
@@ -546,6 +560,7 @@ class Base:
         Args:
             src_path: path to file on backend
             dst_path: destination path to local file
+            num_workers: number of parallel jobs
             validate: verify file was successfully
                 retrieved from the backend
             verbose: show debug messages
@@ -594,6 +609,7 @@ class Base:
                     self._get_file,
                     src_path,
                     tmp_path,
+                    num_workers,
                     verbose,
                 )
                 audeer.move_file(tmp_path, dst_path)
@@ -738,6 +754,7 @@ class Base:
         self,
         src_path: str,
         dst_path: str,
+        num_workers: int,
         verbose: bool,
     ):
         r"""Move file on backend.
@@ -749,7 +766,7 @@ class Base:
         if backend supports a native way to move files.
 
         """
-        self.copy_file(src_path, dst_path, verbose=verbose)
+        self.copy_file(src_path, dst_path, num_workers=num_workers, verbose=verbose)
         self.remove_file(src_path)
 
     def move_file(
@@ -757,6 +774,7 @@ class Base:
         src_path: str,
         dst_path: str,
         *,
+        num_workers: int = 1,
         validate: bool = False,
         verbose: bool = False,
     ):
@@ -783,6 +801,7 @@ class Base:
         Args:
             src_path: source path to file on backend
             dst_path: destination path to file on backend
+            num_workers: number of parallel jobs
             validate: verify file was successfully moved
             verbose: show debug messages
 
@@ -812,6 +831,7 @@ class Base:
                 self.copy_file(
                     src_path,
                     dst_path,
+                    num_workers=num_workers,
                     validate=True,
                     verbose=verbose,
                 )
@@ -821,6 +841,7 @@ class Base:
                     self._move_file,
                     src_path,
                     dst_path,
+                    num_workers,
                     verbose,
                 )
         else:

--- a/audbackend/core/backend/filesystem.py
+++ b/audbackend/core/backend/filesystem.py
@@ -53,6 +53,7 @@ class FileSystem(Base):
         self,
         src_path: str,
         dst_path: str,
+        num_workers: int,
         verbose: bool,
     ):
         r"""Copy file on backend."""
@@ -114,6 +115,7 @@ class FileSystem(Base):
         self,
         src_path: str,
         dst_path: str,
+        num_workers: int,
         verbose: bool,
     ):
         r"""Get file from backend."""
@@ -142,6 +144,7 @@ class FileSystem(Base):
         self,
         src_path: str,
         dst_path: str,
+        num_workers: int,
         verbose: bool,
     ):
         r"""Move file on backend."""

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -2,7 +2,9 @@ import configparser
 import getpass
 import mimetypes
 import os
+import signal
 import tempfile
+import threading
 
 import minio
 
@@ -201,6 +203,7 @@ class Minio(Base):
         self,
         src_path: str,
         dst_path: str,
+        num_workers: int,
         verbose: bool,
     ):
         r"""Copy file on backend."""
@@ -212,7 +215,7 @@ class Minio(Base):
         if self._size(src_path) / 1024 / 1024 / 1024 >= 4.9:
             with tempfile.TemporaryDirectory() as tmp_dir:
                 tmp_path = audeer.path(tmp_dir, os.path.basename(src_path))
-                self._get_file(src_path, tmp_path, verbose)
+                self._get_file(src_path, tmp_path, num_workers, verbose)
                 self._put_file(tmp_path, dst_path, checksum, verbose)
         else:
             self._client.copy_object(
@@ -276,41 +279,96 @@ class Minio(Base):
         self,
         src_path: str,
         dst_path: str,
+        num_workers: int,
         verbose: bool,
     ):
         r"""Get file from backend."""
         src_path = self.path(src_path)
-        src_size = self._client.stat_object(
-            bucket_name=self.repository,
-            object_name=src_path,
-        ).size
-        chunk = 4 * 1024
-        with audeer.progress_bar(total=src_size, disable=not verbose) as pbar:
-            desc = audeer.format_display_message(
-                f"Download {os.path.basename(str(src_path))}", pbar=True
-            )
-            pbar.set_description_str(desc)
-            pbar.refresh()
+        src_size = self._client.stat_object(self.repository, src_path).size
 
-            dst_size = 0
-            try:
-                response = self._client.get_object(
-                    bucket_name=self.repository,
-                    object_name=src_path,
-                )
-                with open(dst_path, "wb") as dst_fp:
-                    while src_size > dst_size:
-                        data = response.read(chunk)
-                        n_data = len(data)
-                        if n_data > 0:
-                            dst_fp.write(data)
-                            dst_size += n_data
-                            pbar.update(n_data)
-            except Exception as e:  # pragma: no cover
-                raise RuntimeError(f"Error downloading file: {e}")
-            finally:
-                response.close()
-                response.release_conn()
+        # Create cancellation event for handling interrupts
+        cancel_event = threading.Event()
+
+        # Install signal handler to set cancel_event on Ctrl+C
+        def signal_handler(signum, frame):
+            cancel_event.set()  # pragma: no cover
+
+        original_handler = signal.signal(signal.SIGINT, signal_handler)
+
+        # Setup progress bar
+        desc = audeer.format_display_message(
+            f"Download {os.path.basename(str(src_path))}",
+            pbar=verbose,
+        )
+        pbar = audeer.progress_bar(total=src_size, desc=desc, disable=not verbose)
+
+        try:
+            if num_workers == 1:
+                # Simple single-threaded download
+                with pbar:
+                    self._download_file(src_path, dst_path, pbar, cancel_event)
+            else:
+                # Multi-threaded download with pre-allocated file
+                with open(dst_path, "wb") as f:
+                    f.truncate(src_size)
+
+                # Create and run download tasks
+                tasks = []
+                # Ensure num_workers does not exceed src_size
+                num_workers = min(num_workers, src_size) if src_size > 0 else 1
+                chunk_size = src_size // num_workers
+                for i in range(num_workers):
+                    offset = i * chunk_size
+                    length = chunk_size if i < num_workers - 1 else src_size - offset
+                    tasks.append(
+                        ([src_path, dst_path, pbar, cancel_event, offset, length], {})
+                    )
+
+                with pbar:
+                    audeer.run_tasks(
+                        self._download_file, tasks, num_workers=num_workers
+                    )
+        except KeyboardInterrupt:
+            # Clean up partial file
+            if os.path.exists(dst_path):
+                os.remove(dst_path)
+            raise
+        finally:
+            # Restore original signal handler
+            signal.signal(signal.SIGINT, original_handler)
+
+    def _download_file(
+        self,
+        src_path: str,
+        dst_path: str,
+        pbar,
+        cancel_event: threading.Event = None,
+        offset: int = 0,
+        length: int | None = None,
+    ):
+        """Download file or part of file."""
+        chunk_size = 4 * 1024  # 4 KB
+
+        # Get the data stream
+        kwargs = {"offset": offset}
+        if length is not None:
+            kwargs["length"] = length
+        response = self._client.get_object(self.repository, src_path, **kwargs)
+
+        try:
+            with open(dst_path, "r+b" if offset else "wb") as f:
+                if offset:
+                    f.seek(offset)
+
+                while data := response.read(chunk_size):
+                    # Check if cancellation was requested
+                    if cancel_event and cancel_event.is_set():
+                        raise KeyboardInterrupt("Download cancelled by user")
+                    f.write(data)
+                    pbar.update(len(data))
+        finally:
+            response.close()
+            response.release_conn()
 
     def _ls(
         self,
@@ -329,10 +387,11 @@ class Minio(Base):
         self,
         src_path: str,
         dst_path: str,
+        num_workers: int,
         verbose: bool,
     ):
         r"""Move file on backend."""
-        self._copy_file(src_path, dst_path, verbose)
+        self._copy_file(src_path, dst_path, num_workers, verbose)
         self._remove_file(src_path)
 
     def _open(

--- a/audbackend/core/interface/unversioned.py
+++ b/audbackend/core/interface/unversioned.py
@@ -73,6 +73,7 @@ class Unversioned(Base):
         src_path: str,
         dst_path: str,
         *,
+        num_workers: int = 1,
         validate: bool = False,
         verbose: bool = False,
     ):
@@ -95,6 +96,7 @@ class Unversioned(Base):
         Args:
             src_path: source path to file on backend
             dst_path: destination path to file on backend
+            num_workers: number of parallel jobs
             validate: verify file was successfully copied
             verbose: show debug messages
 
@@ -123,6 +125,7 @@ class Unversioned(Base):
         self.backend.copy_file(
             src_path,
             dst_path,
+            num_workers=num_workers,
             validate=validate,
             verbose=verbose,
         )
@@ -284,6 +287,7 @@ class Unversioned(Base):
         src_path: str,
         dst_path: str,
         *,
+        num_workers: int = 1,
         validate: bool = False,
         verbose: bool = False,
     ) -> str:
@@ -310,6 +314,7 @@ class Unversioned(Base):
         Args:
             src_path: path to file on backend
             dst_path: destination path to local file
+            num_workers: number of parallel jobs
             validate: verify file was successfully
                 retrieved from the backend
             verbose: show debug messages
@@ -342,6 +347,7 @@ class Unversioned(Base):
         return self.backend.get_file(
             src_path,
             dst_path,
+            num_workers=num_workers,
             validate=validate,
             verbose=verbose,
         )
@@ -422,6 +428,7 @@ class Unversioned(Base):
         src_path: str,
         dst_path: str,
         *,
+        num_workers: int = 1,
         validate: bool = False,
         verbose: bool = False,
     ):
@@ -448,6 +455,7 @@ class Unversioned(Base):
         Args:
             src_path: source path to file on backend
             dst_path: destination path to file on backend
+            num_workers: number of parallel jobs
             validate: verify file was successfully moved
             verbose: show debug messages
 
@@ -478,6 +486,7 @@ class Unversioned(Base):
         self.backend.move_file(
             src_path,
             dst_path,
+            num_workers=num_workers,
             validate=validate,
             verbose=verbose,
         )

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -92,6 +92,7 @@ class Versioned(Base):
         dst_path: str,
         *,
         version: str = None,
+        num_workers: int = 1,
         validate: bool = False,
         verbose: bool = False,
     ):
@@ -118,8 +119,9 @@ class Versioned(Base):
         Args:
             src_path: source path to file on backend
             dst_path: destination path to file on backend
-            validate: verify file was successfully copied
             version: version string
+            num_workers: number of parallel jobs
+            validate: verify file was successfully copied
             verbose: show debug messages
 
         Raises:
@@ -157,6 +159,7 @@ class Versioned(Base):
             self.backend.copy_file(
                 src_path_with_version,
                 dst_path_with_version,
+                num_workers=num_workers,
                 validate=validate,
                 verbose=verbose,
             )
@@ -332,6 +335,7 @@ class Versioned(Base):
         dst_path: str,
         version: str,
         *,
+        num_workers: int = 1,
         validate: bool = False,
         verbose: bool = False,
     ) -> str:
@@ -359,6 +363,7 @@ class Versioned(Base):
             src_path: path to file on backend
             dst_path: destination path to local file
             version: version string
+            num_workers: number of parallel jobs
             validate: verify file was successfully
                 retrieved from the backend
             verbose: show debug messages
@@ -394,6 +399,7 @@ class Versioned(Base):
         return self.backend.get_file(
             src_path_with_version,
             dst_path,
+            num_workers=num_workers,
             validate=validate,
             verbose=verbose,
         )
@@ -576,6 +582,7 @@ class Versioned(Base):
         dst_path: str,
         *,
         version: str = None,
+        num_workers: int = 1,
         validate: bool = False,
         verbose: bool = False,
     ):
@@ -607,6 +614,7 @@ class Versioned(Base):
             src_path: source path to file on backend
             dst_path: destination path to file on backend
             version: version string
+            num_workers: number of parallel jobs
             validate: verify file was successfully moved
             verbose: show debug messages
 
@@ -647,6 +655,7 @@ class Versioned(Base):
             self.backend.move_file(
                 src_path_with_version,
                 dst_path_with_version,
+                num_workers=num_workers,
                 validate=validate,
                 verbose=verbose,
             )

--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -1,0 +1,30 @@
+audbackend Benchmarks
+=====================
+
+Collection of benchmark scripts to evaluate functionality.
+
+
+Parallel file loading
+---------------------
+
+The ``Minio`` backend supports parallel loading of files.
+It can be benchmarked with:
+
+.. code-block:: bash
+
+    $ uv run --python 3.12 minio-parallel.py
+
+Run on a server with 10
+Intel(R) Xeon(R) Platinum 8275CL CPUs @ 3.00GHz
+it resulted in
+
+=========== ======== ============== ==============
+num_workers num_iter elapsed (avg)  elapsed (std)
+=========== ======== ============== ==============
+1           10       0:00:45.036293 0:00:00.011121
+2           10       0:00:22.550618 0:00:00.013874
+3           10       0:00:15.725117 0:00:00.339047
+4           10       0:00:13.304948 0:00:00.917220
+5           10       0:00:11.589374 0:00:00.465975
+10          10       0:00:13.865395 0:00:00.599119
+=========== ======== ============== ==============

--- a/benchmarks/minio-parallel.py
+++ b/benchmarks/minio-parallel.py
@@ -1,0 +1,71 @@
+# /// script
+# dependencies = [
+#   "audbackend[all]",
+#   "numpy",
+#   "pandas",
+#   "tabulate",
+# ]
+# [tool.uv.sources]
+# audbackend = { path = "..", editable = true }
+# ///
+import datetime
+import os
+import time
+
+import numpy as np
+import pandas as pd
+
+import audeer
+
+import audbackend
+
+
+def main():
+    host = "s3.dualstack.eu-north-1.amazonaws.com"
+    repository = "audmodel-internal"
+    src_path = "/alm/audeering-omni/stage1_2/torch/7289b57d.zip"
+    version = "1.0.0"
+    dst_path = "./tmp.zip"
+    num_iter = 10
+
+    ds = []
+
+    for num_workers in audeer.progress_bar([1, 2, 3, 4, 5, 10]):
+        backend = audbackend.backend.Minio(host, repository)
+        backend.open()
+
+        elapsed = []
+
+        for _ in range(num_iter):
+            if os.path.exists(dst_path):
+                os.remove(dst_path)
+
+            interface = audbackend.interface.Maven(backend)
+
+            t = time.time()
+            interface.get_file(
+                src_path=src_path,
+                dst_path=dst_path,
+                version=version,
+                num_workers=num_workers,
+            )
+            elapsed.append(time.time() - t)
+
+        ds.append(
+            {
+                "num_workers": num_workers,
+                "num_iter": num_iter,
+                "elapsed(avg)": str(datetime.timedelta(seconds=np.mean(elapsed))),
+                "elapsed(std)": str(datetime.timedelta(seconds=np.std(elapsed))),
+            }
+        )
+
+        backend.close()
+
+    df = pd.DataFrame(ds)
+    df.to_csv("results.csv", index=False)
+    df.to_markdown("results.md", index=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/developer-guide.rst
+++ b/docs/developer-guide.rst
@@ -443,6 +443,7 @@ we provide a more efficient implementation.
             self,
             src_path: str,
             dst_path: str,
+            num_workers: int,
             verbose: bool,
     ):
         with self._db as db:
@@ -474,6 +475,7 @@ but it is more efficient if we provide one.
             self,
             src_path: str,
             dst_path: str,
+            num_workers: int,
             verbose: bool,
     ):
         with self._db as db:
@@ -499,6 +501,7 @@ from the backend.
             self,
             src_path: str,
             dst_path: str,
+            num_workers: int,
             verbose: bool,
     ):
         with self._db as db:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 requires-python = '>=3.10'
 dependencies = [
-    'audeer >=1.20.0',
+    'audeer >=2.3.1',
     'pywin32; sys_platform == "win32"',
 ]
 # Get version dynamically from git

--- a/tests/bad_file_system.py
+++ b/tests/bad_file_system.py
@@ -30,8 +30,10 @@ class BadFileSystem(audbackend.backend.FileSystem):
         src_path: str,
         dst_path: str,
         verbose: bool,
+        num_workers: int,
+        chunk_size: int,
     ):
-        super()._get_file(src_path, dst_path, verbose)
+        super()._get_file(src_path, dst_path, verbose, num_workers, chunk_size)
         # raise error after file was retrieved
         raise InterruptedError()
 

--- a/tests/singlefolder.py
+++ b/tests/singlefolder.py
@@ -115,6 +115,7 @@ class SingleFolder(audbackend.backend.Base):
         self,
         src_path: str,
         dst_path: str,
+        num_workers: int,
         verbose: bool,
     ):
         with self.Map(self._path, self._lock) as m:


### PR DESCRIPTION
Test rebasing `workers-download`.

## Summary by Sourcery

Add configurable parallel download support and improved interrupt handling for backend file transfers, and wire the new options through interfaces and higher-level operations.

New Features:
- Introduce a num_workers parameter on backend and interface copy, get, move, and archive operations to enable parallel downloads, currently implemented for the Minio backend.

Bug Fixes:
- Ensure interrupted Minio downloads clean up partial destination files and propagate KeyboardInterrupt cleanly.

Enhancements:
- Refactor Minio downloads into a reusable _download_file helper that supports ranged reads and progress updates, and use it for both single-threaded and multi-threaded transfers.
- Add a Minio benchmarking script to measure download performance across different worker counts.
- Update the audeer dependency to a newer version required by the new functionality.

Tests:
- Add tests validating Minio get_file behavior with different num_workers values and verifying interrupt handling and cleanup of partial downloads.
- Adjust or extend test backends to support the new _get_file signature including num_workers.