### PR TITLE
Fix possible TLS certification error in Minio backend

### DIFF
--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -94,8 +94,9 @@ class Minio(Base):
         #   - "read_timeout": seconds for read operations; None means no timeout
         #     (default: None)
         #
-        # The client verifies TLS certificates against the ``certifi`` CA bundle
-        # matching the default client of ``minio.Minio``.
+        # The client verifies TLS certificates against the CA bundle specified
+        # via ``SSL_CERT_FILE`` when set; otherwise it falls back to the
+        # ``certifi`` CA bundle, matching the default client of ``minio.Minio``.
         if "http_client" not in kwargs:
             connect_timeout = _parse_timeout(
                 config.get("connect_timeout", 10.0),

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -8,6 +8,7 @@ import re
 import tempfile
 import warnings
 
+import certifi
 import minio
 import urllib3
 
@@ -92,6 +93,9 @@ class Minio(Base):
         #   - "connect_timeout": seconds for connection establishment (default: 10.0)
         #   - "read_timeout": seconds for read operations; None means no timeout
         #     (default: None)
+        #
+        # The client verifies TLS certificates against the ``certifi`` CA bundle
+        # matching the default client of ``minio.Minio``.
         if "http_client" not in kwargs:
             connect_timeout = _parse_timeout(
                 config.get("connect_timeout", 10.0),
@@ -104,7 +108,11 @@ class Minio(Base):
                 default=None,
             )
             timeout = urllib3.Timeout(connect=connect_timeout, read=read_timeout)
-            kwargs["http_client"] = urllib3.PoolManager(timeout=timeout)
+            kwargs["http_client"] = urllib3.PoolManager(
+                timeout=timeout,
+                cert_reqs="CERT_REQUIRED",
+                ca_certs=os.environ.get("SSL_CERT_FILE") or certifi.where(),
+            )
 
         # Open MinIO client
         self._client = minio.Minio(

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -32,6 +32,11 @@ class Minio(Base):
     provide a custom ``http_client`` object as ``kwargs``
     to fully control connection behavior.
 
+    For secure connections,
+    TLS certificates are verified
+    against the ``certifi`` CA bundle,
+    or the file given by the ``SSL_CERT_FILE`` environment variable if set.
+
     Args:
         host: host address
         repository: repository name

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -5,6 +5,7 @@ import getpass
 import mimetypes
 import os
 import re
+import ssl
 import tempfile
 import warnings
 
@@ -116,7 +117,7 @@ class Minio(Base):
             timeout = urllib3.Timeout(connect=connect_timeout, read=read_timeout)
             kwargs["http_client"] = urllib3.PoolManager(
                 timeout=timeout,
-                cert_reqs="CERT_REQUIRED",
+                cert_reqs=ssl.CERT_REQUIRED,
                 ca_certs=os.environ.get("SSL_CERT_FILE") or certifi.where(),
             )
 

--- a/audbackend/core/backend/minio.py
+++ b/audbackend/core/backend/minio.py
@@ -36,7 +36,7 @@ class Minio(Base):
     For secure connections,
     TLS certificates are verified
     against the ``certifi`` CA bundle,
-    or the file given by the ``SSL_CERT_FILE`` environment variable if set.
+    or the file given by the ``SSL_CERT_FILE`` environment variable.
 
     Args:
         host: host address
@@ -100,9 +100,10 @@ class Minio(Base):
         #   - "read_timeout": seconds for read operations; None means no timeout
         #     (default: None)
         #
-        # The client verifies TLS certificates against the CA bundle specified
-        # via ``SSL_CERT_FILE`` when set; otherwise it falls back to the
-        # ``certifi`` CA bundle, matching the default client of ``minio.Minio``.
+        # Let http_client verify TLS certificates
+        # against the CA bundle
+        # specified via ``SSL_CERT_FILE`` or ``certifi`` CA bundle,
+        # matching the default client of ``minio.Minio``.
         if "http_client" not in kwargs:
             connect_timeout = _parse_timeout(
                 config.get("connect_timeout", 10.0),

--- a/tests/test_backend_minio.py
+++ b/tests/test_backend_minio.py
@@ -4,6 +4,7 @@ import os
 from unittest import mock
 import warnings
 
+import certifi
 import minio
 import pytest
 import urllib3
@@ -752,6 +753,54 @@ def test_default_timeout_configuration(tmpdir, hosts, hide_credentials):
     assert timeout is not None
     assert timeout.connect_timeout == 10.0
     assert timeout.read_timeout is None
+
+
+def test_default_ca_certificates(tmpdir, hosts, hide_credentials):
+    r"""Test that the default http_client verifies TLS via a CA bundle.
+
+    When no http_client is provided,
+    the backend creates one itself.
+    That client must verify TLS certificates
+    against an explicit CA bundle
+    (the ``certifi`` bundle, or ``SSL_CERT_FILE`` if set),
+    exactly like the default client of ``minio.Minio``.
+    Otherwise it falls back to the operating system trust store,
+    which is empty on minimal environments
+    (e.g. Windows containers),
+    causing every request to fail
+    with ``CERTIFICATE_VERIFY_FAILED``,
+    see https://github.com/audeering/audbackend/issues/301.
+
+    Args:
+        tmpdir: tmpdir fixture
+        hosts: hosts fixture
+        hide_credentials: hide_credentials fixture
+
+    """
+    host = hosts["minio"]
+    config_path = audeer.path(tmpdir, "config.cfg")
+    os.environ["MINIO_CONFIG_FILE"] = config_path
+
+    # Create minimal config file without timeout settings
+    with open(config_path, "w") as fp:
+        fp.write(f"[{host}]\n")
+        fp.write("access_key = test\n")
+        fp.write("secret_key = test\n")
+
+    with capture_minio_kwargs() as captured:
+        audbackend.backend.Minio(host, "repository")
+
+    # Verify an http_client was created
+    assert "http_client" in captured
+    http_client = captured["http_client"]
+    assert isinstance(http_client, urllib3.PoolManager)
+
+    # Verify certificate verification is enforced
+    # against an explicit CA bundle
+    # instead of the operating system trust store
+    expected_ca_certs = os.environ.get("SSL_CERT_FILE") or certifi.where()
+    assert http_client.connection_pool_kw.get("cert_reqs") == "CERT_REQUIRED"
+    assert http_client.connection_pool_kw.get("ca_certs") == expected_ca_certs
 
 
 def test_custom_timeout_from_config(tmpdir, hosts, hide_credentials):

--- a/tests/test_backend_minio.py
+++ b/tests/test_backend_minio.py
@@ -766,22 +766,21 @@ def test_default_ca_certificates(tmpdir, hosts, hide_credentials):
     against the ``certifi`` CA bundle,
     exactly like the default client of ``minio.Minio``.
     Otherwise it falls back to the operating system trust store,
-    which is empty on minimal environments
+    which is empty and can fail on minimal environments
     (e.g. Windows containers),
-    causing every request to fail
-    with ``CERTIFICATE_VERIFY_FAILED``,
     see https://github.com/audeering/audbackend/issues/301.
 
     Args:
         tmpdir: tmpdir fixture
         hosts: hosts fixture
-        hide_credentials: hide_credentials fixture
+        hide_credentials: hide_credentials fixture,
+            includes SSL_CERT_FILE,
+            so we test ``certifi`` here
 
     """
     host = hosts["minio"]
     config_path = audeer.path(tmpdir, "config.cfg")
     os.environ["MINIO_CONFIG_FILE"] = config_path
-    # hide_credentials removes SSL_CERT_FILE, so the certifi bundle is expected
 
     # Create minimal config file without timeout settings
     with open(config_path, "w") as fp:
@@ -799,7 +798,6 @@ def test_default_ca_certificates(tmpdir, hosts, hide_credentials):
 
     # Verify certificate verification is enforced
     # against the certifi CA bundle
-    # instead of the operating system trust store
     assert http_client.connection_pool_kw.get("cert_reqs") == ssl.CERT_REQUIRED
     assert http_client.connection_pool_kw.get("ca_certs") == certifi.where()
 

--- a/tests/test_backend_minio.py
+++ b/tests/test_backend_minio.py
@@ -59,6 +59,7 @@ def hide_credentials():
             "MINIO_ACCESS_KEY",
             "MINIO_SECRET_KEY",
             "MINIO_CONFIG_FILE",
+            "SSL_CERT_FILE",
         ]
     }
     for key, value in defaults.items():
@@ -756,13 +757,12 @@ def test_default_timeout_configuration(tmpdir, hosts, hide_credentials):
 
 
 def test_default_ca_certificates(tmpdir, hosts, hide_credentials):
-    r"""Test that the default http_client verifies TLS via a CA bundle.
+    r"""Test that the default http_client verifies TLS via the certifi bundle.
 
     When no http_client is provided,
     the backend creates one itself.
     That client must verify TLS certificates
-    against an explicit CA bundle
-    (the ``certifi`` bundle, or ``SSL_CERT_FILE`` if set),
+    against the ``certifi`` CA bundle,
     exactly like the default client of ``minio.Minio``.
     Otherwise it falls back to the operating system trust store,
     which is empty on minimal environments
@@ -780,6 +780,7 @@ def test_default_ca_certificates(tmpdir, hosts, hide_credentials):
     host = hosts["minio"]
     config_path = audeer.path(tmpdir, "config.cfg")
     os.environ["MINIO_CONFIG_FILE"] = config_path
+    # hide_credentials removes SSL_CERT_FILE, so the certifi bundle is expected
 
     # Create minimal config file without timeout settings
     with open(config_path, "w") as fp:
@@ -796,11 +797,46 @@ def test_default_ca_certificates(tmpdir, hosts, hide_credentials):
     assert isinstance(http_client, urllib3.PoolManager)
 
     # Verify certificate verification is enforced
-    # against an explicit CA bundle
+    # against the certifi CA bundle
     # instead of the operating system trust store
-    expected_ca_certs = os.environ.get("SSL_CERT_FILE") or certifi.where()
     assert http_client.connection_pool_kw.get("cert_reqs") == "CERT_REQUIRED"
-    assert http_client.connection_pool_kw.get("ca_certs") == expected_ca_certs
+    assert http_client.connection_pool_kw.get("ca_certs") == certifi.where()
+
+
+def test_ssl_cert_file_override(tmpdir, hosts, hide_credentials):
+    r"""Test that ``SSL_CERT_FILE`` overrides the default CA bundle.
+
+    When the ``SSL_CERT_FILE`` environment variable is set,
+    the default http_client verifies TLS certificates
+    against that file instead of the ``certifi`` bundle,
+    matching the default client of ``minio.Minio``.
+
+    Args:
+        tmpdir: tmpdir fixture
+        hosts: hosts fixture
+        hide_credentials: hide_credentials fixture
+
+    """
+    host = hosts["minio"]
+    config_path = audeer.path(tmpdir, "config.cfg")
+    os.environ["MINIO_CONFIG_FILE"] = config_path
+
+    # Point SSL_CERT_FILE at a custom CA bundle
+    ca_bundle = audeer.touch(audeer.path(tmpdir, "ca.pem"))
+    os.environ["SSL_CERT_FILE"] = ca_bundle
+
+    # Create minimal config file without timeout settings
+    with open(config_path, "w") as fp:
+        fp.write(f"[{host}]\n")
+        fp.write("access_key = test\n")
+        fp.write("secret_key = test\n")
+
+    with capture_minio_kwargs() as captured:
+        audbackend.backend.Minio(host, "repository")
+
+    http_client = captured["http_client"]
+    assert http_client.connection_pool_kw.get("cert_reqs") == "CERT_REQUIRED"
+    assert http_client.connection_pool_kw.get("ca_certs") == ca_bundle
 
 
 def test_custom_timeout_from_config(tmpdir, hosts, hide_credentials):

--- a/tests/test_backend_minio.py
+++ b/tests/test_backend_minio.py
@@ -1,6 +1,7 @@
 import contextlib
 import filecmp
 import os
+import ssl
 from unittest import mock
 import warnings
 
@@ -799,7 +800,7 @@ def test_default_ca_certificates(tmpdir, hosts, hide_credentials):
     # Verify certificate verification is enforced
     # against the certifi CA bundle
     # instead of the operating system trust store
-    assert http_client.connection_pool_kw.get("cert_reqs") == "CERT_REQUIRED"
+    assert http_client.connection_pool_kw.get("cert_reqs") == ssl.CERT_REQUIRED
     assert http_client.connection_pool_kw.get("ca_certs") == certifi.where()
 
 
@@ -835,7 +836,7 @@ def test_ssl_cert_file_override(tmpdir, hosts, hide_credentials):
         audbackend.backend.Minio(host, "repository")
 
     http_client = captured["http_client"]
-    assert http_client.connection_pool_kw.get("cert_reqs") == "CERT_REQUIRED"
+    assert http_client.connection_pool_kw.get("cert_reqs") == ssl.CERT_REQUIRED
     assert http_client.connection_pool_kw.get("ca_certs") == ca_bundle
 
 


### PR DESCRIPTION
Closes #301 

In https://github.com/audeering/audbackend/pull/283 we introduced to handover a custom `http_client` to the Minio backend. Under operating systems that don't provide a full OS cert store this can fail for https hosts. We solve this here by copying the TLS certification handling of the `minio` package by setting `cert_reqs` and `ca_certs` arguments as well.

The error was discovered in an internal CI runner that uses a stripped down version of Windows (the Github CI runner has a full Windows version). We also add an explicit test for it here to identify the error on all runners.
