### PR TITLE
Enable stream-unzip under Python 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,22 +49,16 @@ jobs:
       run: |
         uv run --no-default-groups --group test-filesystem --isolated pytest --cov-fail-under=0 tests/test_backend_filesystem_only.py tests/test_backend_filesystem.py 
 
-    - name: Test with pytest for Python <3.14
+    - name: Test with pytest for Python
       env:
         ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
         ARTIFACTORY_API_KEY: ${{ secrets.ARTIFACTORY_API_KEY }}
       run: |
         uv run pytest --cov-config=.coveragerc.${{ runner.os }}
-      if: ${{ matrix.python-version != '3.14' }}
-
-    - name: Test with pytest for Python >=3.14
-      run: |
-        uv run pytest --cov-config=.coveragerc.python3.14 --ignore=audbackend/core/backend/artifactory.py --ignore=tests/test_backend_artifactory.py
-      if: ${{ matrix.python-version == '3.14' }}
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
-      if: ${{ (matrix.os == 'ubuntu-latest') && (matrix.python-version != '3.14') }}
+      if: ${{ (matrix.os == 'ubuntu-latest') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,16 +49,22 @@ jobs:
       run: |
         uv run --no-default-groups --group test-filesystem --isolated pytest --cov-fail-under=0 tests/test_backend_filesystem_only.py tests/test_backend_filesystem.py 
 
-    - name: Test with pytest for Python
+    - name: Test with pytest for Python <3.14
       env:
         ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
         ARTIFACTORY_API_KEY: ${{ secrets.ARTIFACTORY_API_KEY }}
       run: |
         uv run pytest --cov-config=.coveragerc.${{ runner.os }}
+      if: ${{ matrix.python-version != '3.14' }}
+
+    - name: Test with pytest for Python >=3.14
+      run: |
+        uv run pytest --cov-config=.coveragerc.python3.14 --ignore=audbackend/core/backend/artifactory.py --ignore=tests/test_backend_artifactory.py
+      if: ${{ matrix.python-version == '3.14' }}
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
-      if: ${{ (matrix.os == 'ubuntu-latest') }}
+      if: ${{ (matrix.os == 'ubuntu-latest') && (matrix.python-version != '3.14') }}

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -526,7 +526,7 @@ class Base:
             with tempfile.TemporaryDirectory(dir=tmp_root):
                 pass
 
-        # Use streaming extraction for ZIP files if stream-unzip is available
+        # Use streaming extraction for ZIP files
         if src_path.lower().endswith(".zip") and num_workers == 1:
             return self._get_archive_streaming(
                 src_path,

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -9,18 +9,11 @@ import shutil
 import tempfile
 import zipfile
 
+from stream_unzip import TruncatedDataError
+from stream_unzip import UnfinishedIterationError
+from stream_unzip import stream_unzip
+
 import audeer
-
-
-# stream-unzip is optional (not available on Python 3.14+)
-try:
-    from stream_unzip import TruncatedDataError
-    from stream_unzip import UnfinishedIterationError
-    from stream_unzip import stream_unzip
-
-    STREAM_UNZIP_AVAILABLE = True
-except ImportError:  # pragma: no cover
-    STREAM_UNZIP_AVAILABLE = False
 
 from audbackend.core import utils
 from audbackend.core.errors import BackendError
@@ -534,11 +527,7 @@ class Base:
                 pass
 
         # Use streaming extraction for ZIP files if stream-unzip is available
-        if (
-            src_path.lower().endswith(".zip")
-            and num_workers == 1
-            and STREAM_UNZIP_AVAILABLE
-        ):
+        if src_path.lower().endswith(".zip") and num_workers == 1:
             return self._get_archive_streaming(
                 src_path,
                 dst_root,

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -464,8 +464,7 @@ class Base:
 
         For ZIP archives,
         streaming extraction is used
-        if ``stream-unzip`` is installed,
-        and ``num_workers=1``.
+        when ``num_workers=1``.
         It extracts files during download
         without storing the archive locally.
 
@@ -490,7 +489,8 @@ class Base:
             dst_root: local destination directory
             tmp_root: directory under which archive is temporarily extracted.
                 Defaults to temporary directory of system.
-                Not used for ZIP archives when ``stream-unzip`` is available.
+                Only relevant if streaming extraction is not used,
+                which is the case for ``num_workers>1``
             num_workers: number of parallel jobs
             validate: verify archive was successfully
                 retrieved from the backend

--- a/audbackend/core/interface/unversioned.py
+++ b/audbackend/core/interface/unversioned.py
@@ -225,8 +225,7 @@ class Unversioned(Base):
 
         For ZIP archives,
         streaming extraction is used
-        if ``stream-unzip`` is installed,
-        and ``num_workers=1``.
+        when ``num_workers=1``.
         It extracts files during download
         without storing the archive locally.
 
@@ -250,7 +249,9 @@ class Unversioned(Base):
             src_path: path to archive on backend
             dst_root: local destination directory
             tmp_root: directory under which archive is temporarily extracted.
-                Defaults to temporary directory of system
+                Defaults to temporary directory of system.
+                Only relevant if streaming extraction is not used,
+                which is the case for ``num_workers>1``
             num_workers: number of parallel jobs
             validate: verify archive was successfully
                 retrieved from the backend

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -268,8 +268,7 @@ class Versioned(Base):
 
         For ZIP archives,
         streaming extraction is used
-        if ``stream-unzip`` is installed,
-        and ``num_workers=1``.
+        when ``num_workers=1``.
         It extracts files during download
         without storing the archive locally.
 
@@ -295,7 +294,9 @@ class Versioned(Base):
             version: version string
             num_workers: number of parallel jobs
             tmp_root: directory under which archive is temporarily extracted.
-                Defaults to temporary directory of system
+                Defaults to temporary directory of system.
+                Only relevant if streaming extraction is not used,
+                which is the case for ``num_workers>1``
             validate: verify archive was successfully
                 retrieved from the backend
             verbose: show debug messages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ requires-python = '>=3.10'
 dependencies = [
     'audeer >=2.3.1',
     'pywin32; sys_platform == "win32"',
-    'stream-unzip >=0.0.101; python_version < "3.14"',
+    'stream-unzip >=0.0.101',
 ]
 # Get version dynamically from git
 # (needs setuptools_scm tools config below)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ requires-python = '>=3.10'
 dependencies = [
     'audeer >=2.3.1',
     'pywin32; sys_platform == "win32"',
-    'stream-unzip >=0.0.101',
+    'stream-unzip >=0.0.101; python_version < "3.14"',
 ]
 # Get version dynamically from git
 # (needs setuptools_scm tools config below)

--- a/tests/test_backend_artifactory.py
+++ b/tests/test_backend_artifactory.py
@@ -286,12 +286,6 @@ def test_get_archive_streaming(tmpdir, interface):
     which is required for streaming ZIP extraction and checksum computation.
 
     """
-    # Skip if stream-unzip is not available
-    try:
-        from stream_unzip import stream_unzip  # noqa: F401
-    except ImportError:
-        pytest.skip("stream-unzip not available")
-
     # Create source files
     src_root = audeer.path(tmpdir, "src")
     audeer.mkdir(src_root)

--- a/tests/test_backend_filesystem.py
+++ b/tests/test_backend_filesystem.py
@@ -204,12 +204,6 @@ def test_get_archive_streaming(tmpdir, interface):
     which is required for streaming ZIP extraction and checksum computation.
 
     """
-    # Skip if stream-unzip is not available
-    try:
-        from stream_unzip import stream_unzip  # noqa: F401
-    except ImportError:
-        pytest.skip("stream-unzip not available")
-
     # Create source files
     src_root = audeer.path(tmpdir, "src")
     audeer.mkdir(src_root)
@@ -257,12 +251,6 @@ def test_streaming_dst_root_is_file(tmpdir, interface):
     NotADirectoryError should be raised and the file should remain unchanged.
 
     """
-    # Skip if stream-unzip is not available
-    try:
-        from stream_unzip import stream_unzip  # noqa: F401
-    except ImportError:
-        pytest.skip("stream-unzip not available")
-
     # Create a regular file where we'll try to extract to
     dst_file = audeer.path(tmpdir, "existing_file.txt")
     with open(dst_file, "w") as f:
@@ -311,12 +299,6 @@ def test_streaming_cleanup_existing_directory(tmpdir, interface):
     or pre-existing files.
 
     """
-    # Skip if stream-unzip is not available
-    try:
-        from stream_unzip import stream_unzip  # noqa: F401
-    except ImportError:
-        pytest.skip("stream-unzip not available")
-
     # Create destination directory with pre-existing file
     dst_root = audeer.path(tmpdir, "existing_dir")
     audeer.mkdir(dst_root)
@@ -355,12 +337,6 @@ def test_streaming_cleanup_extracted_files(tmpdir, interface):
     pre-existing files should remain.
 
     """
-    # Skip if stream-unzip is not available
-    try:
-        from stream_unzip import stream_unzip  # noqa: F401
-    except ImportError:
-        pytest.skip("stream-unzip not available")
-
     # Create destination directory with pre-existing file
     dst_root = audeer.path(tmpdir, "existing_dir")
     audeer.mkdir(dst_root)
@@ -421,12 +397,6 @@ def test_streaming_zip_with_directory_entries(tmpdir, interface):
     while still extracting the files within those directories.
 
     """
-    # Skip if stream-unzip is not available
-    try:
-        from stream_unzip import stream_unzip  # noqa: F401
-    except ImportError:
-        pytest.skip("stream-unzip not available")
-
     # Create source files with subdirectory
     src_root = audeer.path(tmpdir, "src")
     audeer.mkdir(src_root)

--- a/tests/test_backend_minio.py
+++ b/tests/test_backend_minio.py
@@ -805,12 +805,6 @@ def test_get_archive_streaming(tmpdir, interface):
     which is required for streaming ZIP extraction and checksum computation.
 
     """
-    # Skip if stream-unzip is not available
-    try:
-        from stream_unzip import stream_unzip  # noqa: F401
-    except ImportError:
-        pytest.skip("stream-unzip not available")
-
     # Create source files
     src_root = audeer.path(tmpdir, "src")
     audeer.mkdir(src_root)


### PR DESCRIPTION
Removes the restriction to not install `stream-unzip` under Python 3.14, as it now simply works. I guess one of its dependencies was not working with Python 3.14 before.