### PR TITLE
Add backend.ls_dirs()

### DIFF
--- a/audbackend/core/backend/artifactory.py
+++ b/audbackend/core/backend/artifactory.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterator
+import errno
 import os
 
 import artifactory
@@ -306,6 +307,23 @@ class Artifactory(Base):
         paths = [self._collapse(path) for path in paths]
 
         return paths
+
+    def _ls_dirs(
+        self,
+        path: str,
+    ) -> list[str]:
+        r"""List immediate subdirectory names under sub-path."""
+        path = self.path(path)
+        if not path.exists():
+            raise FileNotFoundError(
+                errno.ENOENT,
+                os.strerror(errno.ENOENT),
+                str(path),
+            )
+
+        # Iterating ArtifactoryPath yields immediate children
+        dirs = [x.name for x in path if x.is_dir()]
+        return dirs
 
     def _move_file(
         self,

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -895,16 +895,23 @@ class Base:
                 os.strerror(errno.ENOENT),
                 path,
             )
-        # Extract the first path component after the prefix
-        # e.g. for path="/sub/" and file="/sub/1.0.0/file.txt"
-        # we extract "1.0.0"
-        prefix_depth = path.count(self.sep) - 1  # -1 for leading sep
-        dirs = set()
+
+        sep = self.sep
+        if not path.endswith(sep):
+            path = path + sep
+        prefix_len = len(path)
+
+        dirs: set[str] = set()
         for p in paths:
-            parts = p.split(self.sep)
-            # parts[0] is empty (leading sep), so actual parts start at [1]
-            if len(parts) > prefix_depth + 1:
-                dirs.add(parts[prefix_depth + 1])
+            if not p.startswith(path):
+                continue
+            rest = p[prefix_len:]
+            if not rest:
+                continue
+            first, found_sep, _ = rest.partition(sep)
+            if first and found_sep:
+                dirs.add(first)
+
         return list(dirs)
 
     def ls(

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -897,8 +897,6 @@ class Base:
             )
 
         sep = self.sep
-        if not path.endswith(sep):
-            path = path + sep
         prefix_len = len(path)
 
         dirs: set[str] = set()

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -872,6 +872,41 @@ class Base:
         """
         raise NotImplementedError()
 
+    def _ls_dirs(
+        self,
+        path: str,
+    ) -> list[str]:
+        r"""List immediate subdirectory names under sub-path.
+
+        Raises ``FileNotFoundError``
+        if ``path`` does not exist.
+
+        The default implementation derives subdirectories
+        from :meth:`_ls` results.
+        Backends that support efficient directory listing
+        (e.g. S3 delimiter queries)
+        can override this method.
+
+        """
+        paths = self._ls(path)
+        if not paths:
+            raise FileNotFoundError(
+                errno.ENOENT,
+                os.strerror(errno.ENOENT),
+                path,
+            )
+        # Extract the first path component after the prefix
+        # e.g. for path="/sub/" and file="/sub/1.0.0/file.txt"
+        # we extract "1.0.0"
+        prefix_depth = path.count(self.sep) - 1  # -1 for leading sep
+        dirs = set()
+        for p in paths:
+            parts = p.split(self.sep)
+            # parts[0] is empty (leading sep), so actual parts start at [1]
+            if len(parts) > prefix_depth + 1:
+                dirs.add(parts[prefix_depth + 1])
+        return list(dirs)
+
     def ls(
         self,
         path: str = "/",
@@ -955,6 +990,57 @@ class Base:
             paths = [p for p in paths if fnmatch.fnmatch(os.path.basename(p), pattern)]
 
         return paths
+
+    def ls_dirs(
+        self,
+        path: str = "/",
+        *,
+        suppress_backend_errors: bool = False,
+    ) -> list[str]:
+        r"""List subdirectories on backend.
+
+        Returns a sorted list of immediate subdirectory names
+        under the given sub-path.
+        Only direct child directories are returned,
+        not files or nested subdirectories.
+
+        Args:
+            path: sub-path
+                (must end with ``'/'``)
+                on backend
+            suppress_backend_errors: if set to ``True``,
+                silently catch errors raised on the backend
+                and return an empty list
+
+        Returns:
+            list of subdirectory names
+
+        Raises:
+            BackendError: if ``suppress_backend_errors`` is ``False``
+                and an error is raised on the backend,
+                e.g. ``path`` does not exist
+            ValueError: if ``path`` does not start with ``'/'``,
+                does not end with ``'/'``,
+                or does not match ``'[A-Za-z0-9/._-]+'``
+            RuntimeError: if backend was not opened
+
+        """
+        if not self.opened:
+            raise RuntimeError(backend_not_opened_error)
+
+        path = utils.check_path(path, allow_sub_path=True)
+
+        if not path.endswith("/"):
+            raise ValueError(f"path must end with '/', got: '{path}'")
+
+        dirs = utils.call_function_on_backend(
+            self._ls_dirs,
+            path,
+            suppress_backend_errors=suppress_backend_errors,
+            fallback_return_value=[],
+        )
+
+        return sorted(dirs)
 
     def _move_file(
         self,

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -910,6 +910,7 @@ class Base:
             if first and found_sep:
                 dirs.add(first)
 
+        # Path exists (has files) but no subdirectories
         return list(dirs)
 
     def ls(

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -1039,12 +1039,25 @@ class Base:
         if not path.endswith("/"):
             raise ValueError(f"path must end with '/', got: '{path}'")
 
-        dirs = utils.call_function_on_backend(
-            self._ls_dirs,
-            path,
-            suppress_backend_errors=suppress_backend_errors,
-            fallback_return_value=[],
-        )
+        try:
+            dirs = utils.call_function_on_backend(
+                self._ls_dirs,
+                path,
+                suppress_backend_errors=suppress_backend_errors,
+                fallback_return_value=[],
+            )
+        except BackendError as ex:
+            # The root always exists,
+            # so an empty repository
+            # simply has no subdirectories.
+            # Backends signal a non-existing path
+            # with a ``FileNotFoundError``,
+            # but for the root
+            # we return an empty list instead,
+            # mirroring the behavior of ls().
+            if path == "/" and isinstance(ex.exception, FileNotFoundError):
+                return []
+            raise
 
         return sorted(dirs)
 

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -878,8 +878,11 @@ class Base:
     ) -> list[str]:
         r"""List immediate subdirectory names under sub-path.
 
