### PR TITLE
Support host specific Minio credentials

### DIFF
--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -124,16 +124,13 @@ class Minio(Base):
 
         To get the authentication tuple,
         the function looks first
-        for host-specific environment variables,
-        namely
+        for the host-specific environment variables
         ``MINIO_ACCESS_KEY_<HOST>`` and
         ``MINIO_SECRET_KEY_<HOST>``,
         where ``<HOST>`` is the uppercased hostname
         with every non-alphanumeric character
         replaced by an underscore,
         e.g. ``play.min.io`` becomes ``PLAY_MIN_IO``.
-        This allows to use different credentials
-        for different hosts.
         If those are not set,
         the function falls back
         to the two environment variables

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -4,6 +4,7 @@ import errno
 import getpass
 import mimetypes
 import os
+import re
 import tempfile
 import warnings
 
@@ -123,7 +124,19 @@ class Minio(Base):
 
         To get the authentication tuple,
         the function looks first
-        for the two environment variables
+        for host-specific environment variables,
+        namely
+        ``MINIO_ACCESS_KEY_<HOST>`` and
+        ``MINIO_SECRET_KEY_<HOST>``,
+        where ``<HOST>`` is the uppercased hostname
+        with every non-alphanumeric character
+        replaced by an underscore,
+        e.g. ``play.min.io`` becomes ``PLAY_MIN_IO``.
+        This allows to use different credentials
+        for different hosts.
+        If those are not set,
+        the function falls back
+        to the two environment variables
         ``MINIO_ACCESS_KEY`` and
         ``MINIO_SECRET_KEY``.
         Otherwise,
@@ -143,8 +156,15 @@ class Minio(Base):
 
         """
         config = cls.get_config(host)
-        access_key = os.getenv("MINIO_ACCESS_KEY", config.get("access_key"))
-        secret_key = os.getenv("MINIO_SECRET_KEY", config.get("secret_key"))
+        suffix = re.sub(r"[^A-Za-z0-9]", "_", host).upper()
+        access_key = os.getenv(
+            f"MINIO_ACCESS_KEY_{suffix}",
+            os.getenv("MINIO_ACCESS_KEY", config.get("access_key")),
+        )
+        secret_key = os.getenv(
+            f"MINIO_SECRET_KEY_{suffix}",
+            os.getenv("MINIO_SECRET_KEY", config.get("secret_key")),
+        )
 
         return access_key, secret_key
 

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -153,7 +153,7 @@ class Minio(Base):
 
         """
         config = cls.get_config(host)
-        suffix = re.sub(r"[^A-Za-z0-9]", "_", host).upper()
+        suffix = _host_env_suffix(host)
         access_key = os.getenv(
             f"MINIO_ACCESS_KEY_{suffix}",
             os.getenv("MINIO_ACCESS_KEY", config.get("access_key")),
@@ -617,6 +617,24 @@ def _metadata(checksum: str):
         "checksum": checksum,
         "owner": getpass.getuser(),
     }
