### PR TITLE
Add owner argument to put_file()

### DIFF
--- a/audbackend/core/backend/artifactory.py
+++ b/audbackend/core/backend/artifactory.py
@@ -385,9 +385,16 @@ class Artifactory(Base):
         src_path: str,
         dst_path: str,
         checksum: str,
+        owner: str,
         verbose: bool,
     ):
-        r"""Put file to backend."""
+        r"""Put file to backend.
+
+        ``owner`` is ignored,
+        as Artifactory derives the owner
+        from the user uploading the file.
+
+        """
         dst_path = self.path(dst_path)
         _deploy(src_path, dst_path, checksum, verbose=verbose)
 

--- a/audbackend/core/backend/base.py
+++ b/audbackend/core/backend/base.py
@@ -1315,6 +1315,7 @@ class Base:
         src_path: str,
         dst_path: str,
         checksum: str,
+        owner: str,
         verbose: bool,
     ):  # pragma: no cover
         r"""Put file to backend."""
@@ -1325,6 +1326,7 @@ class Base:
         src_path: str,
         dst_path: str,
         *,
+        owner: str = None,
         validate: bool = False,
         verbose: bool = False,
     ):
@@ -1345,6 +1347,13 @@ class Base:
         Args:
             src_path: path to local file
             dst_path: path to file on backend
+            owner: owner to store with the file.
+                Only backends that track ownership
+                as custom metadata
+                (e.g. :class:`audbackend.backend.Minio`)
+                make use of this.
+                If ``None``,
+                the current user is stored as owner
             validate: verify file was successfully
                 put on the backend
             verbose: show debug messages
@@ -1378,6 +1387,7 @@ class Base:
                 src_path,
                 dst_path,
                 checksum,
+                owner,
                 verbose,
             )
 

--- a/audbackend/core/backend/filesystem.py
+++ b/audbackend/core/backend/filesystem.py
@@ -213,9 +213,16 @@ class FileSystem(Base):
         src_path: str,
         dst_path: str,
         checksum: str,
+        owner: str,
         verbose: bool,
     ):
-        r"""Put file to backend."""
+        r"""Put file to backend.
+
+        ``owner`` is ignored,
+        as the owner is derived
+        from the file system.
+
+        """
         dst_path = self._expand(dst_path)
         audeer.mkdir(os.path.dirname(dst_path))
         shutil.copy(src_path, dst_path)

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -264,7 +264,7 @@ class Minio(Base):
             with tempfile.TemporaryDirectory() as tmp_dir:
                 tmp_path = audeer.path(tmp_dir, os.path.basename(src_path))
                 self._get_file(src_path, tmp_path, num_workers, verbose)
-                self._put_file(tmp_path, dst_path, checksum, verbose)
+                self._put_file(tmp_path, dst_path, checksum, None, verbose)
         else:
             self._client.copy_object(
                 bucket_name=self.repository,
@@ -534,6 +534,7 @@ class Minio(Base):
         src_path: str,
         dst_path: str,
         checksum: str,
+        owner: str,
         verbose: bool,
     ):
         r"""Put file to backend."""
@@ -551,7 +552,7 @@ class Minio(Base):
             object_name=dst_path,
             file_path=src_path,
             content_type=content_type,
-            metadata=_metadata(checksum),
+            metadata=_metadata(checksum, owner),
         )
 
         if verbose:  # pragma: no cover
@@ -587,18 +588,24 @@ class Minio(Base):
         return size
 
 
-def _metadata(checksum: str):
-    """Dictionary with owner entry.
+def _metadata(checksum: str, owner: str = None):
+    """Dictionary with checksum and owner entries.
 
     When uploaded as metadata to MinIO,
-    it can be accessed under ``stat_object(...).metadata["x-amz-meta-owner"]``.
+    the owner can be accessed under
+    ``stat_object(...).metadata["x-amz-meta-owner"]``.
 
     Args:
         checksum: checksum to be stored in metadata