+        Returns an empty list for the root ``'/'``,
+        which always exists
+        (an empty repository has no subdirectories).
         Raises ``FileNotFoundError``
-        if ``path`` does not exist.
+        if any other ``path`` does not exist.
 
         The default implementation derives subdirectories
         from :meth:`_ls` results.
@@ -890,6 +893,8 @@ class Base:
         """
         paths = self._ls(path)
         if not paths:
+            if path == "/":
+                return []
             raise FileNotFoundError(
                 errno.ENOENT,
                 os.strerror(errno.ENOENT),
@@ -1039,25 +1044,12 @@ class Base:
         if not path.endswith("/"):
             raise ValueError(f"path must end with '/', got: '{path}'")
 
-        try:
-            dirs = utils.call_function_on_backend(
-                self._ls_dirs,
-                path,
-                suppress_backend_errors=suppress_backend_errors,
-                fallback_return_value=[],
-            )
-        except BackendError as ex:
-            # The root always exists,
-            # so an empty repository
-            # simply has no subdirectories.
-            # Backends signal a non-existing path
-            # with a ``FileNotFoundError``,
-            # but for the root
-            # we return an empty list instead,
-            # mirroring the behavior of ls().
-            if path == "/" and isinstance(ex.exception, FileNotFoundError):
-                return []
-            raise
+        dirs = utils.call_function_on_backend(
+            self._ls_dirs,
+            path,
+            suppress_backend_errors=suppress_backend_errors,
+            fallback_return_value=[],
+        )
 
         return sorted(dirs)
 

--- a/audbackend/core/backend/filesystem.py
+++ b/audbackend/core/backend/filesystem.py
@@ -169,7 +169,7 @@ class FileSystem(Base):
     ) -> list[str]:
         r"""List immediate subdirectory names under sub-path."""
         path = self._expand(path)
-        if not os.path.exists(path):
+        if not os.path.isdir(path):
             raise FileNotFoundError(
                 errno.ENOENT,
                 os.strerror(errno.ENOENT),

--- a/audbackend/core/backend/filesystem.py
+++ b/audbackend/core/backend/filesystem.py
@@ -1,5 +1,6 @@
 from collections.abc import Iterator
 import datetime
+import errno
 import os
 import shutil
 
@@ -161,6 +162,22 @@ class FileSystem(Base):
         paths = [self._collapse(path) for path in paths]
 
         return paths
+
+    def _ls_dirs(
+        self,
+        path: str,
+    ) -> list[str]:
+        r"""List immediate subdirectory names under sub-path."""
+        path = self._expand(path)
+        if not os.path.exists(path):
+            raise FileNotFoundError(
+                errno.ENOENT,
+                os.strerror(errno.ENOENT),
+                path,
+            )
+
+        dirs = [entry.name for entry in os.scandir(path) if entry.is_dir()]
+        return dirs
 
     def _move_file(
         self,

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -1,5 +1,6 @@
 from collections.abc import Iterator
 import configparser
+import errno
 import getpass
 import mimetypes
 import os
@@ -443,6 +444,35 @@ class Minio(Base):
             recursive=True,
         )
         return [self._collapse(obj.object_name) for obj in objects]
+
+    def _ls_dirs(
+        self,
+        path: str,
+    ) -> list[str]:
+        r"""List immediate subdirectory names under sub-path."""
+        path = self.path(path)
+        objects = list(
+            self._client.list_objects(
+                bucket_name=self.repository,
+                prefix=path,
+                recursive=False,
+            )
+        )
+        if not objects:
+            raise FileNotFoundError(
+                errno.ENOENT,
+                os.strerror(errno.ENOENT),
+                path,
+            )
+        dirs = []
+        for obj in objects:
+            if obj.is_dir:
+                # obj.object_name ends with "/",
+                # e.g. "sub/1.0.0/"
+                # We strip trailing "/" and take the last component
+                name = obj.object_name.rstrip("/").split("/")[-1]
+                dirs.append(name)
+        return dirs
 
     def _move_file(
         self,

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -450,19 +450,23 @@ class Minio(Base):
         path: str,
     ) -> list[str]:
         r"""List immediate subdirectory names under sub-path."""
-        path = self.path(path)
+        prefix = self.path(path)
         objects = list(
             self._client.list_objects(
                 bucket_name=self.repository,
-                prefix=path,
+                prefix=prefix,
                 recursive=False,
             )
         )
         if not objects:
+            # The root always exists,
+            # so an empty repository has no subdirectories.
+            if path == "/":
+                return []
             raise FileNotFoundError(
                 errno.ENOENT,
                 os.strerror(errno.ENOENT),
-                path,
+                prefix,
             )
         dirs = []
         for obj in objects:

--- a/audbackend/core/interface/maven.py
+++ b/audbackend/core/interface/maven.py
@@ -288,7 +288,7 @@ class Maven(Versioned):
             ['1.0.0', '2.0.0']
 
         """
