### PR TITLE
Fix CI caching; bump checkout/setup-python off Node.js 20

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -25,6 +25,8 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
+      with:
+        cache-suffix: ${{ github.workflow }}
 
     # DOCS
     - name: Test building documentation

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -16,15 +16,15 @@ jobs:
         python-version: [ '3.12' ]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d
+      uses: astral-sh/setup-uv@v9.0.0
 
     # DOCS
     - name: Test building documentation

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -21,6 +21,8 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
+      with:
+        cache-suffix: ${{ github.workflow }}
 
     - name: Install pre-commit hooks
       run: uvx pre-commit install --install-hooks

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -12,15 +12,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: '3.12'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d
+      uses: astral-sh/setup-uv@v9.0.0
 
     - name: Install pre-commit hooks
       run: uvx pre-commit install --install-hooks

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,8 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
+      with:
+        cache-suffix: ${{ github.workflow }}
 
     # PyPI package
     - name: Build Python package

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,17 +17,17 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 2
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: '3.12'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d
+      uses: astral-sh/setup-uv@v9.0.0
 
     # PyPI package
     - name: Build Python package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       MINIO_CONFIG_FILE: ${{ github.workspace }}/.github/minio-test.cfg
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Start MinIO
       run: |
@@ -49,12 +49,12 @@ jobs:
         exit 1
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d
+      uses: astral-sh/setup-uv@v9.0.0
 
     - name: Sync Python environment
       run: uv sync
@@ -72,10 +72,10 @@ jobs:
         uv run pytest --cov-config=.coveragerc.${{ runner.os }}
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
+        files: ./coverage.xml
       if: matrix.python-version != '3.14'
 
   build-other-os:
@@ -98,7 +98,7 @@ jobs:
       MINIO_CONFIG_FILE: ${{ github.workspace }}/.github/minio-test.cfg
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Start MinIO (macOS)
       if: runner.os == 'macOS'
@@ -148,12 +148,12 @@ jobs:
         exit 1
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d
+      uses: astral-sh/setup-uv@v9.0.0
 
     - name: Sync Python environment
       run: uv sync

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,8 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
+      with:
+        cache-suffix: ${{ github.workflow }}
 
     - name: Sync Python environment
       run: uv sync
@@ -154,6 +156,8 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
+      with:
+        cache-suffix: ${{ github.workflow }}
 
     - name: Sync Python environment
       run: uv sync


### PR DESCRIPTION
## Summary

Two related CI bugs, both caused by stale GitHub Action version pins:

1. **Dead uv caching**: `astral-sh/setup-uv`'s default `cache-dependency-glob`
   keys on `uv.lock` / `requirements*.txt`, neither of which exists in this
   repo (no committed lockfile, by design — it tests against latest
   resolvable deps). Caching has therefore silently never worked.

   This repo's `setup-uv` pin was a SHA (`3259c6206f993105e3a61b142c2d97bf4b9ef83d`),
   which resolves to tag `v7.1.0` — already past the fix that matters here
   (`v6.0.0` added `pyproject.toml` to the default glob, which *is* committed
   and changes exactly when a dependency does) and past the Node 20 → Node 24
   runtime bump (`v7.0.0`). So neither bug technically applied to this pin.
   Bumping to `v9.0.0` anyway, for consistency with the sibling fixes below
   (matching what was done for audformat's `setup-uv` pin, which was in the
   same situation).

2. **Node.js 20 deprecation**: `actions/checkout@v4` and
   `actions/setup-python@v5` still target the deprecated Node 20 runtime.
   Bumped both to `v7`. `codecov/codecov-action@v4` also bumped to `v7`;
   its `v5` rewrite dropped the singular `file:` input in favor of `files:`
   (plural) — renamed accordingly in `test.yml` so the coverage upload
   doesn't silently no-op. No `actions/cache` usage exists in this repo's
   workflows.

`prune-cache` left at its new default (off): audbackend's dependency tree
(audeer, minio, audformat, sphinx, pytest, stream-unzip) has no large
pre-built binary wheels like torch, so pruning would save ~0 disk space
while costing avoidable re-downloads.

## Test plan

- [x] All four changed workflow YAML files validated with
      `python3 -c "import yaml; yaml.safe_load(open('FILE'))"`
- [ ] CI passes on this PR (checkout/setup-python/setup-uv/codecov-action
      bumps exercised across the full test matrix)

Part of the same CI cleanup as audeering/audeer#206,
audeering/opensmile-python#132, audeering/audb#591, and
audeering/audformat#539.

🤖 Generated with [Claude Code](https://claude.com/claude-code)