+
+
+def _host_env_suffix(host: str) -> str:
+    """Environment variable suffix for a host.
+
+    Uppercases the hostname
+    and replaces every non-alphanumeric character
+    with an underscore,
+    e.g. ``play.min.io`` becomes ``PLAY_MIN_IO``.
+
+    Args:
+        host: hostname
+
+    Returns:
+        environment variable suffix
+
+    """
+    return re.sub(r"[^A-Za-z0-9]", "_", host).upper()
 
 
 def _parse_timeout(

--- a/tests/test_backend_minio.py
+++ b/tests/test_backend_minio.py
@@ -1,6 +1,7 @@
 import contextlib
 import filecmp
 import os
+import re
 from unittest import mock
 import warnings
 
@@ -109,6 +110,58 @@ def test_authentication(tmpdir, hosts, hide_credentials):
     assert backend.authentication == ("bad", "bad")
     with pytest.raises(audbackend.BackendError):
         backend.open()
+
+
+def test_authentication_host_specific(tmpdir, hosts, hide_credentials):
+    r"""Host-specific environment variables take precedence.
+
+    ``MINIO_ACCESS_KEY_<HOST>`` and ``MINIO_SECRET_KEY_<HOST>``
+    allow to provide different credentials per host,
+    and win over the global ``MINIO_ACCESS_KEY``/``MINIO_SECRET_KEY``
+    and the config file,
+    see https://github.com/audeering/audbackend/issues/298.
+
+    Args:
+        tmpdir: tmpdir fixture
+        hosts: hosts fixture
+        hide_credentials: fixture removing global credentials
+
+    """
+    host = hosts["minio"]
+    suffix = re.sub(r"[^A-Za-z0-9]", "_", host).upper()
+
+    # config file provides credentials for the host
+    config_path = audeer.path(tmpdir, "config.cfg")
+    os.environ["MINIO_CONFIG_FILE"] = config_path
+    with open(config_path, "w") as fp:
+        fp.write(f"[{host}]\n")
+        fp.write("access_key = config-key\n")
+        fp.write("secret_key = config-secret\n")
+
+    backend = audbackend.backend.Minio(host, "repository")
+    assert backend.authentication == ("config-key", "config-secret")
+
+    # global environment variables win over the config file
+    with mock.patch.dict(
+        os.environ,
+        {
+            "MINIO_ACCESS_KEY": "global-key",
+            "MINIO_SECRET_KEY": "global-secret",
+        },
+    ):
+        backend = audbackend.backend.Minio(host, "repository")
+        assert backend.authentication == ("global-key", "global-secret")
+
+        # host-specific environment variables win over the global ones
+        with mock.patch.dict(
+            os.environ,
+            {
+                f"MINIO_ACCESS_KEY_{suffix}": "host-key",
+                f"MINIO_SECRET_KEY_{suffix}": "host-secret",
+            },
+        ):
+            backend = audbackend.backend.Minio(host, "repository")
+            assert backend.authentication == ("host-key", "host-secret")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_backend_minio.py
+++ b/tests/test_backend_minio.py
@@ -118,8 +118,7 @@ def test_authentication_host_specific(tmpdir, hosts, hide_credentials):
     ``MINIO_ACCESS_KEY_<HOST>`` and ``MINIO_SECRET_KEY_<HOST>``
     allow to provide different credentials per host,
     and win over the global ``MINIO_ACCESS_KEY``/``MINIO_SECRET_KEY``
-    and the config file,
-    see https://github.com/audeering/audbackend/issues/298.
+    and the config file.
 
     Args:
         tmpdir: tmpdir fixture

--- a/tests/test_backend_minio.py
+++ b/tests/test_backend_minio.py
@@ -1,7 +1,6 @@
 import contextlib
 import filecmp
 import os
-import re
 from unittest import mock
 import warnings
 
@@ -12,6 +11,7 @@ import urllib3
 import audeer
 
 import audbackend
+from audbackend.core.backend.minio import _host_env_suffix
 
 
 @contextlib.contextmanager
@@ -127,7 +127,7 @@ def test_authentication_host_specific(tmpdir, hosts, hide_credentials):
 
     """
     host = hosts["minio"]
-    suffix = re.sub(r"[^A-Za-z0-9]", "_", host).upper()
+    suffix = _host_env_suffix(host)
 
     # config file provides credentials for the host
     config_path = audeer.path(tmpdir, "config.cfg")
@@ -161,6 +161,48 @@ def test_authentication_host_specific(tmpdir, hosts, hide_credentials):
         ):
             backend = audbackend.backend.Minio(host, "repository")
             assert backend.authentication == ("host-key", "host-secret")
+
+
+@pytest.mark.parametrize(
+    "host, expected_suffix",
+    [
+        ("play.min.io", "PLAY_MIN_IO"),
+        (
+            "s3.dualstack.eu-north-1.amazonaws.com",
+            "S3_DUALSTACK_EU_NORTH_1_AMAZONAWS_COM",
+        ),
+        ("localhost:9000", "LOCALHOST_9000"),
+        ("192.168.0.1", "192_168_0_1"),
+    ],
+)
+def test_authentication_host_suffix(hide_credentials, host, expected_suffix):
+    r"""Host-specific credentials are read for the correct env var names.
+
+    Verifies both the computed suffix and that the resulting
+    ``MINIO_ACCESS_KEY_<SUFFIX>``/``MINIO_SECRET_KEY_<SUFFIX>``
+    environment variables are picked up by
+    :meth:`audbackend.backend.Minio.get_authentication`,
+    so future changes to the normalization can't silently break this.
+
+    Args:
+        hide_credentials: fixture removing global credentials
+        host: hostname
+        expected_suffix: expected environment variable suffix
+
+    """
+    assert _host_env_suffix(host) == expected_suffix
+
+    with mock.patch.dict(
+        os.environ,
+        {
+            f"MINIO_ACCESS_KEY_{expected_suffix}": "host-key",
+            f"MINIO_SECRET_KEY_{expected_suffix}": "host-secret",
+        },
+    ):
+        assert audbackend.backend.Minio.get_authentication(host) == (
+            "host-key",
+            "host-secret",
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #298 

Introduces the environment variables `MINIO_ACCESS_KEY_<HOST>` and `MINIO_SECRET_KEY_<HOST>` to allow providing host-specific environment variables, e.g. inside CI jobs. `<HOST>` is the uppercase version of the host, with only alphanumeric values, e.g. `S3_DUALSTACK_EU_NORTH_1_AMAZONAWS_COM` instead of `s3.dualstack.eu-north-1.amazonaws.com`. This conversion is not bulletproof against collisions (e.g. `a.b` vs. `a-b`), but I think it is easy to understand and collisions should not really happen in reality.

For backward compatibility it also supports `MINIO_ACCESS_KEY` and `MINIO_SECRET_KEY` as before, but the host specific variables take precedence.

<img width="732" height="520" alt="image" src="https://github.com/user-attachments/assets/b849bc99-c571-4b93-b1c9-d51a2c5eb420" />