+        owner: owner to be stored in metadata.
+            If ``None`` or empty,
+            the current user is used
     """
+    if not owner:
+        owner = getpass.getuser()
     return {
         "checksum": checksum,
-        "owner": getpass.getuser(),
+        "owner": owner,
     }
 
 

--- a/audbackend/core/interface/unversioned.py
+++ b/audbackend/core/interface/unversioned.py
@@ -624,6 +624,7 @@ class Unversioned(Base):
         src_path: str,
         dst_path: str,
         *,
+        owner: str = None,
         validate: bool = False,
         verbose: bool = False,
     ):
@@ -644,6 +645,13 @@ class Unversioned(Base):
         Args:
             src_path: path to local file
             dst_path: path to file on backend
+            owner: owner to store with the file.
+                Only backends that track ownership
+                as custom metadata
+                (e.g. :class:`audbackend.backend.Minio`)
+                make use of this.
+                If ``None``,
+                the current user is stored as owner
             validate: verify file was successfully
                 put on the backend
             verbose: show debug messages
@@ -673,6 +681,7 @@ class Unversioned(Base):
         self.backend.put_file(
             src_path,
             dst_path,
+            owner=owner,
             validate=validate,
             verbose=verbose,
         )

--- a/audbackend/core/interface/versioned.py
+++ b/audbackend/core/interface/versioned.py
@@ -804,6 +804,7 @@ class Versioned(Base):
         dst_path: str,
         version: str,
         *,
+        owner: str = None,
         validate: bool = False,
         verbose: bool = False,
     ):
@@ -825,6 +826,13 @@ class Versioned(Base):
             src_path: path to local file
             dst_path: path to file on backend
             version: version string
+            owner: owner to store with the file.
+                Only backends that track ownership
+                as custom metadata
+                (e.g. :class:`audbackend.backend.Minio`)
+                make use of this.
+                If ``None``,
+                the current user is stored as owner
             validate: verify file was successfully
                 put on the backend
             verbose: show debug messages
@@ -860,6 +868,7 @@ class Versioned(Base):
         return self.backend.put_file(
             src_path,
             dst_path_with_version,
+            owner=owner,
             validate=validate,
             verbose=verbose,
         )

--- a/docs/developer-guide.rst
+++ b/docs/developer-guide.rst
@@ -357,6 +357,7 @@ a file to our backend.
             src_path: str,
             dst_path: str,
             checksum: str,
+            owner: str,
             verbose: bool,
     ):
         with self._db as db:
@@ -366,7 +367,8 @@ a file to our backend.
                 INSERT INTO data (path, checksum, content, date, owner)
                 VALUES (?, ?, ?, ?, ?)
             """
-            owner = getpass.getuser()
+            if not owner:
+                owner = getpass.getuser()
             date = datetime.datetime.today().strftime("%Y-%m-%d")
             data = (dst_path, checksum, content, date, owner)
             db.execute(query, data)

--- a/tests/bad_file_system.py
+++ b/tests/bad_file_system.py
@@ -12,6 +12,7 @@ class BadFileSystem(audbackend.backend.FileSystem):
         src_path: str,
         dst_path: str,
         *,
+        owner: str = None,
         validate: bool = False,
         verbose: bool = False,
     ):
@@ -22,6 +23,7 @@ class BadFileSystem(audbackend.backend.FileSystem):
             src_path,
             dst_path,
             checksum,
+            owner,
             verbose,
         )
 

--- a/tests/singlefolder.py
+++ b/tests/singlefolder.py
@@ -159,6 +159,7 @@ class SingleFolder(audbackend.backend.Base):
         src_path: str,
         dst_path: str,
         checksum: str,
+        owner: str,
         verbose: bool,
     ):
         with self.Map(self._path, self._lock) as m:


### PR DESCRIPTION
On S3/Minio backends we store the owner of a file in metadata, so we set it during the upload. This is handy when copying/moving files from one repository to another with the goal of preserving the original ownership.

This pull requests implements this functionality with a focus on S3/Minio.

If this is a valid argument for backends as well and we should integrate it in the official API we should decide later. Until then this pull request is marked as draft.