-        utils.check_path(path)
+        path = utils.check_path(path)
 
         root, name = self.split(path)
         base, ext = self._split_ext(name)

--- a/audbackend/core/interface/maven.py
+++ b/audbackend/core/interface/maven.py
@@ -251,6 +251,71 @@ class Maven(Versioned):
 
         return paths_and_versions
 
+    def versions(
+        self,
+        path: str,
+        *,
+        suppress_backend_errors: bool = False,
+    ) -> list[str]:
+        r"""Versions of a file.
+
+        Args:
+            path: path to file on backend
+            suppress_backend_errors: if set to ``True``,
+                silently catch errors raised on the backend
+                and return an empty list
+
+        Returns:
+            list of versions in ascending order
+
+        Raises:
+            BackendError: if ``suppress_backend_errors`` is ``False``
+                and an error is raised on the backend,
+                e.g. ``path`` does not exist
+            ValueError: if ``path`` does not start with ``'/'``,
+                ends on ``'/'``,
+                or does not match ``'[A-Za-z0-9/._-]+'``
+            RuntimeError: if backend was not opened
+
+        ..
+            >>> interface = Maven(filesystem)
+
+        Examples:
+            >>> file = "src.txt"
+            >>> interface.put_file(file, "/file.txt", "1.0.0")
+            >>> interface.put_file(file, "/file.txt", "2.0.0")
+            >>> interface.versions("/file.txt")
+            ['1.0.0', '2.0.0']
+
+        """
+        utils.check_path(path)
+
+        root, name = self.split(path)
+        base, ext = self._split_ext(name)
+
+        # Maven stores files as /<root>/<base>/<version>/<base>-<version><ext>
+        # so version folders are under /<root>/<base>/
+        base_dir = self.join(root, base) + "/"
+
+        dirs = self.backend.ls_dirs(
+            base_dir,
+            suppress_backend_errors=suppress_backend_errors,
+        )
+
+        vs = []
+        for d in dirs:
+            versioned_file = self.join(root, base, d, f"{base}-{d}{ext}")
+            if self.backend.exists(versioned_file):
+                vs.append(d)
+
+        if not vs and not suppress_backend_errors:
+            try:
+                utils.raise_file_not_found_error(path)
+            except FileNotFoundError as ex:
+                raise BackendError(ex)
+
+        return audeer.sort_versions(vs)
+
     def _split_ext(
         self,
         name: str,

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -939,10 +939,27 @@ class Versioned(Base):
         """
         utils.check_path(path)
 
-        paths = self.ls(path, suppress_backend_errors=suppress_backend_errors)
-        vs = [v for _, v in paths]
+        root, file = self.split(path)
+        root_dir = root if root.endswith("/") else root + "/"
 
-        return vs
+        dirs = self.backend.ls_dirs(
+            root_dir,
+            suppress_backend_errors=suppress_backend_errors,
+        )
+
+        vs = []
+        for d in dirs:
+            versioned_path = self.join(root, d, file)
+            if self.backend.exists(versioned_path):
+                vs.append(d)
+
+        if not vs and not suppress_backend_errors:
+            try:
+                utils.raise_file_not_found_error(path)
+            except FileNotFoundError as ex:
+                raise BackendError(ex)
+
+        return audeer.sort_versions(vs)
 
     def _path_with_version(
         self,

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -940,10 +940,8 @@ class Versioned(Base):
         utils.check_path(path)
 
         root, file = self.split(path)
-        root_dir = root if root.endswith("/") else root + "/"
-
         dirs = self.backend.ls_dirs(
-            root_dir,
+            root,
             suppress_backend_errors=suppress_backend_errors,
         )
 

--- a/tests/test_backend_artifactory.py
+++ b/tests/test_backend_artifactory.py
@@ -337,16 +337,55 @@ def test_ls_dirs(tmpdir, interface):
     src_path = audeer.path(tmpdir, "test.txt")
     audeer.touch(src_path)
 
+    # Upload files to create directory structure:
+    # /sub/1.0.0/file.txt
+    # /sub/2.0.0/file.txt
+    # /sub/other/1.0.0/file.txt
+    # /other/sub/1.0.0/file.txt
     interface.put_file(src_path, "/sub/file.txt", "1.0.0")
     interface.put_file(src_path, "/sub/file.txt", "2.0.0")
-    interface.put_file(src_path, "/sub/subsub/file.txt", "3.0.0")
+    interface.put_file(src_path, "/sub/other/file.txt", "3.0.0")
+    interface.put_file(src_path, "/other/sub/file.txt", "4.0.0")
 
     backend = interface.backend
 
-    # List subdirectories
+    # List subdirectories at root
+    dirs = backend.ls_dirs("/")
+    assert dirs == ["other", "sub"]
+
+    # List subdirectories under /sub/
     dirs = backend.ls_dirs("/sub/")
-    assert dirs == ["1.0.0", "2.0.0", "subsub"]
+    assert dirs == ["1.0.0", "2.0.0", "other"]
+
+    # List subdirectories under /sub/other/
+    dirs = backend.ls_dirs("/sub/other/")
+    assert dirs == ["3.0.0"]
+
+    # List subdirectories under /other/
+    dirs = backend.ls_dirs("/other/")
+    assert dirs == ["sub"]
+
+    # List subdirectories under /other/sub/
+    dirs = backend.ls_dirs("/other/sub/")
+    assert dirs == ["4.0.0"]
+
+    # List subdirectories under a leaf directory (no subdirs)
+    dirs = backend.ls_dirs("/sub/1.0.0/")
+    assert dirs == []
+    dirs = backend.ls_dirs("/sub/other/3.0.0/")
+    assert dirs == []
+
+    # Path must end with "/"
+    with pytest.raises(ValueError, match="path must end with '/'"):
+        backend.ls_dirs("/sub")
 
     # Non-existent path raises BackendError
     with pytest.raises(audbackend.BackendError):
         backend.ls_dirs("/nonexistent/")
+
+    # suppress_backend_errors returns empty list on error
+    dirs = backend.ls_dirs(
+        "/nonexistent/",
+        suppress_backend_errors=True,
+    )
+    assert dirs == []

--- a/tests/test_backend_artifactory.py
+++ b/tests/test_backend_artifactory.py
@@ -325,3 +325,27 @@ def test_get_archive_streaming(tmpdir, interface):
         "/archive.zip", dst_root_validated, validate=True
     )
     assert sorted(extracted_validated) == ["file1.txt", "file2.txt"]
+
+
+@pytest.mark.parametrize(
+    "interface",
+    [(audbackend.backend.Artifactory, audbackend.interface.Versioned)],
+    indirect=True,
+)
+def test_ls_dirs(tmpdir, interface):
+    """Test _ls_dirs on Artifactory backend."""
+    src_path = audeer.path(tmpdir, "test.txt")
+    audeer.touch(src_path)
+
+    interface.put_file(src_path, "/sub/file.txt", "1.0.0")
+    interface.put_file(src_path, "/sub/file.txt", "2.0.0")
+
+    backend = interface.backend
+
+    # List subdirectories
+    dirs = backend.ls_dirs("/sub/")
+    assert dirs == ["1.0.0", "2.0.0"]
+
+    # Non-existent path raises BackendError
+    with pytest.raises(audbackend.BackendError):
+        backend.ls_dirs("/nonexistent/")

--- a/tests/test_backend_artifactory.py
+++ b/tests/test_backend_artifactory.py
@@ -339,12 +339,13 @@ def test_ls_dirs(tmpdir, interface):
 
     interface.put_file(src_path, "/sub/file.txt", "1.0.0")
     interface.put_file(src_path, "/sub/file.txt", "2.0.0")
+    interface.put_file(src_path, "/sub/subsub/file.txt", "3.0.0")
 
     backend = interface.backend
 
     # List subdirectories
     dirs = backend.ls_dirs("/sub/")
-    assert dirs == ["1.0.0", "2.0.0"]
+    assert dirs == ["1.0.0", "2.0.0", "subsub"]
 
     # Non-existent path raises BackendError
     with pytest.raises(audbackend.BackendError):

--- a/tests/test_backend_artifactory.py
+++ b/tests/test_backend_artifactory.py
@@ -332,6 +332,19 @@ def test_get_archive_streaming(tmpdir, interface):
     [(audbackend.backend.Artifactory, audbackend.interface.Versioned)],
     indirect=True,
 )
+def test_ls_empty_repository(tmpdir, interface):
+    """Test ls and ls_dirs return an empty list for an empty repository."""
+    backend = interface.backend
+
+    assert backend.ls("/") == []
+    assert backend.ls_dirs("/") == []
+
+
+@pytest.mark.parametrize(
+    "interface",
+    [(audbackend.backend.Artifactory, audbackend.interface.Versioned)],
+    indirect=True,
+)
 def test_ls_dirs(tmpdir, interface):
     """Test _ls_dirs on Artifactory backend."""
     src_path = audeer.path(tmpdir, "test.txt")

--- a/tests/test_backend_base.py
+++ b/tests/test_backend_base.py
@@ -3,6 +3,7 @@ import re
 import pytest
 
 import audbackend
+from audbackend.core.backend.base import Base
 
 
 @pytest.mark.parametrize(
@@ -126,3 +127,76 @@ def test_errors(tmpdir, backend):
         backend.put_file(src_path, dst_path)
     with pytest.raises(RuntimeError, match=error_msg):
         backend.remove_file(path)
+
+
+class DummyLsBackend(Base):
+    """Dummy backend that only implements _ls to exercise Base._ls_dirs."""
+
+    def __init__(self, listings):
+        super().__init__("host", "repo")
+        self._listings = listings
+
+    def _ls(self, path):
+        return self._listings.get(path, [])
+
+    def _open(self):
+        pass
+
+    def _close(self):
+        pass
+
+
+def test_default_ls_dirs_root_and_nested():
+    """Directories are correctly listed for root and nested paths."""
+    backend = DummyLsBackend(
+        {
+            "/": [
+                "/a/file1.txt",
+                "/a/file2.txt",
+                "/b/c/file3.txt",
+                "/d/file4.txt",
+            ],
+            "/a/": [
+                "/a/file1.txt",
+                "/a/subdir/file4.txt",
+            ],
+            "/b/": [
+                "/b/c/file3.txt",
+            ],
+        }
+    )
+    backend.open()
+    assert sorted(backend.ls_dirs("/")) == ["a", "b", "d"]
+    assert sorted(backend.ls_dirs("/a/")) == ["subdir"]
+    assert sorted(backend.ls_dirs("/b/")) == ["c"]
+
+
+def test_default_ls_dirs_derived_from_deeper_paths():
+    """Immediate directory names are derived from deeper nested paths."""
+    backend = DummyLsBackend(
+        {
+            "/": [
+                "/a/file1.txt",
+                "/a/b/c/file2.txt",
+                "/x/y/z/file3",
+            ],
+            "/a/": [
+                "/a/b/c/file2.txt",
+            ],
+        }
+    )
+    backend.open()
+    assert sorted(backend.ls_dirs("/")) == ["a", "x"]
+    assert backend.ls_dirs("/a/") == ["b"]
+
+
+def test_default_ls_dirs_raises_file_not_found():
+    """_ls_dirs raises FileNotFoundError when _ls returns an empty list."""
+    backend = DummyLsBackend(
+        {
+            "/empty/": [],
+        }
+    )
+    backend.open()
+    with pytest.raises(audbackend.BackendError):
+        backend.ls_dirs("/empty/")

--- a/tests/test_backend_base.py
+++ b/tests/test_backend_base.py
@@ -190,6 +190,21 @@ def test_default_ls_dirs_derived_from_deeper_paths():
     assert backend.ls_dirs("/a/") == ["b"]
 
 
+def test_default_ls_dirs_edge_cases():
+    """Cover edge cases: non-matching prefix and path itself in _ls results."""
+    backend = DummyLsBackend(
+        {
+            "/sub/": [
+                "/sub/",
+                "/other/file.txt",
+                "/sub/a/file.txt",
+            ],
+        }
+    )
+    backend.open()
+    assert backend.ls_dirs("/sub/") == ["a"]
+
+
 def test_default_ls_dirs_raises_file_not_found():
     """_ls_dirs raises FileNotFoundError when _ls returns an empty list."""
     backend = DummyLsBackend(

--- a/tests/test_backend_base.py
+++ b/tests/test_backend_base.py
@@ -115,6 +115,8 @@ def test_errors(tmpdir, backend):
     with pytest.raises(RuntimeError, match=error_msg):
         backend.ls(path)
     with pytest.raises(RuntimeError, match=error_msg):
+        backend.ls_dirs("/")
+    with pytest.raises(RuntimeError, match=error_msg):
         backend.move_file(src_path, dst_path)
     with pytest.raises(RuntimeError, match=error_msg):
         backend.owner(path)

--- a/tests/test_backend_base.py
+++ b/tests/test_backend_base.py
@@ -205,6 +205,20 @@ def test_default_ls_dirs_edge_cases():
     assert backend.ls_dirs("/sub/") == ["a"]
 
 
+def test_default_ls_dirs_leaf_directory():
+    """Leaf directory with files but no subdirs returns empty list."""
+    backend = DummyLsBackend(
+        {
+            "/sub/1.0.0/": [
+                "/sub/1.0.0/file.txt",
+                "/sub/1.0.0/other.txt",
+            ],
+        }
+    )
+    backend.open()
+    assert backend.ls_dirs("/sub/1.0.0/") == []
+
+
 def test_default_ls_dirs_raises_file_not_found():
     """_ls_dirs raises FileNotFoundError when _ls returns an empty list."""
     backend = DummyLsBackend(

--- a/tests/test_backend_base.py
+++ b/tests/test_backend_base.py
@@ -229,3 +229,14 @@ def test_default_ls_dirs_raises_file_not_found():
     backend.open()
     with pytest.raises(audbackend.BackendError):
         backend.ls_dirs("/empty/")
+
+
+def test_default_ls_dirs_suppress_backend_errors():
+    """ls_dirs returns an empty list without raising when errors are suppressed."""
+    backend = DummyLsBackend(
+        {
+            "/empty/": [],
+        }
+    )
+    backend.open()
+    assert backend.ls_dirs("/empty/", suppress_backend_errors=True) == []

--- a/tests/test_backend_base.py
+++ b/tests/test_backend_base.py
@@ -219,6 +219,17 @@ def test_default_ls_dirs_leaf_directory():
     assert backend.ls_dirs("/sub/1.0.0/") == []
 
 
+def test_default_ls_dirs_empty_root():
+    """ls_dirs returns an empty list for the root of an empty repository."""
+    backend = DummyLsBackend(
+        {
+            "/": [],
+        }
+    )
+    backend.open()
+    assert backend.ls_dirs("/") == []
+
+
 def test_default_ls_dirs_raises_file_not_found():
     """_ls_dirs raises FileNotFoundError when _ls returns an empty list."""
     backend = DummyLsBackend(

--- a/tests/test_backend_filesystem.py
+++ b/tests/test_backend_filesystem.py
@@ -509,10 +509,12 @@ def test_ls_dirs(tmpdir, interface):
     # Upload files to create directory structure:
     # /sub/1.0.0/file.txt
     # /sub/2.0.0/file.txt
-    # /other/1.0.0/file.txt
+    # /sub/other/1.0.0/file.txt
+    # /other/sub/1.0.0/file.txt
     interface.put_file(src_path, "/sub/file.txt", "1.0.0")
     interface.put_file(src_path, "/sub/file.txt", "2.0.0")
-    interface.put_file(src_path, "/other/file.txt", "1.0.0")
+    interface.put_file(src_path, "/sub/other/file.txt", "3.0.0")
+    interface.put_file(src_path, "/other/sub/file.txt", "4.0.0")
 
     backend = interface.backend
 
@@ -522,14 +524,24 @@ def test_ls_dirs(tmpdir, interface):
 
     # List subdirectories under /sub/
     dirs = backend.ls_dirs("/sub/")
-    assert dirs == ["1.0.0", "2.0.0"]
+    assert dirs == ["1.0.0", "2.0.0", "other"]
+
+    # List subdirectories under /sub/other/
+    dirs = backend.ls_dirs("/sub/other/")
+    assert dirs == ["3.0.0"]
 
     # List subdirectories under /other/
     dirs = backend.ls_dirs("/other/")
-    assert dirs == ["1.0.0"]
+    assert dirs == ["sub"]
+
+    # List subdirectories under /other/sub/
+    dirs = backend.ls_dirs("/other/sub/")
+    assert dirs == ["4.0.0"]
 
     # List subdirectories under a leaf directory (no subdirs)
     dirs = backend.ls_dirs("/sub/1.0.0/")
+    assert dirs == []
+    dirs = backend.ls_dirs("/sub/other/3.0.0/")
     assert dirs == []
 
     # Path must end with "/"

--- a/tests/test_backend_filesystem.py
+++ b/tests/test_backend_filesystem.py
@@ -494,3 +494,55 @@ def test_size(tmpdir, interface):
     actual_size = interface.backend._size(backend_path)
 
     assert actual_size == expected_size
+
+
+@pytest.mark.parametrize(
+    "interface",
+    [(audbackend.backend.FileSystem, audbackend.interface.Versioned)],
+    indirect=True,
+)
+def test_ls_dirs(tmpdir, interface):
+    """Test ls_dirs returns immediate subdirectory names."""
+    src_path = audeer.path(tmpdir, "test.txt")
+    audeer.touch(src_path)
+
+    # Upload files to create directory structure:
+    # /sub/1.0.0/file.txt
+    # /sub/2.0.0/file.txt
+    # /other/1.0.0/file.txt
+    interface.put_file(src_path, "/sub/file.txt", "1.0.0")
+    interface.put_file(src_path, "/sub/file.txt", "2.0.0")
+    interface.put_file(src_path, "/other/file.txt", "1.0.0")
+
+    backend = interface.backend
+
+    # List subdirectories at root
+    dirs = backend.ls_dirs("/")
+    assert dirs == ["other", "sub"]
+
+    # List subdirectories under /sub/
+    dirs = backend.ls_dirs("/sub/")
+    assert dirs == ["1.0.0", "2.0.0"]
+
+    # List subdirectories under /other/
+    dirs = backend.ls_dirs("/other/")
+    assert dirs == ["1.0.0"]
+
+    # List subdirectories under a leaf directory (no subdirs)
+    dirs = backend.ls_dirs("/sub/1.0.0/")
+    assert dirs == []
+
+    # Path must end with "/"
+    with pytest.raises(ValueError, match="path must end with '/'"):
+        backend.ls_dirs("/sub")
+
+    # Non-existent path raises BackendError
+    with pytest.raises(audbackend.BackendError):
+        backend.ls_dirs("/nonexistent/")
+
+    # suppress_backend_errors returns empty list on error
+    dirs = backend.ls_dirs(
+        "/nonexistent/",
+        suppress_backend_errors=True,
+    )
+    assert dirs == []

--- a/tests/test_backend_filesystem.py
+++ b/tests/test_backend_filesystem.py
@@ -501,6 +501,19 @@ def test_size(tmpdir, interface):
     [(audbackend.backend.FileSystem, audbackend.interface.Versioned)],
     indirect=True,
 )
+def test_ls_empty_repository(tmpdir, interface):
+    """Test ls and ls_dirs return an empty list for an empty repository."""
+    backend = interface.backend
+
+    assert backend.ls("/") == []
+    assert backend.ls_dirs("/") == []
+
+
+@pytest.mark.parametrize(
+    "interface",
+    [(audbackend.backend.FileSystem, audbackend.interface.Versioned)],
+    indirect=True,
+)
 def test_ls_dirs(tmpdir, interface):
     """Test ls_dirs returns immediate subdirectory names."""
     src_path = audeer.path(tmpdir, "test.txt")

--- a/tests/test_backend_minio.py
+++ b/tests/test_backend_minio.py
@@ -844,3 +844,27 @@ def test_get_archive_streaming(tmpdir, interface):
         "/archive.zip", dst_root_validated, validate=True
     )
     assert sorted(extracted_validated) == ["file1.txt", "file2.txt"]
+
+
+@pytest.mark.parametrize(
+    "interface",
+    [(audbackend.backend.Minio, audbackend.interface.Versioned)],
+    indirect=True,
+)
+def test_ls_dirs(tmpdir, interface):
+    """Test _ls_dirs on MinIO backend."""
+    src_path = audeer.path(tmpdir, "test.txt")
+    audeer.touch(src_path)
+
+    interface.put_file(src_path, "/sub/file.txt", "1.0.0")
+    interface.put_file(src_path, "/sub/file.txt", "2.0.0")
+
+    backend = interface.backend
+
+    # List subdirectories
+    dirs = backend.ls_dirs("/sub/")
+    assert dirs == ["1.0.0", "2.0.0"]
+
+    # Non-existent path raises BackendError
+    with pytest.raises(audbackend.BackendError):
+        backend.ls_dirs("/nonexistent/")

--- a/tests/test_backend_minio.py
+++ b/tests/test_backend_minio.py
@@ -856,15 +856,55 @@ def test_ls_dirs(tmpdir, interface):
     src_path = audeer.path(tmpdir, "test.txt")
     audeer.touch(src_path)
 
+    # Upload files to create directory structure:
+    # /sub/1.0.0/file.txt
+    # /sub/2.0.0/file.txt
+    # /sub/other/1.0.0/file.txt
+    # /other/sub/1.0.0/file.txt
     interface.put_file(src_path, "/sub/file.txt", "1.0.0")
     interface.put_file(src_path, "/sub/file.txt", "2.0.0")
+    interface.put_file(src_path, "/sub/other/file.txt", "3.0.0")
+    interface.put_file(src_path, "/other/sub/file.txt", "4.0.0")
 
     backend = interface.backend
 
-    # List subdirectories
+    # List subdirectories at root
+    dirs = backend.ls_dirs("/")
+    assert dirs == ["other", "sub"]
+
+    # List subdirectories under /sub/
     dirs = backend.ls_dirs("/sub/")
-    assert dirs == ["1.0.0", "2.0.0"]
+    assert dirs == ["1.0.0", "2.0.0", "other"]
+
+    # List subdirectories under /sub/other/
+    dirs = backend.ls_dirs("/sub/other/")
+    assert dirs == ["3.0.0"]
+
+    # List subdirectories under /other/
+    dirs = backend.ls_dirs("/other/")
+    assert dirs == ["sub"]
+
+    # List subdirectories under /other/sub/
+    dirs = backend.ls_dirs("/other/sub/")
+    assert dirs == ["4.0.0"]
+
+    # List subdirectories under a leaf directory (no subdirs)
+    dirs = backend.ls_dirs("/sub/1.0.0/")
+    assert dirs == []
+    dirs = backend.ls_dirs("/sub/other/3.0.0/")
+    assert dirs == []
+
+    # Path must end with "/"
+    with pytest.raises(ValueError, match="path must end with '/'"):
+        backend.ls_dirs("/sub")
 
     # Non-existent path raises BackendError
     with pytest.raises(audbackend.BackendError):
         backend.ls_dirs("/nonexistent/")
+
+    # suppress_backend_errors returns empty list on error
+    dirs = backend.ls_dirs(
+        "/nonexistent/",
+        suppress_backend_errors=True,
+    )
+    assert dirs == []

--- a/tests/test_backend_minio.py
+++ b/tests/test_backend_minio.py
@@ -851,6 +851,19 @@ def test_get_archive_streaming(tmpdir, interface):
     [(audbackend.backend.Minio, audbackend.interface.Versioned)],
     indirect=True,
 )
+def test_ls_empty_repository(tmpdir, interface):
+    """Test ls and ls_dirs return an empty list for an empty repository."""
+    backend = interface.backend
+
+    assert backend.ls("/") == []
+    assert backend.ls_dirs("/") == []
+
+
+@pytest.mark.parametrize(
+    "interface",
+    [(audbackend.backend.Minio, audbackend.interface.Versioned)],
+    indirect=True,
+)
 def test_ls_dirs(tmpdir, interface):
     """Test _ls_dirs on MinIO backend."""
     src_path = audeer.path(tmpdir, "test.txt")

--- a/tests/test_interface_maven.py
+++ b/tests/test_interface_maven.py
@@ -334,6 +334,32 @@ def test_ls(tmpdir, interface, files, path, latest, pattern, expected):
     ) == sorted(expected)
 
 
+@pytest.mark.parametrize(
+    "interface",
+    backend_interface_combinations,
+    indirect=True,
+)
+def test_versions(tmpdir, interface):
+    """Test Maven.versions() using ls_dirs."""
+    src_path = audeer.path(tmpdir, "~")
+    audeer.touch(src_path)
+
+    dst_path = "/file.txt"
+
+    # Non-existent file raises BackendError
+    with pytest.raises(audbackend.BackendError):
+        interface.versions(dst_path)
+    assert not interface.versions(dst_path, suppress_backend_errors=True)
+
+    # v1
+    interface.put_file(src_path, dst_path, "1.0.0")
+    assert interface.versions(dst_path) == ["1.0.0"]
+
+    # v2
+    interface.put_file(src_path, dst_path, "2.0.0")
+    assert interface.versions(dst_path) == ["1.0.0", "2.0.0"]
+
+
 def test_repr():
     interface = audbackend.interface.Maven(
         audbackend.backend.FileSystem("host", "repo")

--- a/tests/test_interface_maven.py
+++ b/tests/test_interface_maven.py
@@ -351,6 +351,13 @@ def test_versions(tmpdir, interface):
         interface.versions(dst_path)
     assert not interface.versions(dst_path, suppress_backend_errors=True)
 
+    # Base dir exists but file with different extension,
+    # so versions for our file should still raise
+    other_path = "/file.other"
+    interface.put_file(src_path, other_path, "1.0.0")
+    with pytest.raises(audbackend.BackendError):
+        interface.versions(dst_path)
+
     # v1
     interface.put_file(src_path, dst_path, "1.0.0")
     assert interface.versions(dst_path) == ["1.0.0"]

--- a/tests/test_interface_versioned.py
+++ b/tests/test_interface_versioned.py
@@ -1207,7 +1207,7 @@ def test_validate(tmpdir):
         )
     assert not interface.exists("/remote.zip", "1.0.0")
     interface.put_archive(
-        ".",
+        tmpdir,
         "/remote.zip",
         "1.0.0",
         validate=True,


### PR DESCRIPTION
Closes #252 

Originally, we did not cover folders as some backends do not have the concept of folders. But with our `path` syntax in `audbackend` we clearly follow sub-directory structures, e.g. `/sub0/sub1/file.txt`. This means if you ask to list all folders under `/sub0/` this is well defined. 

The `Versioned` and `Maven` interfaces further use this folder like structure to encode the versions, e.g. `/sub/version/file.zip`. When we want to get all possible versions of `file.zip` we use `ls()` to first list all files that are stored under `/sub` and then look for the potential version. There can be a lot of files, and that is the reason why `interface.versions()` can be very slow.

This pull request improves this by adding `backend.ls_dirs()` to return folders under a given path.
To handle backends that do not understand a folder structure `ls_dirs()` defaults to use `_ls()` under the hood. Backends that support a faster lookup of folders need then to implement a custom `_ls_dirs()` method, which I have done for all our current backends.

<img width="718" height="648" alt="image" src="https://github.com/user-attachments/assets/cef24c98-3f02-4026-81cc-a9e2efe85934" />

## Example

Here an example file structure from `audb` using `audbackend.interface.Versioned`:

```
name/1.0.0/db.yaml
name/1.0.0/db.zip
name/2.0.0/db.yaml
name/2.0.0/db.zip
name/media/1.0.0/...
name/media/2.0.0/...
name/meta/1.0.0/...
name/meta/2.0.0/...
```

### Current implementation

When you would use `audbackend.interface.Versioned.versions("/name/db.yaml")` it would currently (`main` branch) execute

```python
paths = self.ls(path, suppress_backend_errors=suppress_backend_errors)
```

which would call

```python
root, file = self.split(path)
paths = self.backend.ls(root, suppress_backend_errors=suppress_backend_errors)
```

`root` would be `"/name/"`, which means `ls()` would need to list potentially millions of files.

### Proposed implementation

When you would use `audbackend.interface.Versioned.versions("/name/db.yaml")` it would (`add-ls-dirs` branch) execute

```python
root, file = self.split(path)
root_dir = root if root.endswith("/") else root + "/"
dirs = self.backend.ls_dirs(root_dir, suppress_backend_errors=suppress_backend_errors)
```
where `root_dir` would be `"/name/"`, which would then run for the minio backend

```python
objects = list(
    self._client.list_objects(bucket_name=self.repository, prefix=path, recursive=False)
)
```

which only needs to return all files/folders under `"/name/"`.

## Benchmark

Execution time for running `audb.versions()`:

| Dataset | Backend | Current | Proposed |
| --- | --- | --- | --- |
| librispeech | minio | 103.469s | 1.773s |
| aisoundlab-covid-19 | artifactory | 3.544s | 2.303s |

Note: the artifactory backend in `audb.versions()` is not relying on `audbackend.interface.Maven.versions()`, but on custom code at https://github.com/audeering/audb/blob/ccadb4424b8e808aa8a7061efdd1bdd513853a45/audb/core/api.py#L620-L648. With the changes proposed here, we no longer need that custom code for the artifactory backend in `audb`. The results reported for Proposed in the table are run with a modified version of `audb` that has no special handling of the artifactory backend. If we run the same code for Current the execution time would be 6.675s.

## Discussion

* The main downside of the current implementation is the need for calling `exists()` in `versions()` on the backend multiple times. But as backends can also be handled by other players besides `audbackend` (e.g. web interfaces), I don't think we can avoid this
* An alternative to adding `ls_dirs()` would be to add a `recursive` parameter directly to `ls()` and let it return all folders and files within a folder when `recursive=False`
* We could add `latest_version()` in a follow up pull request as there we could first get a list of sub-folders and then start checking for existing files traversing the sub-folders in reversed order